### PR TITLE
feat(domain): 메뉴 마진 + 가중 이동 평균 단가 (헌법 III)

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -129,10 +129,10 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### 도메인 로직 (테스트 우선)
 
-- [ ] T057 [P] [US3] Write unit test `tests/unit/margin.test.ts` for menu cost/margin calculation: `calculateMenuCost(recipe, ingredientPrices)`, `calculateMargin(price, cost)` with label assertion
-- [ ] T058 [US3] Implement domain function `src/lib/domain/margin.ts` to satisfy T057 unit tests; uses Decimal.js for precision
-- [ ] T059 [P] [US3] Write unit test `tests/unit/pricing.test.ts` for weighted moving average: 30-day scenario, first purchase (stock=0), accumulated precision ≤ 0.01원 (SC-009)
-- [ ] T060 [US3] Implement domain function `src/lib/domain/pricing.ts` with `computeNewWeightedAverage(currentStock, currentAvg, newQty, newPrice)` to satisfy T059
+- [x] T057 [P] [US3] Write unit test `tests/unit/margin.test.ts` for menu cost/margin calculation: `calculateMenuCost(recipe, ingredientPrices)`, `calculateMargin(price, cost)` with label assertion
+- [x] T058 [US3] Implement domain function `src/lib/domain/margin.ts` to satisfy T057 unit tests; uses Decimal.js for precision
+- [x] T059 [P] [US3] Write unit test `tests/unit/pricing.test.ts` for weighted moving average: 30-day scenario, first purchase (stock=0), accumulated precision ≤ 0.01원 (SC-009)
+- [x] T060 [US3] Implement domain function `src/lib/domain/pricing.ts` with `computeNewWeightedAverage(currentStock, currentAvg, newQty, newPrice)` to satisfy T059
 
 ### 데이터 모델 + RPC
 

--- a/src/lib/domain/margin.ts
+++ b/src/lib/domain/margin.ts
@@ -1,0 +1,54 @@
+import Decimal from "decimal.js";
+
+/**
+ * 헌법 III: 메뉴 원가 / 마진 산정.
+ *
+ * - 메뉴 원가 = Σ(레시피 항목.수량 × 재료.current_avg_price)
+ * - 마진 금액 = 메뉴 가격 - 메뉴 원가
+ * - 마진율 = 마진 금액 / 메뉴 가격 × 100
+ *
+ * UI 표기는 항상 `MARGIN_LABEL` 동봉 (재료 원가 기준 이동평균법) — 임대료·인건비 미포함.
+ */
+
+export const MARGIN_LABEL = "재료 원가 기준 (이동평균법)" as const;
+export type MarginLabel = typeof MARGIN_LABEL;
+
+export interface RecipeItemForCost {
+  quantity: number;
+  avgPrice: number;
+}
+
+export function calculateMenuCost(recipe: readonly RecipeItemForCost[]): Decimal {
+  return recipe.reduce((total, item) => {
+    if (item.quantity < 0) {
+      throw new Error(`recipe item quantity must be non-negative (got ${item.quantity})`);
+    }
+    if (item.avgPrice < 0) {
+      throw new Error(`recipe item avgPrice must be non-negative (got ${item.avgPrice})`);
+    }
+    return total.plus(new Decimal(item.quantity).times(item.avgPrice));
+  }, new Decimal(0));
+}
+
+export interface MarginInput {
+  price: number;
+  cost: Decimal;
+}
+
+export interface MarginResult {
+  amount: Decimal;
+  rate: Decimal;
+  label: MarginLabel;
+}
+
+export function calculateMargin({ price, cost }: MarginInput): MarginResult {
+  if (price < 0) {
+    throw new Error(`menu price must be non-negative (got ${price})`);
+  }
+
+  const priceDecimal = new Decimal(price);
+  const amount = priceDecimal.minus(cost);
+  const rate = priceDecimal.isZero() ? new Decimal(0) : amount.dividedBy(priceDecimal).times(100);
+
+  return { amount, rate, label: MARGIN_LABEL };
+}

