### PR TITLE
refactor(domain): PR #20 simplify follow-up — Decimal 격리 + assert 추출 + margin API

### DIFF
--- a/src/lib/domain/_assert.ts
+++ b/src/lib/domain/_assert.ts
@@ -1,0 +1,12 @@
+/**
+ * 도메인 invariants 가드.
+ *
+ * 내부 도메인 함수에서만 사용 — I/O 경계는 Zod schema가 담당.
+ * 메시지 포맷이 일관되어야 추후 i18n 전환 시 검색·치환이 쉬움.
+ */
+
+export function assertNonNegative(value: number, label: string): void {
+  if (value < 0) {
+    throw new Error(`${label} must be non-negative (got ${value})`);
+  }
+}

--- a/src/lib/domain/_decimal.ts
+++ b/src/lib/domain/_decimal.ts
@@ -1,0 +1,21 @@
+import DecimalBase from "decimal.js";
+
+/**
+ * 도메인 전용 Decimal 인스턴스.
+ *
+ * `Decimal.set()`을 글로벌에 호출하면 다른 모듈 또는 라이브러리가 같은
+ * Decimal에 의존할 때 silent하게 영향받음. `clone()`으로 우리 도메인 전용
+ * 인스턴스를 분리하고, 도메인 모듈은 모두 여기서 import.
+ *
+ * Precision 28: SC-009의 30일 누적 ≤0.01원 요구를 충분히 만족하면서 (decimal.js
+ * 내부 곱셈/나눗셈 라운딩 헤드룸) 일반 거래 단위(numeric(12,4)) 변환에 불필요
+ * 하게 큰 메모리를 안 씀. 28은 decimal.js 기본값.
+ */
+export const DOMAIN_DECIMAL_PRECISION = 28;
+
+export const Decimal = DecimalBase.clone({
+  precision: DOMAIN_DECIMAL_PRECISION,
+  rounding: DecimalBase.ROUND_HALF_UP,
+});
+
+export type Decimal = InstanceType<typeof Decimal>;

--- a/src/lib/domain/margin.ts
+++ b/src/lib/domain/margin.ts
@@ -1,9 +1,10 @@
-import Decimal from "decimal.js";
+import { Decimal } from "./_decimal";
+import { assertNonNegative } from "./_assert";
 
 /**
  * 헌법 III: 메뉴 원가 / 마진 산정.
  *
- * - 메뉴 원가 = Σ(레시피 항목.수량 × 재료.current_avg_price)
+ * - 메뉴 원가 = Σ(레시피 항목.quantity × 재료.avgPrice)
  * - 마진 금액 = 메뉴 가격 - 메뉴 원가
  * - 마진율 = 마진 금액 / 메뉴 가격 × 100
  *
@@ -20,19 +21,15 @@ export interface RecipeItemForCost {
 
 export function calculateMenuCost(recipe: readonly RecipeItemForCost[]): Decimal {
   return recipe.reduce((total, item) => {
-    if (item.quantity < 0) {
-      throw new Error(`recipe item quantity must be non-negative (got ${item.quantity})`);
-    }
-    if (item.avgPrice < 0) {
-      throw new Error(`recipe item avgPrice must be non-negative (got ${item.avgPrice})`);
-    }
+    assertNonNegative(item.quantity, "recipe item quantity");
+    assertNonNegative(item.avgPrice, "recipe item avgPrice");
     return total.plus(new Decimal(item.quantity).times(item.avgPrice));
   }, new Decimal(0));
 }
 
 export interface MarginInput {
   price: number;
-  cost: Decimal;
+  cost: number | Decimal;
 }
 
 export interface MarginResult {
@@ -42,13 +39,17 @@ export interface MarginResult {
 }
 
 export function calculateMargin({ price, cost }: MarginInput): MarginResult {
-  if (price < 0) {
-    throw new Error(`menu price must be non-negative (got ${price})`);
+  assertNonNegative(price, "menu price");
+
+  const costDecimal = cost instanceof Decimal ? cost : new Decimal(cost);
+
+  if (price === 0) {
+    return { amount: costDecimal.negated(), rate: new Decimal(0), label: MARGIN_LABEL };
   }
 
   const priceDecimal = new Decimal(price);
-  const amount = priceDecimal.minus(cost);
-  const rate = priceDecimal.isZero() ? new Decimal(0) : amount.dividedBy(priceDecimal).times(100);
+  const amount = priceDecimal.minus(costDecimal);
+  const rate = amount.dividedBy(priceDecimal).times(100);
 
   return { amount, rate, label: MARGIN_LABEL };
 }

--- a/src/lib/domain/pricing.ts
+++ b/src/lib/domain/pricing.ts
@@ -1,4 +1,5 @@
-import Decimal from "decimal.js";
+import { Decimal } from "./_decimal";
+import { assertNonNegative } from "./_assert";
 
 /**
  * 헌법 III (NON-NEGOTIABLE): 가중 이동 평균법으로 재료 단가 산정.
@@ -7,13 +8,10 @@ import Decimal from "decimal.js";
  *           / (current_stock + new_qty)
  *
  * - 첫 매입(current_stock = 0): new_avg = new_unit_price (FR-004)
- * - new_quantity = 0: current_avg 유지 (no-op 매입은 호출 측에서 막아야 하지만 방어)
+ * - new_quantity = 0: current_avg 유지 (no-op 매입 방어)
  *
- * Decimal.js로 부동소수점 누적 오차 차단. 결과는 numeric(12,4) DB 컬럼에
- * `.toFixed(4)`로 저장.
+ * 결과는 Decimal — numeric(12,4) DB 컬럼에는 `.toFixed(4)`로 저장.
  */
