### PR TITLE
feat(regular-days-off): RPC + editor + domain + RLS integration tests

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -102,10 +102,10 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### 정기휴무 등록 흐름
 
-- [ ] T049 [P] Write `update_regular_days_off` RPC migration `supabase/migrations/011_update_regular_days_off_rpc.sql` (per contracts/domain-rpc.md)
-- [ ] T050 Create regular days off setting component at `src/features/settings/components/RegularDaysOffEditor.tsx` (요일 멀티선택 + 즉시 저장)
-- [ ] T051 [P] Create domain function `src/lib/domain/regular-days-off.ts` with helpers: `isRegularDayOff(date, daysOff)`, `excludeFromAverage(samples, daysOff)`, `applyChangeSnapshot(...)` per FR-040~045
-- [ ] T052 [P] Write unit test `tests/unit/regular-days-off.test.ts` covering: 요일 검사, 누락/푸시/예측 제외, 변경 snapshot, 예외 영업
+- [x] T049 [P] Write `update_regular_days_off` RPC migration `supabase/migrations/011_update_regular_days_off_rpc.sql` (per contracts/domain-rpc.md)
+- [x] T050 Create regular days off setting component at `src/features/settings/components/RegularDaysOffEditor.tsx` (요일 멀티선택 + 즉시 저장)
+- [x] T051 [P] Create domain function `src/lib/domain/regular-days-off.ts` with helpers: `isRegularDayOff(date, daysOff)`, `excludeFromAverage(samples, daysOff)`, `applyChangeSnapshot(...)` per FR-040~045
+- [x] T052 [P] Write unit test `tests/unit/regular-days-off.test.ts` covering: 요일 검사, 누락/푸시/예측 제외, 변경 snapshot, 예외 영업
 
 ### TanStack Query + Zustand 셋업
 
@@ -114,8 +114,8 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### RLS 통합 테스트 (헌법 IV 가드)
 
-- [ ] T055 [P] Write integration test `tests/integration/rls.test.ts` verifying cross-user SELECT/INSERT/UPDATE/DELETE rejection on all domain tables (users, ingredients, ingredient_price_history)
-- [ ] T056 [P] Add helper for integration tests: `tests/helpers/test-supabase.ts` with `createTestUser()`, `cleanupTestUser()`, `signInAs()`
+- [x] T055 [P] Write integration test `tests/integration/rls.test.ts` verifying cross-user SELECT/INSERT/UPDATE/DELETE rejection on all domain tables (users, ingredients, ingredient_price_history)
+- [x] T056 [P] Add helper for integration tests: `tests/helpers/test-supabase.ts` with `createTestUser()`, `cleanupTestUser()`, `signInAs()`
 
 **Checkpoint**: Foundation ready — auth 동작, RLS 격리 검증, 5탭 네비게이션 표시, 정기휴무 등록·저장 가능
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,28 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { RegularDaysOffEditor } from "@/features/settings/components/RegularDaysOffEditor";
+import type { Weekday } from "@/lib/domain/regular-days-off";
 
-export default function SettingsPage(): React.ReactElement {
+export default async function SettingsPage(): Promise<React.ReactElement> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login?next=/settings");
+  }
+
+  const { data } = await supabase
+    .from("users")
+    .select("regular_days_off")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const profile = data as { regular_days_off: Weekday[] } | null;
+  const initialDaysOff: Weekday[] = profile?.regular_days_off ?? [];
+
   return (
     <main className="mx-auto flex min-h-screen max-w-screen-md flex-col gap-section p-screen pb-20">
       <header className="flex items-center justify-between">
@@ -9,9 +31,8 @@ export default function SettingsPage(): React.ReactElement {
           닫기
         </Link>
       </header>
-      <p className="text-body-regular text-ink-3">
-        가게 정보 / 정기휴무 / 탈퇴 — 정기휴무 편집기는 PR 10에서 구현
-      </p>
+
+      <RegularDaysOffEditor initialDaysOff={initialDaysOff} />
     </main>
   );
 }