--- a/src/lib/domain/pricing.ts
+++ b/src/lib/domain/pricing.ts
@@ -1,0 +1,52 @@
+import Decimal from "decimal.js";
+
+/**
+ * 헌법 III (NON-NEGOTIABLE): 가중 이동 평균법으로 재료 단가 산정.
+ *
+ *   new_avg = (current_stock × current_avg + new_qty × new_unit_price)
+ *           / (current_stock + new_qty)
+ *
+ * - 첫 매입(current_stock = 0): new_avg = new_unit_price (FR-004)
+ * - new_quantity = 0: current_avg 유지 (no-op 매입은 호출 측에서 막아야 하지만 방어)
+ *
+ * Decimal.js로 부동소수점 누적 오차 차단. 결과는 numeric(12,4) DB 컬럼에
+ * `.toFixed(4)`로 저장.
+ */
+
+Decimal.set({ precision: 28, rounding: Decimal.ROUND_HALF_UP });
+
+export interface WeightedAverageInput {
+  currentStock: number;
+  currentAvg: number;
+  newQuantity: number;
+  newUnitPrice: number;
+}
+
+export function computeNewWeightedAverage({
+  currentStock,
+  currentAvg,
+  newQuantity,
+  newUnitPrice,
+}: WeightedAverageInput): Decimal {
+  if (newQuantity < 0) {
+    throw new Error(`newQuantity must be non-negative (got ${newQuantity})`);
+  }
+  if (newUnitPrice < 0) {
+    throw new Error(`newUnitPrice must be non-negative (got ${newUnitPrice})`);
+  }
+
+  if (newQuantity === 0) {
+    return new Decimal(currentAvg);
+  }
+
+  const newPrice = new Decimal(newUnitPrice);
+  if (currentStock === 0) {
+    return newPrice;
+  }
+
+  const stock = new Decimal(currentStock);
+  const avg = new Decimal(currentAvg);
+  const qty = new Decimal(newQuantity);
+
+  return stock.times(avg).plus(qty.times(newPrice)).dividedBy(stock.plus(qty));
+}

--- a/tests/unit/margin.test.ts
+++ b/tests/unit/margin.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import {
+  calculateMenuCost,
+  calculateMargin,
+  MARGIN_LABEL,
+  type RecipeItemForCost,
+} from "@/lib/domain/margin";
+
+/**
+ * 헌법 III: 메뉴 원가/마진은 항상 "재료 원가 기준 (이동평균법)" 라벨과 함께 표시.
+ * 임대료·인건비 절대 포함하지 않음.
+ *
+ * 메뉴 원가 = sum(quantity × ingredient.current_avg_price)
+ * 마진 금액 = price - cost
+ * 마진율 = (price - cost) / price × 100
+ */
+
+describe("calculateMenuCost", () => {
+  it("단일 재료: 우유 200ml @ 5원/ml = 1000원", () => {
+    const recipe: RecipeItemForCost[] = [{ quantity: 200, avgPrice: 5 }];
+    const result = calculateMenuCost(recipe);
+    expect(result.toString()).toBe("1000");
+  });
+
+  it("복수 재료 합산", () => {
+    const recipe: RecipeItemForCost[] = [
+      { quantity: 200, avgPrice: 5 }, // 1000
+      { quantity: 150, avgPrice: 8 }, // 1200
+      { quantity: 1, avgPrice: 500 }, // 500
+    ];
+    const result = calculateMenuCost(recipe);
+    expect(result.toString()).toBe("2700");
+  });
+
+  it("빈 레시피는 0원", () => {
+    expect(calculateMenuCost([]).toString()).toBe("0");
+  });
+
+  it("avgPrice = 0인 재료(가입 직후 상태)는 0원으로 합산 — 마진 100% 표시", () => {
+    const recipe: RecipeItemForCost[] = [
+      { quantity: 200, avgPrice: 0 },
+      { quantity: 150, avgPrice: 0 },
+    ];
+    expect(calculateMenuCost(recipe).toString()).toBe("0");
+  });
+
+  it("부동소수점 누적 — Decimal로 정밀 계산", () => {
+    const recipe: RecipeItemForCost[] = [
+      { quantity: 0.1, avgPrice: 0.2 },
+      { quantity: 0.1, avgPrice: 0.2 },
+      { quantity: 0.1, avgPrice: 0.2 },
+    ];
+    // JS native: 0.1*0.2 + 0.1*0.2 + 0.1*0.2 = 0.06000000000000001
+    // Decimal: 정확히 0.06
+    expect(calculateMenuCost(recipe).toString()).toBe("0.06");
+  });
+
+  it("결과는 Decimal 타입", () => {
+    const recipe: RecipeItemForCost[] = [{ quantity: 100, avgPrice: 10 }];
+    expect(calculateMenuCost(recipe)).toBeInstanceOf(Decimal);
+  });
+
+  it("음수 수량/단가는 거부", () => {
+    expect(() => calculateMenuCost([{ quantity: -1, avgPrice: 10 }])).toThrow();
+    expect(() => calculateMenuCost([{ quantity: 1, avgPrice: -10 }])).toThrow();
+  });
+});
+
+describe("calculateMargin", () => {
+  it("매출 5000원 - 원가 2000원 = 마진 3000원, 60%", () => {
+    const result = calculateMargin({ price: 5000, cost: new Decimal(2000) });
+    expect(result.amount.toString()).toBe("3000");
+    expect(result.rate.toString()).toBe("60");
+  });
+
+  it("원가가 매출보다 크면 음수 마진율", () => {
+    const result = calculateMargin({ price: 1000, cost: new Decimal(1500) });
+    expect(result.amount.toString()).toBe("-500");
+    expect(result.rate.toString()).toBe("-50");
+  });
+
+  it("price = 0이면 rate는 0 (division by zero 방어)", () => {
+    const result = calculateMargin({ price: 0, cost: new Decimal(0) });
+    expect(result.rate.toString()).toBe("0");
+  });
+
+  it("cost = 0이면 마진율 100% (가입 직후 상태)", () => {
+    const result = calculateMargin({ price: 5000, cost: new Decimal(0) });
+    expect(result.rate.toString()).toBe("100");
+  });
+
+  it("라벨이 항상 '재료 원가 기준 (이동평균법)'", () => {
+    const result = calculateMargin({ price: 5000, cost: new Decimal(2000) });
+    expect(result.label).toBe("재료 원가 기준 (이동평균법)");
+    expect(MARGIN_LABEL).toBe("재료 원가 기준 (이동평균법)");
+  });
+
+  it("음수 가격은 거부", () => {
+    expect(() => calculateMargin({ price: -100, cost: new Decimal(50) })).toThrow();
+  });
+});

