### PR TITLE
feat(data-model): users + ingredients migrations + Supabase clients + middleware

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -74,13 +74,13 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### 데이터 모델 기반
 
-- [ ] T030 Write SQL migration `supabase/migrations/001_users_and_isolation.sql` creating `public.users` table, `regular_days_off` text[] column, withdrawal fields, trigger to sync from `auth.users`, RLS policies (per data-model.md §1)
-- [ ] T031 Write SQL migration `supabase/migrations/002_ingredients_and_pricing.sql` creating `ingredients`, `ingredient_price_history` tables, indexes, RLS policies (per data-model.md §2-3)
-- [ ] T032 [P] Write SQL migration `supabase/migrations/008_user_withdrawal_grace.sql` adding indexes for `permanent_delete_at` and Edge Function dependency (per data-model.md §1)
-- [ ] T033 Generate TypeScript types from schema: `npm run db:gen-types > src/lib/supabase/types.ts`; commit generated types
-- [ ] T034 [P] Create Supabase browser client at `src/lib/supabase/client.ts` using `createBrowserClient`
-- [ ] T035 [P] Create Supabase server client at `src/lib/supabase/server.ts` using `createServerClient` for App Router server components
-- [ ] T036 Create middleware at `src/middleware.ts` calling `updateSession()` to refresh auth cookies; block grace-period users from protected routes (per contracts/auth.md)
+- [x] T030 Write SQL migration `supabase/migrations/001_users_and_isolation.sql` creating `public.users` table, `regular_days_off` text[] column, withdrawal fields, trigger to sync from `auth.users`, RLS policies (per data-model.md §1)
+- [x] T031 Write SQL migration `supabase/migrations/002_ingredients_and_pricing.sql` creating `ingredients`, `ingredient_price_history` tables, indexes, RLS policies (per data-model.md §2-3)
+- [x] T032 [P] Write SQL migration `supabase/migrations/008_user_withdrawal_grace.sql` adding indexes for `permanent_delete_at` and Edge Function dependency (per data-model.md §1)
+- [x] T033 Generate TypeScript types from schema: `npm run db:gen-types > src/lib/supabase/types.ts`; commit generated types (1차 stub: 미들웨어 의존 테이블만 손으로 정의, 마이그 적용 후 실제 generated 타입으로 후속 PR에서 대체)
+- [x] T034 [P] Create Supabase browser client at `src/lib/supabase/client.ts` using `createBrowserClient`
+- [x] T035 [P] Create Supabase server client at `src/lib/supabase/server.ts` using `createServerClient` for App Router server components
+- [x] T036 Create middleware at `src/middleware.ts` calling `updateSession()` to refresh auth cookies; block grace-period users from protected routes (per contracts/auth.md)
 
 ### Auth 흐름
 

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,9 @@
+import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "./types";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+export function createClient(): ReturnType<typeof createBrowserClient<Database>> {
+  return createBrowserClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,30 @@
+import { cookies } from "next/headers";
+import { type CookieOptions, createServerClient } from "@supabase/ssr";
+import type { Database } from "./types";
+
+type CookieMutation = { name: string; value: string; options: CookieOptions };
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+export async function createClient(): Promise<ReturnType<typeof createServerClient<Database>>> {
+  const cookieStore = await cookies();
+
+  return createServerClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet: CookieMutation[]) {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Server Components에서 호출되면 set이 실패할 수 있음 (정상).
+          // 미들웨어가 세션 갱신을 처리하므로 무시 가능.
+        }
+      },
+    },
+  });
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,98 @@
+/**
+ * Supabase 자동 생성 타입 stub.
+ *
+ * 마이그레이션이 Cloud에 적용된 후 다음 명령으로 재생성:
+ *   npm run db:gen-types > src/lib/supabase/types.ts
+ *
+ * 1차 stub: 미들웨어와 클라이언트가 필요로 하는 최소 스키마만 손으로 정의.
+ * 후속 PR에서 실제 generated 타입으로 대체.
+ */
+
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+
+type StoreType = "bingsu_cafe" | "cafe" | "dessert_cafe";
+type Weekday = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
+type IngredientUnit = "g" | "ml" | "piece";
+type PriceHistoryReason =
+  | "purchase"
+  | "stock_count_correction"
+  | "sale_consumption"
+  | "sale_edit_revert"
+  | "sale_edit_apply";
+
+interface UsersRow {
+  id: string;
+  email: string;
+  store_name: string;
+  store_type: StoreType;
+  regular_days_off: Weekday[];
+  signed_up_at: string;
+  withdrawal_requested_at: string | null;
+  permanent_delete_at: string | null;
+  analytics_consent: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface IngredientsRow {
+  id: string;
+  user_id: string;
+  name: string;
+  unit: IngredientUnit;
+  current_stock: number;
+  current_avg_price: number;
+  expiry_date: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface IngredientPriceHistoryRow {
+  id: string;
+  user_id: string;
+  ingredient_id: string;
+  changed_at: string;
+  previous_avg_price: number;
+  new_avg_price: number;
+  previous_stock: number;
+  new_stock: number;
+  reason: PriceHistoryReason;
+  reference_id: string | null;
+}
+
+export interface Database {
+  public: {
+    Tables: {
+      users: {
+        Row: UsersRow;
+        Insert: Pick<UsersRow, "id" | "email" | "store_name" | "store_type"> &
+          Partial<Omit<UsersRow, "id" | "email" | "store_name" | "store_type">>;
+        Update: Partial<UsersRow>;
+        Relationships: [];
+      };
+      ingredients: {
+        Row: IngredientsRow;
+        Insert: Pick<IngredientsRow, "user_id" | "name" | "unit"> &
+          Partial<Omit<IngredientsRow, "user_id" | "name" | "unit">>;
+        Update: Partial<IngredientsRow>;
+        Relationships: [];
+      };
+      ingredient_price_history: {
+        Row: IngredientPriceHistoryRow;
+        Insert: Omit<IngredientPriceHistoryRow, "id" | "changed_at"> &
+          Partial<Pick<IngredientPriceHistoryRow, "id" | "changed_at">>;
+        Update: Partial<IngredientPriceHistoryRow>;
+        Relationships: [];
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: {
+      store_type: StoreType;
+      weekday: Weekday;
+      ingredient_unit: IngredientUnit;
+      price_history_reason: PriceHistoryReason;
+    };
+    CompositeTypes: Record<string, never>;
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,85 @@
+import { type CookieOptions, createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+import type { Database } from "@/lib/supabase/types";
+
+type CookieMutation = { name: string; value: string; options: CookieOptions };
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+const PUBLIC_PATHS = ["/login", "/signup", "/", "/manifest.webmanifest"];
+const STATIC_PREFIXES = ["/_next/", "/icons/", "/fonts/", "/sw.js"];
+
+function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_PATHS.includes(pathname)) return true;
+  return STATIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  let response = NextResponse.next({ request });
+
+  const supabase = createServerClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet: CookieMutation[]) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const pathname = request.nextUrl.pathname;
+
+  // 인증 안 된 사용자: protected route 접근 시 /login 리디렉션
+  if (!user && !isPublicPath(pathname)) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.searchParams.set("next", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // 인증된 사용자: grace period 진행 중이면 차단 + /login 안내
+  // (contracts/auth.md: withdrawal_in_progress 에러)
+  if (user) {
+    const { data } = await supabase
+      .from("users")
+      .select("withdrawal_requested_at")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const profile = data as { withdrawal_requested_at: string | null } | null;
+
+    if (profile?.withdrawal_requested_at) {
+      await supabase.auth.signOut();
+      const loginUrl = request.nextUrl.clone();
+      loginUrl.pathname = "/login";
+      loginUrl.searchParams.set("withdrawal_in_progress", "1");
+      return NextResponse.redirect(loginUrl);
+    }
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * 모든 경로 매칭. 단 다음은 제외:
+     * - 정적 파일 (_next/static, _next/image, favicon, icons)
+     * - sw.js (서비스 워커)
+     * 미들웨어 내부에서 isPublicPath()로 한 번 더 필터.
+     */
+    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|icons/|fonts/).*)",
+  ],
+};

--- a/supabase/migrations/001_users_and_isolation.sql
+++ b/supabase/migrations/001_users_and_isolation.sql
@@ -1,0 +1,130 @@
+-- Migration: public.users + 정기휴무 + 탈퇴 grace period + RLS
+-- Spec: data-model.md §1, contracts/auth.md, FR-001/002/034~037/040/044
+-- 헌법 IV (NON-NEGOTIABLE): 모든 테이블 RLS user_id 격리
+
+create extension if not exists "uuid-ossp";
+
+-- ─── 가게 유형 enum ─────────────────────────────────────────────
+create type public.store_type as enum (
+  'bingsu_cafe',
+  'cafe',
+  'dessert_cafe'
+);
+
+-- ─── 요일 약어 enum (정기휴무용) ────────────────────────────────
+create type public.weekday as enum ('MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN');
+
+-- ─── public.users ───────────────────────────────────────────────
+create table public.users (
+  id uuid primary key references auth.users (id) on delete cascade,
+  email text not null unique,
+  store_name text not null,
+  store_type public.store_type not null,
+  regular_days_off public.weekday[] not null default '{}',
+  signed_up_at timestamptz not null default now(),
+  withdrawal_requested_at timestamptz,
+  permanent_delete_at timestamptz,
+  analytics_consent boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- withdrawal 필드 일관성: 둘 다 NULL 또는 둘 다 NOT NULL
+  constraint users_withdrawal_consistency check (
+    (withdrawal_requested_at is null and permanent_delete_at is null)
+    or (withdrawal_requested_at is not null and permanent_delete_at is not null)
+  ),
+
+  -- store_name 길이 (FR-001)
+  constraint users_store_name_length check (char_length(store_name) between 1 and 50)
+);
+
+comment on table public.users is '사장님 도메인 프로필. auth.users와 1:1, store 정보 + 정기휴무 + 탈퇴 grace period 관리.';
+comment on column public.users.regular_days_off is '정기휴무 요일 (FR-040). 빈 배열 = 365일 영업.';
+comment on column public.users.withdrawal_requested_at is '탈퇴 신청일 (FR-034). NOT NULL이면 grace period 진입.';
+comment on column public.users.permanent_delete_at is '영구 삭제 예정일 = withdrawal_requested_at + 30일 (FR-036).';
+
+-- ─── updated_at 자동 갱신 트리거 ────────────────────────────────
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+create trigger users_set_updated_at
+before update on public.users
+for each row
+execute function public.set_updated_at();
+
+-- ─── auth.users → public.users 자동 동기화 (가입 시 row 생성) ──
+-- 가입 흐름: supabase.auth.signUp → auth.users 생성 → 트리거 → public.users 생성
+-- raw_user_meta_data에 가게 정보를 클라이언트가 함께 보냄 (contracts/auth.md SignUpInput).
+create or replace function public.handle_new_auth_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  meta jsonb := coalesce(new.raw_user_meta_data, '{}'::jsonb);
+  v_store_name text := nullif(meta ->> 'store_name', '');
+  v_store_type public.store_type;
+  v_days_off public.weekday[];
+begin
+  -- store_type enum 캐스팅 (없으면 'cafe' 기본값)
+  begin
+    v_store_type := coalesce((meta ->> 'store_type')::public.store_type, 'cafe');
+  exception when invalid_text_representation then
+    v_store_type := 'cafe';
+  end;
+
+  -- regular_days_off enum 배열 캐스팅
+  begin
+    v_days_off := coalesce(
+      array(select jsonb_array_elements_text(meta -> 'regular_days_off'))::public.weekday[],
+      '{}'::public.weekday[]
+    );
+  exception when others then
+    v_days_off := '{}'::public.weekday[];
+  end;
+
+  insert into public.users (id, email, store_name, store_type, regular_days_off)
+  values (
+    new.id,
+    new.email,
+    coalesce(v_store_name, '내 가게'),
+    v_store_type,
+    v_days_off
+  )
+  on conflict (id) do nothing;
+
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+after insert on auth.users
+for each row
+execute function public.handle_new_auth_user();
+
+-- ─── RLS 정책 (헌법 IV 의무) ────────────────────────────────────
+alter table public.users enable row level security;
+
+create policy users_select_own
+on public.users
+for select
+using (auth.uid() = id);
+
+create policy users_update_own
+on public.users
+for update
+using (auth.uid() = id)
+with check (auth.uid() = id);
+
+-- INSERT는 트리거에서만, DELETE는 service role (Edge Function)에서만.
+-- 명시적 정책 없음 → RLS가 거부.
+
+grant select, update on public.users to authenticated;

--- a/supabase/migrations/002_ingredients_and_pricing.sql
+++ b/supabase/migrations/002_ingredients_and_pricing.sql
@@ -1,0 +1,107 @@
+-- Migration: ingredients + ingredient_price_history + RLS
+-- Spec: data-model.md §2-3, FR-002/004/029/038
+-- 헌법 III: 가중 이동 평균법 단가 산정의 기반 테이블
+
+-- ─── 단위 enum ──────────────────────────────────────────────────
+create type public.ingredient_unit as enum ('g', 'ml', 'piece');
+
+-- ─── 단가 변경 사유 enum ────────────────────────────────────────
+create type public.price_history_reason as enum (
+  'purchase',
+  'stock_count_correction',
+  'sale_consumption',
+  'sale_edit_revert',
+  'sale_edit_apply'
+);
+
+-- ─── ingredients ─────────────────────────────────────────────────
+create table public.ingredients (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  name text not null,
+  unit public.ingredient_unit not null,
+  current_stock numeric(12, 3) not null default 0,
+  current_avg_price numeric(12, 4) not null default 0,
+  expiry_date date,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint ingredients_name_per_user_unique unique (user_id, name),
+  constraint ingredients_stock_nonneg check (current_stock >= 0),
+  constraint ingredients_avg_price_nonneg check (current_avg_price >= 0),
+  constraint ingredients_name_length check (char_length(name) between 1 and 50)
+);
+
+comment on table public.ingredients is '재료. 이름은 사용자 단위 unique (FR-038). 단위는 등록 후 변경 불가 (data-model §2 Validation).';
+comment on column public.ingredients.current_avg_price is '가중 이동 평균법으로 산정 (헌법 III). 매입 시에만 갱신, 실사는 수량만 보정.';
+
+create index ingredients_user_active_idx on public.ingredients (user_id, is_active);
+
+create trigger ingredients_set_updated_at
+before update on public.ingredients
+for each row
+execute function public.set_updated_at();
+
+-- 단위 변경 차단 트리거 (data-model §2 Validation)
+create or replace function public.reject_unit_change()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.unit is distinct from old.unit then
+    raise exception 'ingredient unit cannot be changed (id=%, old=%, new=%)',
+      old.id, old.unit, new.unit
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger ingredients_reject_unit_change
+before update on public.ingredients
+for each row
+execute function public.reject_unit_change();
+
+-- ─── ingredient_price_history (FR-029) ──────────────────────────
+create table public.ingredient_price_history (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  ingredient_id uuid not null references public.ingredients (id) on delete cascade,
+  changed_at timestamptz not null default now(),
+  previous_avg_price numeric(12, 4) not null,
+  new_avg_price numeric(12, 4) not null,
+  previous_stock numeric(12, 3) not null,
+  new_stock numeric(12, 3) not null,
+  reason public.price_history_reason not null,
+  reference_id uuid
+);
+
+comment on table public.ingredient_price_history is '재료 평균 단가/재고 변경 이력. 매입·실사·판매·편집 모든 사건 기록 (FR-029).';
+comment on column public.ingredient_price_history.reference_id is '매입/실사/판매 레코드 ID. FK 제약 없음 (이력 보존 우선).';
+
+create index ingredient_price_history_ingredient_idx
+on public.ingredient_price_history (ingredient_id, changed_at desc);
+
+create index ingredient_price_history_user_changed_idx
+on public.ingredient_price_history (user_id, changed_at desc);
+
+-- ─── RLS 정책 (헌법 IV) ─────────────────────────────────────────
+alter table public.ingredients enable row level security;
+alter table public.ingredient_price_history enable row level security;
+
+create policy ingredients_isolated
+on public.ingredients
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy ingredient_price_history_isolated
+on public.ingredient_price_history
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+grant select, insert, update, delete on public.ingredients to authenticated;
+grant select on public.ingredient_price_history to authenticated;
+-- ingredient_price_history INSERT는 RPC (save_purchase 등)에서만, 직접 INSERT 금지.

--- a/supabase/migrations/008_user_withdrawal_grace.sql
+++ b/supabase/migrations/008_user_withdrawal_grace.sql
@@ -1,0 +1,10 @@
+-- Migration: 탈퇴 grace period 인덱스
+-- Spec: data-model.md §1, FR-034~037
+-- Edge Function `permanent-delete`가 매일 cron으로 만료 사용자 batch query 시 사용.
+
+-- 탈퇴 신청한 사용자만 부분 인덱스 (NULL이 대부분이므로 효율적)
+create index users_pending_deletion_idx
+on public.users (permanent_delete_at)
+where withdrawal_requested_at is not null;
+
+comment on index public.users_pending_deletion_idx is 'permanent-delete Edge Function이 만료 사용자 조회에 사용 (FR-036).';


### PR DESCRIPTION
Closes #10 — Phase 2 첫 PR.

## 변경 (T030~T036)

### 마이그레이션 3개

**`001_users_and_isolation.sql`** (T030)
- `public.users` (auth.users FK, store_type enum, regular_days_off weekday[], withdrawal/permanent_delete_at, analytics_consent)
- `store_type`, `weekday` enums
- `handle_new_auth_user` 트리거: 가입 시 자동 row 생성. `raw_user_meta_data`에서 store 정보 추출
- `updated_at` 자동 갱신 트리거
- `withdrawal_consistency` CHECK (둘 다 NULL 또는 NOT NULL)
- RLS `select_own` / `update_own` (헌법 IV)

**`002_ingredients_and_pricing.sql`** (T031)
- `ingredient_unit`, `price_history_reason` enums
- `ingredients` (UNIQUE `user_id+name` per FR-038, numeric(12,3) stock, numeric(12,4) avg_price 헌법 III 정확도)
- `reject_unit_change` 트리거 (단위 변경 차단)
- `ingredient_price_history` (FR-029)
- 인덱스 3개 (활성 목록, ingredient+changed, user+changed)
- RLS `isolated` 둘 다. price_history INSERT는 RPC만

**`008_user_withdrawal_grace.sql`** (T032)
- `permanent_delete_at` partial index (`WHERE withdrawal_requested_at IS NOT NULL`)
- Edge Function `permanent-delete`의 batch query 효율화

### Supabase 클라이언트 + 미들웨어

- `src/lib/supabase/types.ts` (T033) — 1차 stub. 미들웨어 의존 테이블만 손으로 정의. Cloud 마이그 적용 후 후속 PR에서 generated 타입으로 대체
- `src/lib/supabase/client.ts` (T034) — `createBrowserClient<Database>`
- `src/lib/supabase/server.ts` (T035) — `createServerClient<Database>` + Next.js cookies
- `src/middleware.ts` (T036) — 세션 갱신 + 인증 가드 + grace period 차단

## 마이그레이션 적용 안내

이 PR은 SQL 파일 commit만. Cloud 적용은 PR 머지 후 **Actions → Migrate DB → workflow_dispatch → environment=production** 으로 수동 실행 필요. (또는 로컬에서 `supabase db push --linked`)

## 로컬 검증

| 명령 | 결과 |
|---|---|
| `npm run typecheck` | ✅ |
| `npm run lint` | ✅ |
| `npm run format:check` | ✅ |
| `npm run test` | ✅ 2/2 |
| `npm run build` | ✅ + ƒ Middleware 95.8 kB |

## 다음

PR 8: Auth 흐름 (signup/login pages + complete_signup RPC + GA4 이벤트 + permanent-delete Edge Function + request_withdrawal RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