--- a/src/features/settings/components/RegularDaysOffEditor.tsx
+++ b/src/features/settings/components/RegularDaysOffEditor.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { updateRegularDaysOff } from "@/lib/supabase/rpc";
+import { WEEKDAYS, WEEKDAY_LABELS } from "@/features/auth/schemas";
+import type { Weekday } from "@/lib/domain/regular-days-off";
+import { cn } from "@/lib/utils";
+
+interface RegularDaysOffEditorProps {
+  initialDaysOff: readonly Weekday[];
+}
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+export function RegularDaysOffEditor({
+  initialDaysOff,
+}: RegularDaysOffEditorProps): React.ReactElement {
+  const [selected, setSelected] = useState<Set<Weekday>>(() => new Set(initialDaysOff));
+  const [status, setStatus] = useState<SaveStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // 빠른 연속 토글 시 늦게 도착한 응답이 최신 상태를 덮어쓰지 않도록 monotonic id로 가드.
+  const latestRequestId = useRef(0);
+
+  function handleToggle(day: Weekday): void {
+    const next = new Set(selected);
+    if (next.has(day)) {
+      next.delete(day);
+    } else {
+      next.add(day);
+    }
+    setSelected(next);
+    void persist(next);
+  }
+
+  async function persist(next: Set<Weekday>): Promise<void> {
+    const requestId = ++latestRequestId.current;
+    setStatus("saving");
+    setErrorMessage(null);
+
+    const payload = WEEKDAYS.filter((d) => next.has(d));
+    const supabase = createClient();
+    const { error } = await updateRegularDaysOff(supabase, { p_days_off: payload });
+
+    if (requestId !== latestRequestId.current) return;
+
+    if (error) {
+      setStatus("error");
+      setErrorMessage(error.message);
+      return;
+    }
+    setStatus("saved");
+  }
+
+  return (
+    <section className="flex flex-col gap-stack">
+      <header className="flex flex-col gap-stack-tight">
+        <h2 className="text-title-md text-ink-1">정기휴무</h2>
+        <p className="text-caption text-ink-3">
+          쉬는 요일을 선택하세요. 누락 알림과 평균 산정에서 제외됩니다.
+        </p>
+      </header>
+
+      <div role="group" aria-label="정기휴무 요일" className="flex flex-wrap gap-stack-tight">
+        {WEEKDAYS.map((day) => {
+          const active = selected.has(day);
+          return (
+            <button
+              key={day}
+              type="button"
+              aria-pressed={active}
+              onClick={() => handleToggle(day)}
+              className={cn(
+                "h-11 min-w-11 rounded-full border px-4 text-body transition",
+                active
+                  ? "border-border-strong bg-ink-1 text-bg"
+                  : "border-border bg-card text-ink-2 hover:bg-card-hover",
+              )}
+            >
+              {WEEKDAY_LABELS[day]}
+            </button>
+          );
+        })}
+      </div>
+
+      <SaveStatusLine status={status} errorMessage={errorMessage} count={selected.size} />
+    </section>
+  );
+}
+
+interface SaveStatusLineProps {
+  status: SaveStatus;
+  errorMessage: string | null;
+  count: number;
+}
+
+function SaveStatusLine({ status, errorMessage, count }: SaveStatusLineProps): React.ReactElement {
+  if (status === "saving") {
+    return <p className="text-caption text-ink-3">저장 중…</p>;
+  }
+  if (status === "error") {
+    return <p className="text-caption text-red">저장 실패: {errorMessage ?? "알 수 없는 오류"}</p>;
+  }
+  if (status === "saved") {
+    return <p className="text-caption text-green">저장됨</p>;
+  }
+  return (
+    <p className="text-caption text-ink-3">{count === 0 ? "365일 영업" : `주 ${count}회 휴무`}</p>
+  );
+}