--- a/tests/unit/pricing.test.ts
+++ b/tests/unit/pricing.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { computeNewWeightedAverage } from "@/lib/domain/pricing";
+
+/**
+ * 헌법 III (NON-NEGOTIABLE): 가중 이동 평균법.
+ *
+ * new_avg = (current_stock × current_avg + qty × unit_price) / (current_stock + qty)
+ *
+ * 첫 매입(current_stock = 0)이면 new_avg = unit_price (FR-004).
+ * 누적 정밀도: numeric(12,4) 컬럼과 일관, 30일 누적 ≤ 0.01원 오차 (SC-009).
+ */
+
+describe("computeNewWeightedAverage", () => {
+  describe("첫 매입 (current_stock = 0)", () => {
+    it("새 평균 단가는 단위 가격과 같다", () => {
+      const result = computeNewWeightedAverage({
+        currentStock: 0,
+        currentAvg: 0,
+        newQuantity: 1000,
+        newUnitPrice: 50,
+      });
+      expect(result.toString()).toBe("50");
+    });
+
+    it("currentAvg가 0이 아니어도 stock이 0이면 새 단가만 반영", () => {
+      const result = computeNewWeightedAverage({
+        currentStock: 0,
+        currentAvg: 100, // 이전 데이터, 무시되어야 함
+        newQuantity: 500,
+        newUnitPrice: 80,
+      });
+      expect(result.toString()).toBe("80");
+    });
+  });
+
+  describe("일반 매입", () => {
+    it("재고 1000g @ 50원 + 1000g @ 70원 = 60원", () => {
+      const result = computeNewWeightedAverage({
+        currentStock: 1000,
+        currentAvg: 50,
+        newQuantity: 1000,
+        newUnitPrice: 70,
+      });
+      expect(result.toString()).toBe("60");
+    });
+
+    it("재고 차이 큼: 9000g @ 50원 + 1000g @ 100원 = 55원", () => {
+      const result = computeNewWeightedAverage({
+        currentStock: 9000,
+        currentAvg: 50,
+        newQuantity: 1000,
+        newUnitPrice: 100,
+      });
+      expect(result.toString()).toBe("55");
+    });
+
+    it("결과는 Decimal 타입 (부동소수점 오차 방지)", () => {
+      const result = computeNewWeightedAverage({
+        currentStock: 333,
+        currentAvg: 33.33,
+        newQuantity: 100,
+        newUnitPrice: 99.99,
+      });
+      expect(result).toBeInstanceOf(Decimal);
+    });
+  });
+
+  describe("정밀도 (SC-009)", () => {
+    it("30일 누적 시 오차 ≤ 0.01원", () => {
+      // 시나리오: 매일 100g씩, 단가 1.111원 ~ 1.999원 사이 변동.
+      const purchases = [
+        1.111, 1.234, 1.567, 1.789, 1.234, 1.456, 1.678, 1.999, 1.111, 1.345, 1.567, 1.789, 1.234,
+        1.456, 1.678, 1.999, 1.111, 1.345, 1.567, 1.789, 1.234, 1.456, 1.678, 1.999, 1.111, 1.345,
+        1.567, 1.789, 1.234, 1.456,
+      ];
+
+      let stock = 0;
+      let avg = new Decimal(0);
+      for (const unitPrice of purchases) {
+        avg = computeNewWeightedAverage({
+          currentStock: stock,
+          currentAvg: Number(avg),
+          newQuantity: 100,
+          newUnitPrice: unitPrice,
+        });
+        stock += 100;
+      }
+
+      // 정확한 가중 평균 = sum(qty × price) / sum(qty)
+      const totalCost = purchases.reduce(
+        (sum, p) => sum.plus(new Decimal(100).times(p)),
+        new Decimal(0),
+      );
+      const totalQty = purchases.length * 100;
+      const exactAvg = totalCost.dividedBy(totalQty);
+
+      expect(avg.minus(exactAvg).abs().toNumber()).toBeLessThanOrEqual(0.01);
+    });
+
+    it("소수 4자리 numeric(12,4) DB 컬럼 호환", () => {
+      const result = computeNewWeightedAverage({
+        currentStock: 7,
+        currentAvg: 3,
+        newQuantity: 3,
+        newUnitPrice: 11,
+      });
+      // (7×3 + 3×11) / 10 = (21 + 33) / 10 = 5.4
+      expect(result.toFixed(4)).toBe("5.4000");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("newQuantity = 0이면 currentAvg 유지", () => {
+      const result = computeNewWeightedAverage({
+        currentStock: 1000,
+        currentAvg: 50,
+        newQuantity: 0,
+        newUnitPrice: 999,
+      });
+      expect(result.toString()).toBe("50");
+    });
+
+    it("음수 수량은 거부", () => {
+      expect(() =>
+        computeNewWeightedAverage({
+          currentStock: 1000,
+          currentAvg: 50,
+          newQuantity: -100,
+          newUnitPrice: 70,
+        }),
+      ).toThrow();
+    });
+
+    it("음수 단가는 거부", () => {
+      expect(() =>
+        computeNewWeightedAverage({
+          currentStock: 1000,
+          currentAvg: 50,
+          newQuantity: 100,
+          newUnitPrice: -10,
+        }),
+      ).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Phase 3 첫 PR — 헌법 III(가중 이동 평균법, 재료 원가 기준 마진)의 핵심 도메인 로직 + 테스트 우선.

## What

### `src/lib/domain/pricing.ts` + `tests/unit/pricing.test.ts` (10개)

- `computeNewWeightedAverage({ currentStock, currentAvg, newQuantity, newUnitPrice })`
- FR-004: 첫 매입(`current_stock = 0`) → `new_avg = unit_price`
- 일반 매입: `(stock × avg + qty × price) / (stock + qty)` 그대로
- **SC-009 검증**: 30일 매일 100g씩 매입(단가 1.111~1.999원 변동) → 정확값과 차이 ≤ 0.01원
- `numeric(12,4)` DB 컬럼과 `.toFixed(4)`로 호환
- `Decimal.js` precision 28, ROUND_HALF_UP — 부동소수점 누적 오차 차단
- 음수 수량/단가 throw

### `src/lib/domain/margin.ts` + `tests/unit/margin.test.ts` (13개)

- `calculateMenuCost(recipe[])` → `Σ(qty × avgPrice)` Decimal 결과
- `calculateMargin({ price, cost })` → `{ amount, rate, label }`
- **`MARGIN_LABEL = "재료 원가 기준 (이동평균법)"` 상수 export** — UI 어디서든 import해서 라벨 일관성 (헌법 III, 임대료·인건비 미포함)
- `price = 0` division-by-zero 방어 (rate = 0)
- `cost = 0` → rate 100% (가입 직후 자연스러운 상태)
- 부동소수점: `0.1 × 0.2 × 3` Native JS는 0.06000000000000001, Decimal은 정확히 0.06
- 음수 입력은 throw

## 설계 메모

- **결과는 항상 `Decimal` 객체로 반환** — 호출 체인에서 정밀도 보존, 표시 직전에 `.toFixed()` / `.toString()`으로 변환
- **DB RPC와 이중 가드**: 다음 PR의 `clone_menu_template` / `save_purchase` RPC가 SQL로 동일 공식을 구현하지만, 클라이언트 미리보기·재계산용으로 이 TS 함수가 필요 (실시간 UI에서 RPC 왕복 없이 마진 보여주기)

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ **48/48** (23개 신규 + 25개 기존)
- `npm run build` ✅

## 다음 PR 예고

PR 20: `menus` / `recipe_items` 마이그레이션 + `clone_menu_template` RPC + `menu_templates` 시드 + Zod + 통합 테스트.

Closes #19