-
-Decimal.set({ precision: 28, rounding: Decimal.ROUND_HALF_UP });
 
 export interface WeightedAverageInput {
   currentStock: number;
@@ -28,12 +26,8 @@ export function computeNewWeightedAverage({
   newQuantity,
   newUnitPrice,
 }: WeightedAverageInput): Decimal {
-  if (newQuantity < 0) {
-    throw new Error(`newQuantity must be non-negative (got ${newQuantity})`);
-  }
-  if (newUnitPrice < 0) {
-    throw new Error(`newUnitPrice must be non-negative (got ${newUnitPrice})`);
-  }
+  assertNonNegative(newQuantity, "newQuantity");
+  assertNonNegative(newUnitPrice, "newUnitPrice");
 
   if (newQuantity === 0) {
     return new Decimal(currentAvg);

--- a/tests/unit/margin.test.ts
+++ b/tests/unit/margin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import Decimal from "decimal.js";
+import { Decimal } from "@/lib/domain/_decimal";
 import {
   calculateMenuCost,
   calculateMargin,
@@ -90,10 +90,15 @@ describe("calculateMargin", () => {
     expect(result.rate.toString()).toBe("100");
   });
 
-  it("라벨이 항상 '재료 원가 기준 (이동평균법)'", () => {
+  it("라벨이 항상 MARGIN_LABEL 상수와 일치 — UI에서 import해 비교 가능", () => {
     const result = calculateMargin({ price: 5000, cost: new Decimal(2000) });
-    expect(result.label).toBe("재료 원가 기준 (이동평균법)");
-    expect(MARGIN_LABEL).toBe("재료 원가 기준 (이동평균법)");
+    expect(result.label).toBe(MARGIN_LABEL);
+  });
+
+  it("cost를 number로 넘겨도 Decimal로 normalize됨 — RPC 응답 직결 호출 호환", () => {
+    const result = calculateMargin({ price: 5000, cost: 2000 });
+    expect(result.amount.toString()).toBe("3000");
+    expect(result.rate.toString()).toBe("60");
   });
 
   it("음수 가격은 거부", () => {

--- a/tests/unit/pricing.test.ts
+++ b/tests/unit/pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import Decimal from "decimal.js";
+import { Decimal } from "@/lib/domain/_decimal";
 import { computeNewWeightedAverage } from "@/lib/domain/pricing";
 
 /**


### PR DESCRIPTION
PR #20 (도메인 로직) 머지 후 사후 simplify 리뷰(reuse / quality / efficiency 3개 에이전트)에서 발견한 항목 반영. **기능 변경 없음, 모든 기존 테스트 통과 (49/49).**

## What

| # | 항목 | 효과 |
|---|------|------|
| 1 | `Decimal.set()` 전역 mutation → `Decimal.clone()` 격리 (`src/lib/domain/_decimal.ts`) | 모듈 import-order 의존성 제거. 다른 라이브러리/모듈의 Decimal 사용에 silent 영향 차단 |
| 2 | `assertNonNegative(value, label)` 헬퍼 (`src/lib/domain/_assert.ts`) | 5곳 중복 → 한 함수, 메시지 포맷 일관 (i18n 대비) |
| 3 | `calculateMargin({ cost: number \| Decimal })` | RPC 응답(plain number) 직결 호출 가능, 호출자 편의 |
| 4 | `price === 0` short-circuit을 `priceDecimal` 할당 이전으로 | 불필요한 Decimal 할당 회피 |
| 5 | `MARGIN_LABEL` 테스트 literal 중복 assertion 제거 + number-cost 경로 신규 테스트 | 상수가 진짜 단일 진실 공급원 역할 |
| 6 | JSDoc `current_avg_price` → `avgPrice` (실제 필드명) | 코드와 문서 일치 |
| 7 | Magic 28 → `DOMAIN_DECIMAL_PRECISION` 상수 + SC-009 근거 주석 | "왜 28인가" 답이 코드 안에 |

## 명명 컨벤션

내부 헬퍼는 `_decimal.ts` / `_assert.ts`처럼 **underscore prefix**로 표시. 도메인의 외부 API(`margin.ts`, `pricing.ts`, `regular-days-off.ts`)와 시각적으로 구분. 새로 도입된 컨벤션이라 후속 도메인 헬퍼도 같은 규칙으로.

## 두 번째 simplify 패스 결과

방금 변경분에 다시 simplify 돌려 확인:
- ✅ 클론된 Decimal class 정합성 (`toBeInstanceOf(Decimal)` 동작)
- ✅ `import Decimal from "decimal.js"` 잔여 없음 (`_decimal.ts`만 raw 라이브러리 참조)
- ✅ precision 28 / ROUND_HALF_UP 보존
- ✅ underscore prefix 컨벤션 신규 도입 명시

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ **49/49**
- `npm run build` ✅

## 메모

이 PR이 simplify를 PR 흐름에 강제로 박는 첫 follow-up. 이후 모든 PR은 푸시 전에 simplify 통과해야 함.