--- a/src/lib/domain/regular-days-off.ts
+++ b/src/lib/domain/regular-days-off.ts
@@ -1,0 +1,71 @@
+/**
+ * 정기휴무 도메인 함수 (FR-040~045).
+ *
+ * - FR-041: 누락 카운트 / 푸시 / 재고 알림 제외
+ * - FR-042: 소진 예측 요일별 평균 산정 제외
+ * - FR-043: 캘린더 회색 표시 (이 모듈은 데이터, UI는 상위 레이어)
+ * - FR-044: 변경은 변경 시점 이후부터 적용 — 과거 표시는 그 시점 규칙 유지
+ * - FR-045: 정기휴무 요일에도 Sale 입력 시 정상 영업일 (예외 영업)
+ */
+
+import type { Database } from "@/lib/supabase/types";
+
+export type Weekday = Database["public"]["Enums"]["weekday"];
+
+const WEEKDAY_BY_INDEX: readonly Weekday[] = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+export function weekdayOf(date: Date): Weekday {
+  const w = WEEKDAY_BY_INDEX[date.getDay()];
+  if (!w) {
+    throw new Error(`invalid weekday index: ${date.getDay()}`);
+  }
+  return w;
+}
+
+export function isRegularDayOff(date: Date, daysOff: readonly Weekday[]): boolean {
+  return daysOff.includes(weekdayOf(date));
+}
+
+export interface DailySample {
+  date: Date;
+  hasSale: boolean;
+  value: number;
+}
+
+/**
+ * FR-042: 평균 산정에서 정기휴무 요일을 제외한다.
+ * FR-045: 정기휴무 요일이라도 Sale이 입력된 날은 예외 영업 → 평균에 포함.
+ */
+export function excludeFromAverage(
+  samples: readonly DailySample[],
+  daysOff: readonly Weekday[],
+): DailySample[] {
+  return samples.filter((s) => s.hasSale || !isRegularDayOff(s.date, daysOff));
+}
+
+/**
+ * FR-041: 누락(영업일인데 sale 없음) 판정.
+ * 정기휴무는 영업일이 아니므로 누락이 아니다. 단, Sale이 있으면 예외 영업으로 영업일 취급.
+ */
+export function isMissingDay(sample: DailySample, daysOff: readonly Weekday[]): boolean {
+  if (sample.hasSale) return false;
+  return !isRegularDayOff(sample.date, daysOff);
+}
+
+export interface DaysOffChange {
+  effectiveFrom: Date;
+  daysOff: readonly Weekday[];
+}
+
+/**
+ * FR-044: 과거 어떤 날의 정기휴무 규칙을 알아내려면, 그 날짜에 활성이었던 변경을 찾는다.
+ * `changes`는 시간 오름차순. 가장 최근에 effectiveFrom <= date인 항목의 daysOff가 적용 규칙.
+ * 일치하는 변경이 없으면(가입 직후 날짜 등) 빈 배열로 가정 — 365일 영업.
+ */
+export function applyChangeSnapshot(
+  date: Date,
+  changes: readonly DaysOffChange[],
+): readonly Weekday[] {
+  const t = date.getTime();
+  return changes.findLast((c) => c.effectiveFrom.getTime() <= t)?.daysOff ?? [];
+}

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -1,0 +1,53 @@
+import { WEEKDAYS } from "@/features/auth/schemas";
+
+type Weekday = (typeof WEEKDAYS)[number];
+
+/**
+ * 타입 있는 RPC 래퍼.
+ *
+ * Functions가 stub 단계라 supabase.rpc()의 제네릭 추론을 우회한다.
+ * 실제 generated 타입(`supabase gen types typescript`)이 들어오면
+ * 이 래퍼는 단순 위임이 되거나 제거 가능.
+ */
+
+interface RpcResult<T> {
+  data: T | null;
+  error: { message: string; code?: string } | null;
+}
+
+type RpcCaller = (fn: string, args?: Record<string, unknown>) => Promise<RpcResult<unknown>>;
+
+interface ClientLike {
+  rpc: unknown;
+}
+
+interface UpdateRegularDaysOffArgs {
+  p_days_off: readonly Weekday[];
+}
+
+interface UpdateRegularDaysOffRow {
+  success: boolean;
+  days_off: Weekday[];
+}
+
+export async function updateRegularDaysOff(
+  client: ClientLike,
+  args: UpdateRegularDaysOffArgs,
+): Promise<RpcResult<UpdateRegularDaysOffRow[]>> {
+  const rpc = client.rpc as RpcCaller;
+  const result = await rpc("update_regular_days_off", { p_days_off: [...args.p_days_off] });
+  return result as RpcResult<UpdateRegularDaysOffRow[]>;
+}
+
+interface RequestWithdrawalRow {
+  success: boolean;
+  permanent_delete_at: string;
+}
+
+export async function requestWithdrawal(
+  client: ClientLike,
+): Promise<RpcResult<RequestWithdrawalRow[]>> {
+  const rpc = client.rpc as RpcCaller;
+  const result = await rpc("request_withdrawal");
+  return result as RpcResult<RequestWithdrawalRow[]>;
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -4,95 +4,165 @@
  * 마이그레이션이 Cloud에 적용된 후 다음 명령으로 재생성:
  *   npm run db:gen-types > src/lib/supabase/types.ts
  *
- * 1차 stub: 미들웨어와 클라이언트가 필요로 하는 최소 스키마만 손으로 정의.
+ * 1차 stub: 미들웨어/클라이언트/도메인 함수가 필요로 하는 최소 스키마.
  * 후속 PR에서 실제 generated 타입으로 대체.
  */
 
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
-type StoreType = "bingsu_cafe" | "cafe" | "dessert_cafe";
-type Weekday = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
-type IngredientUnit = "g" | "ml" | "piece";
-type PriceHistoryReason =
-  | "purchase"
-  | "stock_count_correction"
-  | "sale_consumption"
-  | "sale_edit_revert"
-  | "sale_edit_apply";
-
-interface UsersRow {
-  id: string;
-  email: string;
-  store_name: string;
-  store_type: StoreType;
-  regular_days_off: Weekday[];
-  signed_up_at: string;
-  withdrawal_requested_at: string | null;
-  permanent_delete_at: string | null;
-  analytics_consent: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
-interface IngredientsRow {
-  id: string;
-  user_id: string;
-  name: string;
-  unit: IngredientUnit;
-  current_stock: number;
-  current_avg_price: number;
-  expiry_date: string | null;
-  is_active: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
-interface IngredientPriceHistoryRow {
-  id: string;
-  user_id: string;
-  ingredient_id: string;
-  changed_at: string;
-  previous_avg_price: number;
-  new_avg_price: number;
-  previous_stock: number;
-  new_stock: number;
-  reason: PriceHistoryReason;
-  reference_id: string | null;
-}
-
-export interface Database {
+export type Database = {
+  __InternalSupabase: {
+    PostgrestVersion: "12";
+  };
   public: {
     Tables: {
       users: {
-        Row: UsersRow;
-        Insert: Pick<UsersRow, "id" | "email" | "store_name" | "store_type"> &
-          Partial<Omit<UsersRow, "id" | "email" | "store_name" | "store_type">>;
-        Update: Partial<UsersRow>;
+        Row: {
+          id: string;
+          email: string;
+          store_name: string;
+          store_type: Database["public"]["Enums"]["store_type"];
+          regular_days_off: Database["public"]["Enums"]["weekday"][];
+          signed_up_at: string;
+          withdrawal_requested_at: string | null;
+          permanent_delete_at: string | null;
+          analytics_consent: boolean;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id: string;
+          email: string;
+          store_name: string;
+          store_type: Database["public"]["Enums"]["store_type"];
+          regular_days_off?: Database["public"]["Enums"]["weekday"][];
+          signed_up_at?: string;
+          withdrawal_requested_at?: string | null;
+          permanent_delete_at?: string | null;
+          analytics_consent?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          email?: string;
+          store_name?: string;
+          store_type?: Database["public"]["Enums"]["store_type"];
+          regular_days_off?: Database["public"]["Enums"]["weekday"][];
+          signed_up_at?: string;
+          withdrawal_requested_at?: string | null;
+          permanent_delete_at?: string | null;
+          analytics_consent?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
         Relationships: [];
       };
       ingredients: {
-        Row: IngredientsRow;
-        Insert: Pick<IngredientsRow, "user_id" | "name" | "unit"> &
-          Partial<Omit<IngredientsRow, "user_id" | "name" | "unit">>;
-        Update: Partial<IngredientsRow>;
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          unit: Database["public"]["Enums"]["ingredient_unit"];
+          current_stock: number;
+          current_avg_price: number;
+          expiry_date: string | null;
+          is_active: boolean;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          unit: Database["public"]["Enums"]["ingredient_unit"];
+          current_stock?: number;
+          current_avg_price?: number;
+          expiry_date?: string | null;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          unit?: Database["public"]["Enums"]["ingredient_unit"];
+          current_stock?: number;
+          current_avg_price?: number;
+          expiry_date?: string | null;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
         Relationships: [];
       };
       ingredient_price_history: {
-        Row: IngredientPriceHistoryRow;
-        Insert: Omit<IngredientPriceHistoryRow, "id" | "changed_at"> &
-          Partial<Pick<IngredientPriceHistoryRow, "id" | "changed_at">>;
-        Update: Partial<IngredientPriceHistoryRow>;
+        Row: {
+          id: string;
+          user_id: string;
+          ingredient_id: string;
+          changed_at: string;
+          previous_avg_price: number;
+          new_avg_price: number;
+          previous_stock: number;
+          new_stock: number;
+          reason: Database["public"]["Enums"]["price_history_reason"];
+          reference_id: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          ingredient_id: string;
+          changed_at?: string;
+          previous_avg_price: number;
+          new_avg_price: number;
+          previous_stock: number;
+          new_stock: number;
+          reason: Database["public"]["Enums"]["price_history_reason"];
+          reference_id?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          ingredient_id?: string;
+          changed_at?: string;
+          previous_avg_price?: number;
+          new_avg_price?: number;
+          previous_stock?: number;
+          new_stock?: number;
+          reason?: Database["public"]["Enums"]["price_history_reason"];
+          reference_id?: string | null;
+        };
         Relationships: [];
       };
     };
-    Views: Record<string, never>;
-    Functions: Record<string, never>;
-    Enums: {
-      store_type: StoreType;
-      weekday: Weekday;
-      ingredient_unit: IngredientUnit;
-      price_history_reason: PriceHistoryReason;
+    Views: {
+      [_ in never]: never;
     };
-    CompositeTypes: Record<string, never>;
+    Functions: {
+      update_regular_days_off: {
+        Args: { p_days_off: string[] };
+        Returns: { success: boolean; days_off: string[] }[];
+      };
+      request_withdrawal: {
+        Args: Record<PropertyKey, never>;
+        Returns: { success: boolean; permanent_delete_at: string }[];
+      };
+    };
+    Enums: {
+      store_type: "bingsu_cafe" | "cafe" | "dessert_cafe";
+      weekday: "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
+      ingredient_unit: "g" | "ml" | "piece";
+      price_history_reason:
+        | "purchase"
+        | "stock_count_correction"
+        | "sale_consumption"
+        | "sale_edit_revert"
+        | "sale_edit_apply";
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
   };
-}
+};

--- a/supabase/migrations/011_update_regular_days_off_rpc.sql
+++ b/supabase/migrations/011_update_regular_days_off_rpc.sql
@@ -1,0 +1,47 @@
+-- Migration: 정기휴무 요일 갱신 RPC
+-- Spec: contracts/domain-rpc.md L246-258, FR-040, FR-044
+-- 호출자: 인증된 사용자가 본인 가게 정기휴무 요일 변경 (Settings 페이지)
+--
+-- FR-044: 변경은 변경 시점 이후부터 적용. 과거 데이터(캘린더, 누락 카운트, 평균 산정)는
+-- 그 시점의 규칙을 유지해야 한다. 이 RPC는 현재 값만 갱신하고, 과거 표시는 호출 측에서
+-- 변경 이력을 참조해 재현한다 (도메인 함수 `applyChangeSnapshot`).
+
+create or replace function public.update_regular_days_off(p_days_off public.weekday[])
+returns table (success boolean, days_off public.weekday[])
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_now timestamptz := now();
+  v_days_off public.weekday[] := coalesce(p_days_off, '{}'::public.weekday[]);
+begin
+  if v_user_id is null then
+    raise exception 'not authenticated' using errcode = '28000';
+  end if;
+
+  if array_length(v_days_off, 1) > 7 then
+    raise exception 'too many days_off (max 7)' using errcode = '22023';
+  end if;
+
+  update public.users
+  set regular_days_off = v_days_off,
+      updated_at = v_now
+  where id = v_user_id
+    and withdrawal_requested_at is null;
+
+  if not found then
+    raise exception 'user not found or withdrawal in progress'
+      using errcode = '02000';
+  end if;
+
+  return query select true, v_days_off;
+end;
+$$;
+
+comment on function public.update_regular_days_off(public.weekday[]) is
+  '정기휴무 요일 갱신 (FR-040). 변경 시점 이후부터 적용 (FR-044) — 과거 데이터 재계산 없음.';
+
+revoke all on function public.update_regular_days_off(public.weekday[]) from public;
+grant execute on function public.update_regular_days_off(public.weekday[]) to authenticated;

--- a/tests/helpers/test-supabase.ts
+++ b/tests/helpers/test-supabase.ts
@@ -1,0 +1,94 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * 통합 테스트용 Supabase 헬퍼.
+ *
+ * 헌법 IV (RLS 가드) 통합 테스트는 실제 Supabase 인스턴스가 있어야 의미 있음.
+ * CI/로컬에서 환경변수가 없으면 호출 측이 `describe.skipIf(!hasSupabaseTestEnv)`로
+ * 건너뛴다 — 테스트는 발견되지만 실행은 실제 환경에서만.
+ *
+ * Service role 클라이언트는 RLS를 우회 → 픽스처 정리/생성용.
+ * 사용자별 클라이언트는 anon key + 로그인된 세션 → RLS 검증용.
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ANON_KEY = process.env.SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const hasSupabaseTestEnv = Boolean(SUPABASE_URL && SERVICE_ROLE_KEY && ANON_KEY);
+
+export interface TestUser {
+  id: string;
+  email: string;
+  password: string;
+}
+
+function requireEnv(): { url: string; serviceRoleKey: string; anonKey: string } {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY || !ANON_KEY) {
+    throw new Error(
+      "Supabase test env not configured: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY required",
+    );
+  }
+  return { url: SUPABASE_URL, serviceRoleKey: SERVICE_ROLE_KEY, anonKey: ANON_KEY };
+}
+
+export function getServiceRoleClient(): SupabaseClient<Database> {
+  const { url, serviceRoleKey } = requireEnv();
+  return createClient<Database>(url, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function createTestUser(overrides?: {
+  storeName?: string;
+  storeType?: "bingsu_cafe" | "cafe" | "dessert_cafe";
+}): Promise<TestUser> {
+  const admin = getServiceRoleClient();
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const email = `rls-test-${suffix}@easystock.test`;
+  const password = `Test!${suffix}`;
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: {
+      store_name: overrides?.storeName ?? `테스트가게-${suffix}`,
+      store_type: overrides?.storeType ?? "bingsu_cafe",
+      regular_days_off: [],
+    },
+  });
+
+  if (error || !data.user) {
+    throw new Error(`createTestUser failed: ${error?.message ?? "no user returned"}`);
+  }
+
+  return { id: data.user.id, email, password };
+}
+
+export async function cleanupTestUser(userId: string): Promise<void> {
+  const admin = getServiceRoleClient();
+  const { error } = await admin.auth.admin.deleteUser(userId);
+  if (error && !error.message.includes("not found")) {
+    throw new Error(`cleanupTestUser failed: ${error.message}`);
+  }
+}
+
+export async function signInAs(user: TestUser): Promise<SupabaseClient<Database>> {
+  const { url, anonKey } = requireEnv();
+  const client = createClient<Database>(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { error } = await client.auth.signInWithPassword({
+    email: user.email,
+    password: user.password,
+  });
+
+  if (error) {
+    throw new Error(`signInAs failed: ${error.message}`);
+  }
+
+  return client;
+}

--- a/tests/integration/rls.test.ts
+++ b/tests/integration/rls.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  cleanupTestUser,
+  createTestUser,
+  getServiceRoleClient,
+  hasSupabaseTestEnv,
+  signInAs,
+  type TestUser,
+} from "../helpers/test-supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * 헌법 IV (NON-NEGOTIABLE): user_id 격리 RLS 가드.
+ *
+ * 검증 대상: users / ingredients / ingredient_price_history
+ * 시나리오: A로 로그인 → B가 만든 row를 SELECT/UPDATE/DELETE 시도 → 빈 결과 또는 거부
+ *           A가 user_id=B로 INSERT 시도 → RLS WITH CHECK 거부
+ *
+ * Supabase 환경 변수가 없으면 skip (CI에서는 secret이 설정된 환경에서만 실행).
+ */
+
+const describeRls = hasSupabaseTestEnv ? describe : describe.skip;
+
+describeRls("RLS user_id isolation", () => {
+  let userA: TestUser;
+  let userB: TestUser;
+  let clientA: SupabaseClient<Database>;
+  let ingredientByB: { id: string; user_id: string };
+
+  beforeAll(async () => {
+    userA = await createTestUser({ storeName: "A 가게" });
+    userB = await createTestUser({ storeName: "B 가게" });
+    clientA = await signInAs(userA);
+
+    const admin = getServiceRoleClient();
+    const { data, error } = await admin
+      .from("ingredients")
+      .insert({ user_id: userB.id, name: "B 우유", unit: "ml" })
+      .select("id, user_id")
+      .single();
+
+    if (error || !data) {
+      throw new Error(`fixture insert failed: ${error?.message ?? "no row"}`);
+    }
+    ingredientByB = data;
+  }, 30_000);
+
+  afterAll(async () => {
+    if (userA?.id) await cleanupTestUser(userA.id);
+    if (userB?.id) await cleanupTestUser(userB.id);
+  }, 30_000);
+
+  describe("users table", () => {
+    it("A는 B의 users row를 조회할 수 없다", async () => {
+      const { data, error } = await clientA.from("users").select("id").eq("id", userB.id);
+      expect(error).toBeNull();
+      expect(data ?? []).toHaveLength(0);
+    });
+
+    it("A는 본인 users row만 조회 가능", async () => {
+      const { data, error } = await clientA.from("users").select("id").eq("id", userA.id);
+      expect(error).toBeNull();
+      expect(data?.[0]?.id).toBe(userA.id);
+    });
+
+    it("A는 B의 users row를 UPDATE할 수 없다", async () => {
+      const { data } = await clientA
+        .from("users")
+        .update({ store_name: "해킹시도" })
+        .eq("id", userB.id)
+        .select("id");
+      expect(data ?? []).toHaveLength(0);
+    });
+  });
+
+  describe("ingredients table", () => {
+    it("A는 B의 ingredient를 조회할 수 없다", async () => {
+      const { data, error } = await clientA
+        .from("ingredients")
+        .select("id")
+        .eq("id", ingredientByB.id);
+      expect(error).toBeNull();
+      expect(data ?? []).toHaveLength(0);
+    });
+
+    it("A는 user_id=B로 ingredient INSERT를 거부당한다", async () => {
+      const { data, error } = await clientA
+        .from("ingredients")
+        .insert({ user_id: userB.id, name: "위장 재료", unit: "g" })
+        .select("id");
+      expect(data ?? []).toHaveLength(0);
+      expect(error).not.toBeNull();
+    });
+
+    it("A는 B의 ingredient UPDATE/DELETE 시 영향 행 0", async () => {
+      const upd = await clientA
+        .from("ingredients")
+        .update({ name: "탈취" })
+        .eq("id", ingredientByB.id)
+        .select("id");
+      expect(upd.data ?? []).toHaveLength(0);
+
+      const del = await clientA
+        .from("ingredients")
+        .delete()
+        .eq("id", ingredientByB.id)
+        .select("id");
+      expect(del.data ?? []).toHaveLength(0);
+    });
+  });
+
+  describe("ingredient_price_history table", () => {
+    it("A는 B의 price_history를 조회할 수 없다", async () => {
+      const { data, error } = await clientA
+        .from("ingredient_price_history")
+        .select("id")
+        .eq("user_id", userB.id);
+      expect(error).toBeNull();
+      expect(data ?? []).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/regular-days-off.test.ts
+++ b/tests/unit/regular-days-off.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyChangeSnapshot,
+  excludeFromAverage,
+  isMissingDay,
+  isRegularDayOff,
+  weekdayOf,
+  type DailySample,
+  type Weekday,
+} from "@/lib/domain/regular-days-off";
+
+const monday = new Date("2026-04-27T00:00:00");
+const tuesday = new Date("2026-04-28T00:00:00");
+const wednesday = new Date("2026-04-29T00:00:00");
+const sunday = new Date("2026-05-03T00:00:00");
+
+describe("weekdayOf", () => {
+  it("월요일을 MON으로 매핑한다", () => {
+    expect(weekdayOf(monday)).toBe("MON");
+  });
+
+  it("일요일을 SUN으로 매핑한다", () => {
+    expect(weekdayOf(sunday)).toBe("SUN");
+  });
+});
+
+describe("isRegularDayOff", () => {
+  it("정기휴무에 포함된 요일은 true", () => {
+    expect(isRegularDayOff(monday, ["MON"])).toBe(true);
+  });
+
+  it("포함되지 않은 요일은 false", () => {
+    expect(isRegularDayOff(tuesday, ["MON"])).toBe(false);
+  });
+
+  it("빈 배열이면 항상 false (365일 영업)", () => {
+    expect(isRegularDayOff(monday, [])).toBe(false);
+  });
+});
+
+describe("excludeFromAverage (FR-042 + FR-045)", () => {
+  const samples: DailySample[] = [
+    { date: monday, hasSale: false, value: 0 },
+    { date: tuesday, hasSale: true, value: 50 },
+    { date: wednesday, hasSale: true, value: 60 },
+  ];
+
+  it("정기휴무 요일은 평균 산정에서 제외", () => {
+    const result = excludeFromAverage(samples, ["MON"]);
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.value)).toEqual([50, 60]);
+  });
+
+  it("정기휴무 요일이라도 Sale이 입력된 날은 예외 영업으로 포함 (FR-045)", () => {
+    const withException: DailySample[] = [
+      { date: monday, hasSale: true, value: 30 }, // 정기휴무지만 영업함
+      ...samples.slice(1),
+    ];
+    const result = excludeFromAverage(withException, ["MON"]);
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.value)).toContain(30);
+  });
+});
+
+describe("isMissingDay (FR-041)", () => {
+  it("영업일에 Sale 없으면 누락", () => {
+    const sample: DailySample = { date: tuesday, hasSale: false, value: 0 };
+    expect(isMissingDay(sample, ["MON"])).toBe(true);
+  });
+
+  it("정기휴무 요일은 누락이 아니다", () => {
+    const sample: DailySample = { date: monday, hasSale: false, value: 0 };
+    expect(isMissingDay(sample, ["MON"])).toBe(false);
+  });
+
+  it("정기휴무여도 Sale이 있으면 누락 아님 (영업일 인식)", () => {
+    const sample: DailySample = { date: monday, hasSale: true, value: 30 };
+    expect(isMissingDay(sample, ["MON"])).toBe(false);
+  });
+
+  it("Sale이 있으면 정기휴무 여부와 무관하게 누락 아님", () => {
+    const sample: DailySample = { date: tuesday, hasSale: true, value: 50 };
+    expect(isMissingDay(sample, ["MON"])).toBe(false);
+  });
+});
+
+describe("applyChangeSnapshot (FR-044)", () => {
+  const changes = [
+    { effectiveFrom: new Date("2026-01-01"), daysOff: [] as Weekday[] },
+    { effectiveFrom: new Date("2026-03-01"), daysOff: ["MON"] as Weekday[] },
+    { effectiveFrom: new Date("2026-04-15"), daysOff: ["MON", "TUE"] as Weekday[] },
+  ];
+
+  it("변경 이전 날짜는 빈 배열을 반환한다 (가입 직후 등)", () => {
+    const earlier = new Date("2025-12-31");
+    expect(applyChangeSnapshot(earlier, changes)).toEqual([]);
+  });
+
+  it("첫 변경 시점 날짜는 첫 변경의 규칙을 적용한다", () => {
+    const date = new Date("2026-01-01");
+    expect(applyChangeSnapshot(date, changes)).toEqual([]);
+  });
+
+  it("중간 변경 후 날짜는 그 변경의 규칙을 적용 (이전 휴무는 영향 없음)", () => {
+    const date = new Date("2026-03-15");
+    expect(applyChangeSnapshot(date, changes)).toEqual(["MON"]);
+  });
+
+  it("최신 변경 이후는 최신 규칙 적용", () => {
+    const date = new Date("2026-04-30");
+    expect(applyChangeSnapshot(date, changes)).toEqual(["MON", "TUE"]);
+  });
+
+  it("changes가 비어 있으면 빈 배열", () => {
+    expect(applyChangeSnapshot(monday, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Phase 2 마지막 PR — 정기휴무 흐름 + 헌법 IV (RLS) 가드.

## What

- **T049** `update_regular_days_off` RPC migration (FR-040 / FR-044) — 변경 시점 이후 적용. 과거 데이터 영향 없음 (스냅샷 처리는 도메인 함수 `applyChangeSnapshot`)
- **T050** `RegularDaysOffEditor` — 요일 chip 멀티선택 + 즉시 저장. **monotonic requestId**로 빠른 연속 토글 시 늦은 응답이 최신 상태를 덮어쓰지 못하게 가드
- **T051** `src/lib/domain/regular-days-off.ts` — `isRegularDayOff` / `excludeFromAverage` (FR-042/045) / `isMissingDay` (FR-041) / `applyChangeSnapshot` (FR-044)
- **T052** Unit tests 16개 — 요일 검사 / 누락 / 평균 제외 / 예외 영업 (FR-045) / 변경 snapshot
- **T055** RLS integration tests — A↔B cross-user SELECT/INSERT/UPDATE/DELETE 거부 검증 (헌법 IV). Supabase env 없으면 `skipIf`로 건너뜀 → CI 그린 유지하면서 실제 환경에서만 실행
- **T056** test-supabase 헬퍼 — service role 픽스처 / `signInAs(user)` / `createTestUser` / `cleanupTestUser`

## Notes

- `types.ts` 재작성: `__InternalSupabase` + 명시적 Row/Insert/Update + Functions 필드. 단 supabase-js v2.105의 `rpc()` 제네릭 추론이 stub Functions와 맞지 않아 `src/lib/supabase/rpc.ts`에 타입 래퍼 도입 (`updateRegularDaysOff`, `requestWithdrawal`). 실제 generated 타입 도입 시 단순 위임으로 정리 가능
- settings 페이지: 미들웨어가 grace period 가드를 처리하고, settings는 `regular_days_off` 컬럼을 별도로 읽음 (미들웨어는 `withdrawal_requested_at`만 사용 → 중복 아님)
- 디자인 시스템 토큰(border / ink-1 / card-hover) 사용. 그림자 금지, 보더로만 위계 표현 원칙 준수

## Local verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ 18 passed / 7 skipped (RLS, env-gated)
- `npm run build` ✅ /settings 1.92 kB, all routes prerender

## Checkpoint after merge

Phase 2 완료 — auth + RLS 가드 + 5탭 + 정기휴무 등록 가능. Phase 3 (메뉴/레시피/단가)로 진입.

Closes #16