### PR TITLE
chore(test-infra): vitest env loader + supabase CLI 신문법 + uuid 함수

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -63,7 +63,7 @@ enabled = true
 policy = "oneshot"
 inspector_port = 8083
 
-[functions]
+[functions.permanent-delete]
 verify_jwt = true
 
 [analytics]

--- a/supabase/migrations/002_ingredients_and_pricing.sql
+++ b/supabase/migrations/002_ingredients_and_pricing.sql
@@ -16,7 +16,7 @@ create type public.price_history_reason as enum (
 
 -- ─── ingredients ─────────────────────────────────────────────────
 create table public.ingredients (
-  id uuid primary key default uuid_generate_v4(),
+  id uuid primary key default gen_random_uuid(),
   user_id uuid not null references public.users (id) on delete cascade,
   name text not null,
   unit public.ingredient_unit not null,
@@ -65,7 +65,7 @@ execute function public.reject_unit_change();
 
 -- ─── ingredient_price_history (FR-029) ──────────────────────────
 create table public.ingredient_price_history (
-  id uuid primary key default uuid_generate_v4(),
+  id uuid primary key default gen_random_uuid(),
   user_id uuid not null references public.users (id) on delete cascade,
   ingredient_id uuid not null references public.ingredients (id) on delete cascade,
   changed_at timestamptz not null default now(),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from "vitest/config";
+import { loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
+
+// `.env.local` 등 dotenv 파일을 vitest에 주입.
+// CI는 GitHub Secrets가 process.env에 직접 들어가서 그대로 작동.
+const env = loadEnv("", process.cwd(), "");
 
 export default defineConfig({
   plugins: [react()],
@@ -12,6 +17,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    env,
     setupFiles: ["./tests/setup.ts"],
     include: ["tests/unit/**/*.test.{ts,tsx}", "tests/integration/**/*.test.{ts,tsx}"],
     exclude: ["tests/e2e/**", "node_modules/**", ".next/**"],


### PR DESCRIPTION
## Why

PR #17(정기휴무) 머지 후 로컬에서 RLS 통합 테스트를 실제로 돌려보다가 막힌 3가지를 한 번에 정리.

## What

### 1. `vitest.config.ts` — `.env.local` 자동 주입
- `loadEnv()`로 dotenv 변수를 vitest에 넘김
- 로컬: `.env.local` 자동 로드 → RLS 테스트 7개 실행
- CI: GitHub Secrets가 `process.env`에 직접 들어가서 그대로 작동
- 결과: 로컬에서 `npm run test` → **25/25 그린** (이전엔 18 passed / 7 skipped)

### 2. `supabase/config.toml` — CLI 신문법
- 구: `[functions] verify_jwt = true`
- 신: `[functions.permanent-delete] verify_jwt = true`
- supabase CLI 2.95+에서 `[functions]`는 함수 이름의 map으로 파싱됨. 구문법으로는 `supabase config push` 자체가 실패

### 3. `migrations/002` — `uuid_generate_v4()` → `gen_random_uuid()`
- Supabase Cloud는 `uuid-ossp` 확장을 `extensions` 스키마에 설치 → `uuid_generate_v4()`는 search_path에 없어서 함수 못 찾음
- `gen_random_uuid()`는 PG13+ 내장이라 schema qualifier 불필요, 의존성도 줄어듦
- 마이그레이션 005 ~ 009 자리에 매입/판매가 들어올 거라 `gen_random_uuid()`로 통일하는 편이 일관됨

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ 25/25
- 클라우드 DB에 마이그레이션 5개(`001`/`002`/`008`/`010`/`011`) 모두 적용됨 — `npx supabase migration list`로 동기 확인