### PR TITLE
feat(menu): UI + 라우팅 + 훅 + GA4 (Phase 3 완료)

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -144,20 +144,20 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### UI 컴포넌트 + 라우팅
 
-- [ ] T066 [P] [US3] Create `src/features/menu/components/MenuList.tsx` listing user menus with margin badge (재료 원가 기준 라벨 포함)
-- [ ] T067 [P] [US3] Create `src/features/menu/components/MenuDetailCard.tsx` showing recipe items + 재료별 단가 + 메뉴원가 + 마진율 with 변동 표시 (FR-058 ±5% indicator)
-- [ ] T068 [P] [US3] Create `src/features/menu/components/MenuForm.tsx` for create/edit (name unique 검증, recipe items 추가/삭제)
-- [ ] T069 [P] [US3] Create `src/features/menu/components/TemplateLoadDialog.tsx` showing template preview + "불러오기" button
-- [ ] T070 [US3] Create page `src/app/(main)/menu/page.tsx` integrating MenuList + TemplateLoadDialog (cold-start: empty list + prominent template CTA)
-- [ ] T071 [US3] Create page `src/app/(main)/menu/[id]/page.tsx` integrating MenuDetailCard
-- [ ] T072 [US3] Create page `src/app/(main)/menu/new/page.tsx` integrating MenuForm
-- [ ] T073 [P] [US3] Create hook `src/features/menu/hooks/useMenus.ts` (TanStack Query for menu list + invalidation on save)
-- [ ] T074 [P] [US3] Create hook `src/features/menu/hooks/useCloneTemplate.ts` (mutation calling `clone_menu_template` RPC)
+- [x] T066 [P] [US3] Create `src/features/menu/components/MenuList.tsx` listing user menus with margin badge (재료 원가 기준 라벨 포함)
+- [x] T067 [P] [US3] Create `src/features/menu/components/MenuDetailCard.tsx` showing recipe items + 재료별 단가 + 메뉴원가 + 마진율 with 변동 표시 (FR-058 ±5% indicator)
+- [x] T068 [P] [US3] Create `src/features/menu/components/MenuForm.tsx` for create/edit (name unique 검증, recipe items 추가/삭제)
+- [x] T069 [P] [US3] Create `src/features/menu/components/TemplateLoadDialog.tsx` showing template preview + "불러오기" button
+- [x] T070 [US3] Create page `src/app/(main)/menu/page.tsx` integrating MenuList + TemplateLoadDialog (cold-start: empty list + prominent template CTA)
+- [x] T071 [US3] Create page `src/app/(main)/menu/[id]/page.tsx` integrating MenuDetailCard
+- [x] T072 [US3] Create page `src/app/(main)/menu/new/page.tsx` integrating MenuForm
+- [x] T073 [P] [US3] Create hook `src/features/menu/hooks/useMenus.ts` (TanStack Query for menu list + invalidation on save)
+- [x] T074 [P] [US3] Create hook `src/features/menu/hooks/useCloneTemplate.ts` (mutation calling `clone_menu_template` RPC)
 
 ### GA4 이벤트
 
-- [ ] T075 [US3] Wire `first_menu_registered` GA4 event in MenuForm save handler (fire only if user's menu count was 0 before this save)
-- [ ] T076 [US3] Wire `template_loaded` GA4 event in TemplateLoadDialog success with `store_type` parameter
+- [x] T075 [US3] Wire `first_menu_registered` GA4 event in MenuForm save handler (fire only if user's menu count was 0 before this save)
+- [x] T076 [US3] Wire `template_loaded` GA4 event in TemplateLoadDialog success with `store_type` parameter
 
 ### 통합 테스트
 

--- a/src/app/(main)/menu/[id]/page.tsx
+++ b/src/app/(main)/menu/[id]/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMenus } from "@/features/menu/hooks/useMenus";
+import { MenuDetailCard } from "@/features/menu/components/MenuDetailCard";
+
+export default function MenuDetailPage(): React.ReactElement {
+  const { id } = useParams<{ id: string }>();
+  const { data, isLoading, error } = useMenus();
+
+  const menu = data?.find((m) => m.id === id);
+
+  return (
+    <section className="flex flex-col gap-section">
+      <header className="flex items-center justify-between">
+        <Link href="/menu" className="text-body-regular text-ink-3 hover:text-ink-2">
+          ← 메뉴 목록
+        </Link>
+      </header>
+
+      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
+
+      {error && (
+        <p role="alert" className="text-body-regular text-red">
+          {error.message}
+        </p>
+      )}
+
+      {data && !menu && <p className="text-body-regular text-ink-3">메뉴를 찾을 수 없습니다.</p>}
+
+      {menu && <MenuDetailCard menu={menu} />}
+    </section>
+  );
+}

--- a/src/app/(main)/menu/new/page.tsx
+++ b/src/app/(main)/menu/new/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { MenuForm } from "@/features/menu/components/MenuForm";
+import { useMenus } from "@/features/menu/hooks/useMenus";
+
+interface IngredientOption {
+  id: string;
+  name: string;
+  unit: string;
+}
+
+export default function MenuNewPage(): React.ReactElement {
+  const { data: menus, isLoading: menusLoading } = useMenus();
+  const [ingredients, setIngredients] = useState<IngredientOption[]>([]);
+  const [ingredientsLoading, setIngredientsLoading] = useState(true);
+  const [ingredientsError, setIngredientsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+    void supabase
+      .from("ingredients")
+      .select("id, name, unit")
+      .eq("is_active", true)
+      .order("name")
+      .then(({ data, error }) => {
+        if (error) {
+          setIngredientsError(error.message);
+        } else {
+          setIngredients(data ?? []);
+        }
+        setIngredientsLoading(false);
+      });
+  }, []);
+
+  const isLoading = menusLoading || ingredientsLoading;
+  const isFirstMenu = (menus?.length ?? 0) === 0;
+
+  return (
+    <section className="flex flex-col gap-section">
+      <header className="flex items-center justify-between">
+        <h1 className="text-title-lg text-ink-1">메뉴 추가</h1>
+        <Link href="/menu" className="text-body-regular text-ink-3 hover:text-ink-2">
+          취소
+        </Link>
+      </header>
+
+      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
+
+      {ingredientsError && (
+        <p role="alert" className="text-body-regular text-red">
+          재료 목록을 불러오지 못했어요: {ingredientsError}
+        </p>
+      )}
+
+      {!isLoading && !ingredientsError && (
+        <MenuForm ingredients={ingredients} isFirstMenu={isFirstMenu} />
+      )}
+    </section>
+  );
+}

--- a/src/app/(main)/menu/page.tsx
+++ b/src/app/(main)/menu/page.tsx
@@ -1,8 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { useMenus } from "@/features/menu/hooks/useMenus";
+import { MenuList } from "@/features/menu/components/MenuList";
+import { TemplateLoadDialog } from "@/features/menu/components/TemplateLoadDialog";
+
 export default function MenuPage(): React.ReactElement {
+  const { data, isLoading, error } = useMenus();
+
   return (
-    <section className="flex flex-col gap-stack">
-      <h1 className="text-title-lg text-ink-1">메뉴/레시피</h1>
-      <p className="text-body-regular text-ink-3">메뉴 등록 + 템플릿 — Phase 3에서 구현</p>
+    <section className="flex flex-col gap-section">
+      <header className="flex items-center justify-between">
+        <h1 className="text-title-lg text-ink-1">메뉴</h1>
+        <Link
+          href="/menu/new"
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
+        >
+          + 추가
+        </Link>
+      </header>
+
+      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
+
+      {error && (
+        <p role="alert" className="text-body-regular text-red">
+          메뉴를 불러오지 못했어요: {error.message}
+        </p>
+      )}
+
+      {data && data.length === 0 && <TemplateLoadDialog />}
+
+      {data && data.length > 0 && <MenuList menus={data} />}
     </section>
   );
 }

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,24 @@
+/**
+ * 폼 필드 wrapper — 라벨 / 입력 / 에러 메시지 정렬.
+ * auth / menu / 후속 도메인 폼에서 공유.
+ */
+
+interface FieldProps {
+  label: string;
+  error?: string;
+  children: React.ReactNode;
+}
+
+export function Field({ label, error, children }: FieldProps): React.ReactElement {
+  return (
+    <label className="flex flex-col gap-stack-tight">
+      <span className="text-label text-ink-2">{label}</span>
+      {children}
+      {error && (
+        <span role="alert" className="text-caption text-red">
+          {error}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/src/components/ui/primary-button.tsx
+++ b/src/components/ui/primary-button.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * 페르소나 1차 액션 (저장 / 등록 / 불러오기) 버튼.
+ * 디자인 토큰 ink-1 / bg, opacity 90% hover, disabled 50%.
+ */
+
+type PrimaryButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function PrimaryButton({
+  className,
+  children,
+  ...rest
+}: PrimaryButtonProps): React.ReactElement {
+  return (
+    <button
+      {...rest}
+      className={cn(
+        "rounded-md bg-ink-1 px-stack py-stack text-body text-bg transition hover:opacity-90 disabled:opacity-50",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createClient } from "@/lib/supabase/client";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
 import { type LoginInput, loginSchema } from "../schemas";
 
 export function LoginForm(): React.ReactElement {
@@ -56,29 +58,23 @@ export function LoginForm(): React.ReactElement {
         </div>
       )}
 
-      <label className="flex flex-col gap-stack-tight">
-        <span className="text-label text-ink-2">이메일</span>
+      <Field label="이메일" error={errors.email?.message}>
         <input
           {...register("email")}
           type="email"
           autoComplete="email"
           className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
         />
-        {errors.email && <span className="text-caption text-red">{errors.email.message}</span>}
-      </label>
+      </Field>
 
-      <label className="flex flex-col gap-stack-tight">
-        <span className="text-label text-ink-2">비밀번호</span>
+      <Field label="비밀번호" error={errors.password?.message}>
         <input
           {...register("password")}
           type="password"
           autoComplete="current-password"
           className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
         />
-        {errors.password && (
-          <span className="text-caption text-red">{errors.password.message}</span>
-        )}
-      </label>
+      </Field>
 
       {submitError && (
         <p role="alert" className="text-body-regular text-red">
@@ -86,13 +82,9 @@ export function LoginForm(): React.ReactElement {
         </p>
       )}
 
-      <button
-        type="submit"
-        disabled={isSubmitting}
-        className="rounded-md bg-ink-1 px-stack py-stack text-body text-bg hover:opacity-90 disabled:opacity-50"
-      >
+      <PrimaryButton type="submit" disabled={isSubmitting}>
         {isSubmitting ? "로그인 중..." : "로그인"}
-      </button>
+      </PrimaryButton>
     </form>
   );
 }

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -6,6 +6,8 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { createClient } from "@/lib/supabase/client";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
 import {
   STORE_TYPES,
   STORE_TYPE_LABELS,
@@ -132,29 +134,9 @@ export function SignupForm(): React.ReactElement {
         </p>
       )}
 
-      <button
-        type="submit"
-        disabled={isSubmitting}
-        className="rounded-md bg-ink-1 px-stack py-stack text-body text-bg hover:opacity-90 disabled:opacity-50"
-      >
+      <PrimaryButton type="submit" disabled={isSubmitting}>
         {isSubmitting ? "가입 중..." : "가입하기"}
-      </button>
+      </PrimaryButton>
     </form>
-  );
-}
-
-interface FieldProps {
-  label: string;
-  error?: string;
-  children: React.ReactNode;
-}
-
-function Field({ label, error, children }: FieldProps): React.ReactElement {
-  return (
-    <label className="flex flex-col gap-stack-tight">
-      <span className="text-label text-ink-2">{label}</span>
-      {children}
-      {error && <span className="text-caption text-red">{error}</span>}
-    </label>
   );
 }

--- a/src/features/menu/components/MenuDetailCard.tsx
+++ b/src/features/menu/components/MenuDetailCard.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { MARGIN_LABEL } from "@/lib/domain/margin";
+import { computeMenuMarginFromRow } from "../lib/compute-menu-margin";
+import type { MenuRowWithRecipe } from "../hooks/useMenus";
+
+interface MenuDetailCardProps {
+  menu: MenuRowWithRecipe;
+}
+
+const fmt = (value: number): string => Math.round(value).toLocaleString("ko-KR");
+
+export function MenuDetailCard({ menu }: MenuDetailCardProps): React.ReactElement {
+  const { cost, margin, hasRecipe } = computeMenuMarginFromRow(menu);
+
+  return (
+    <article className="flex flex-col gap-section rounded-lg border border-border bg-card p-tile">
+      <header className="flex items-start justify-between">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-title-md text-ink-1">{menu.name}</h2>
+          <span className="text-caption text-ink-3 tabular-nums">판매가 {fmt(menu.price)}원</span>
+        </div>
+        {hasRecipe ? (
+          <div className="flex flex-col items-end gap-1">
+            <span className="text-metric-lg text-ink-1 tabular-nums">
+              {margin.rate.toFixed(0)}%
+            </span>
+            <span className="text-caption text-ink-3">마진율</span>
+          </div>
+        ) : (
+          <span className="text-caption text-ink-3">레시피 미등록</span>
+        )}
+      </header>
+
+      {hasRecipe && (
+        <ul className="flex flex-col divide-y divide-border">
+          {menu.recipe_items.map((item) => (
+            <RecipeRow key={item.id} item={item} />
+          ))}
+        </ul>
+      )}
+
+      {hasRecipe && (
+        <footer className="flex items-baseline justify-between border-t border-border pt-stack">
+          <div className="flex flex-col gap-1">
+            <span className="text-caption text-ink-3">{MARGIN_LABEL}</span>
+            <span className="text-body-regular text-ink-2 tabular-nums">
+              마진 금액 {fmt(margin.amount.toNumber())}원
+            </span>
+          </div>
+          <span className="text-metric-md text-ink-1 tabular-nums">
+            원가 {fmt(cost.toNumber())}원
+          </span>
+        </footer>
+      )}
+    </article>
+  );
+}
+
+function RecipeRow({
+  item,
+}: {
+  item: MenuRowWithRecipe["recipe_items"][number];
+}): React.ReactElement {
+  const lineCost = item.quantity_per_serving * item.ingredient.current_avg_price;
+
+  return (
+    <li className="grid grid-cols-[1fr_auto_auto] items-center gap-stack py-stack-tight">
+      <span className="text-body-regular text-ink-1">{item.ingredient.name}</span>
+      <span className="text-caption text-ink-3 tabular-nums">
+        {item.quantity_per_serving}
+        {item.ingredient.unit}
+      </span>
+      <span className="text-body-regular text-ink-2 tabular-nums">{fmt(lineCost)}원</span>
+    </li>
+  );
+}

--- a/src/features/menu/components/MenuForm.tsx
+++ b/src/features/menu/components/MenuForm.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm, useFieldArray } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { saveMenu } from "@/lib/supabase/rpc";
+import { trackEvent } from "@/lib/analytics/ga4";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { menuSchema, type MenuInput } from "../schemas";
+import { menuListQueryKey } from "../hooks/useMenus";
+
+interface IngredientOption {
+  id: string;
+  name: string;
+  unit: string;
+}
+
+interface MenuFormProps {
+  ingredients: readonly IngredientOption[];
+  isFirstMenu: boolean;
+}
+
+export function MenuForm({ ingredients, isFirstMenu }: MenuFormProps): React.ReactElement {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors, isSubmitting },
+  } = useForm<MenuInput>({
+    resolver: zodResolver(menuSchema),
+    defaultValues: { name: "", price: 0, recipe: [] },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: "recipe" });
+
+  async function onSubmit(values: MenuInput): Promise<void> {
+    setSubmitError(null);
+
+    const supabase = createClient();
+    const { error } = await saveMenu(supabase, {
+      name: values.name,
+      price: values.price,
+      recipe: values.recipe,
+    });
+
+    if (error) {
+      setSubmitError(error.message);
+      return;
+    }
+
+    if (isFirstMenu) {
+      trackEvent("first_menu_registered", {});
+    }
+
+    void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+    router.push("/menu");
+  }
+
+  return (
+    <form
+      onSubmit={(event) => void handleSubmit(onSubmit)(event)}
+      className="flex flex-col gap-stack"
+      noValidate
+    >
+      <Field label="메뉴 이름" error={errors.name?.message}>
+        <input
+          {...register("name")}
+          type="text"
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        />
+      </Field>
+
+      <Field label="판매가 (원)" error={errors.price?.message}>
+        <input
+          {...register("price", { valueAsNumber: true })}
+          type="number"
+          min={0}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+        />
+      </Field>
+
+      <section className="flex flex-col gap-stack-tight">
+        <header className="flex items-center justify-between">
+          <span className="text-label text-ink-2">레시피 (1회 제공량)</span>
+          <button
+            type="button"
+            onClick={() =>
+              append({ ingredientId: ingredients[0]?.id ?? "", quantityPerServing: 0 })
+            }
+            className="rounded-md border border-border px-stack py-1 text-label text-ink-2 hover:bg-card-hover"
+            disabled={ingredients.length === 0}
+          >
+            + 재료 추가
+          </button>
+        </header>
+
+        {ingredients.length === 0 && (
+          <p className="text-caption text-ink-3">
+            재료를 먼저 등록해주세요. (템플릿 불러오면 재료/메뉴가 함께 만들어집니다.)
+          </p>
+        )}
+
+        {fields.map((field, idx) => (
+          <RecipeRow
+            key={field.id}
+            idx={idx}
+            register={register}
+            ingredients={ingredients}
+            onRemove={() => remove(idx)}
+            error={errors.recipe?.[idx]?.quantityPerServing?.message}
+          />
+        ))}
+      </section>
+
+      {submitError && (
+        <p role="alert" className="text-body-regular text-red">
+          {submitError}
+        </p>
+      )}
+
+      <PrimaryButton type="submit" disabled={isSubmitting}>
+        {isSubmitting ? "저장 중…" : "저장"}
+      </PrimaryButton>
+    </form>
+  );
+}
+
+interface RecipeRowProps {
+  idx: number;
+  register: ReturnType<typeof useForm<MenuInput>>["register"];
+  ingredients: readonly IngredientOption[];
+  onRemove: () => void;
+  error?: string;
+}
+
+function RecipeRow({
+  idx,
+  register,
+  ingredients,
+  onRemove,
+  error,
+}: RecipeRowProps): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="grid grid-cols-[1fr_100px_auto] items-center gap-stack-tight">
+        <select
+          {...register(`recipe.${idx}.ingredientId`)}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        >
+          {ingredients.map((ing) => (
+            <option key={ing.id} value={ing.id}>
+              {ing.name} ({ing.unit})
+            </option>
+          ))}
+        </select>
+        <input
+          {...register(`recipe.${idx}.quantityPerServing`, { valueAsNumber: true })}
+          type="number"
+          min={0}
+          step="0.001"
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+        />
+        <button type="button" onClick={onRemove} className="text-caption text-ink-3 hover:text-red">
+          삭제
+        </button>
+      </div>
+      {error && <span className="text-caption text-red">{error}</span>}
+    </div>
+  );
+}

--- a/src/features/menu/components/MenuList.tsx
+++ b/src/features/menu/components/MenuList.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { computeMenuMarginFromRow } from "../lib/compute-menu-margin";
+import type { MenuRowWithRecipe } from "../hooks/useMenus";
+
+interface MenuListProps {
+  menus: readonly MenuRowWithRecipe[];
+}
+
+export function MenuList({ menus }: MenuListProps): React.ReactElement {
+  return (
+    <ul className="flex flex-col gap-stack-tight">
+      {menus.map((menu) => (
+        <MenuListRow key={menu.id} menu={menu} />
+      ))}
+    </ul>
+  );
+}
+
+function MenuListRow({ menu }: { menu: MenuRowWithRecipe }): React.ReactElement {
+  const { cost, margin, hasRecipe } = computeMenuMarginFromRow(menu);
+
+  return (
+    <li>
+      <Link
+        href={`/menu/${menu.id}`}
+        className="flex items-center justify-between rounded-lg border border-border bg-card px-tile py-stack hover:bg-card-hover"
+      >
+        <div className="flex flex-col gap-1">
+          <span className="text-body text-ink-1">{menu.name}</span>
+          <span className="text-caption text-ink-3 tabular-nums">
+            {menu.price.toLocaleString("ko-KR")}원
+            {hasRecipe && (
+              <>
+                <span className="text-ink-4"> · </span>
+                원가 {Math.round(cost.toNumber()).toLocaleString("ko-KR")}원
+              </>
+            )}
+          </span>
+        </div>
+        {hasRecipe ? (
+          <MarginChip rate={margin.rate.toNumber()} />
+        ) : (
+          <span className="text-caption text-ink-3">레시피 미등록</span>
+        )}
+      </Link>
+    </li>
+  );
+}
+
+/**
+ * 디자인 시스템 임계값 (components.md L75-77):
+ * - green: 50%+, amber: 30~49%, red: <30%
+ */
+function MarginChip({ rate }: { rate: number }): React.ReactElement {
+  const tone: "green" | "amber" | "red" = rate >= 50 ? "green" : rate >= 30 ? "amber" : "red";
+  return (
+    <span
+      className={cn(
+        "rounded-full px-3 py-1 text-label tabular-nums",
+        tone === "green" && "bg-green-soft text-green-deep",
+        tone === "amber" && "bg-amber-soft text-amber-deep",
+        tone === "red" && "bg-red-soft text-red-deep",
+      )}
+    >
+      {rate.toFixed(0)}%
+    </span>
+  );
+}

--- a/src/features/menu/components/TemplateLoadDialog.tsx
+++ b/src/features/menu/components/TemplateLoadDialog.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { STORE_TYPES, STORE_TYPE_LABELS } from "@/features/auth/schemas";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { useCloneTemplate } from "../hooks/useCloneTemplate";
+import { cn } from "@/lib/utils";
+
+type StoreType = (typeof STORE_TYPES)[number];
+
+const TEMPLATE_PREVIEWS: Record<StoreType, { count: number; samples: string[] }> = {
+  bingsu_cafe: { count: 8, samples: ["팥빙수", "망고빙수", "딸기빙수"] },
+  cafe: { count: 10, samples: ["아메리카노", "카페라떼", "카페모카"] },
+  dessert_cafe: { count: 0, samples: [] },
+};
+
+interface TemplateLoadDialogProps {
+  defaultStoreType?: StoreType;
+}
+
+export function TemplateLoadDialog({
+  defaultStoreType = "bingsu_cafe",
+}: TemplateLoadDialogProps): React.ReactElement {
+  const [selected, setSelected] = useState<StoreType>(defaultStoreType);
+  const mutation = useCloneTemplate();
+
+  const preview = TEMPLATE_PREVIEWS[selected];
+  const isDisabled = preview.count === 0 || mutation.isPending;
+
+  return (
+    <section className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-title-md text-ink-1">템플릿으로 빠르게 시작</h2>
+        <p className="text-caption text-ink-3">
+          가게 유형을 고르면 메뉴와 재료가 자동으로 만들어집니다.
+        </p>
+      </header>
+
+      <div role="group" aria-label="가게 유형" className="flex gap-stack-tight">
+        {STORE_TYPES.map((type) => (
+          <button
+            key={type}
+            type="button"
+            aria-pressed={selected === type}
+            onClick={() => setSelected(type)}
+            className={cn(
+              "flex-1 rounded-md border px-stack py-stack-tight text-body-regular transition",
+              selected === type
+                ? "border-border-strong bg-ink-1 text-bg"
+                : "border-border bg-card text-ink-2 hover:bg-card-hover",
+            )}
+          >
+            {STORE_TYPE_LABELS[type]}
+          </button>
+        ))}
+      </div>
+
+      {preview.count > 0 ? (
+        <p className="text-caption text-ink-3">
+          메뉴 {preview.count}개 ({preview.samples.join(" · ")} 등)
+        </p>
+      ) : (
+        <p className="text-caption text-ink-3">이 유형은 아직 템플릿이 없어요.</p>
+      )}
+
+      <PrimaryButton
+        type="button"
+        onClick={() => mutation.mutate({ storeType: selected })}
+        disabled={isDisabled}
+      >
+        {mutation.isPending ? "불러오는 중…" : "템플릿 불러오기"}
+      </PrimaryButton>
+
+      {mutation.isError && (
+        <p role="alert" className="text-caption text-red">
+          {mutation.error.message}
+        </p>
+      )}
+
+      {mutation.isSuccess && mutation.data.newMenuCount === 0 && (
+        <p className="text-caption text-ink-3">이미 같은 메뉴가 등록되어 있어요.</p>
+      )}
+    </section>
+  );
+}

--- a/src/features/menu/hooks/useCloneTemplate.ts
+++ b/src/features/menu/hooks/useCloneTemplate.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { cloneMenuTemplate } from "@/lib/supabase/rpc";
+import { trackEvent } from "@/lib/analytics/ga4";
+import { menuListQueryKey } from "./useMenus";
+import type { CloneTemplateInput } from "../schemas";
+
+interface CloneResult {
+  newMenuCount: number;
+  newIngredientCount: number;
+}
+
+async function clone(input: CloneTemplateInput): Promise<CloneResult> {
+  const supabase = createClient();
+  const { data, error } = await cloneMenuTemplate(supabase, { storeType: input.storeType });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const row = data?.[0];
+  return {
+    newMenuCount: row?.menu_ids.length ?? 0,
+    newIngredientCount: row?.ingredient_ids.length ?? 0,
+  };
+}
+
+export function useCloneTemplate(): UseMutationResult<CloneResult, Error, CloneTemplateInput> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: clone,
+    onSuccess: (result, input) => {
+      trackEvent("template_loaded", {
+        store_type: input.storeType,
+        new_menus: result.newMenuCount,
+      });
+      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+    },
+  });
+}

--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * 사용자 메뉴 + 레시피 + 재료 단가를 한 번에 fetch.
+ * 메뉴별 원가 계산은 `computeMenuMarginFromRow`가 헌법 III를 적용.
+ *
+ * `ingredient` non-null: `recipe_items.ingredient_id`는 `on delete restrict`라
+ * orphan 불가 (003_menus_and_recipes.sql). Supabase 자동 타입은 보수적으로
+ * nullable로 잡지만 fetch 시점에 좁힌다.
+ */
+
+interface RawIngredient {
+  id: string;
+  name: string;
+  unit: string;
+  current_avg_price: number;
+}
+
+interface RawRecipeItem {
+  id: string;
+  quantity_per_serving: number;
+  ingredient: RawIngredient | null;
+}
+
+export interface MenuRowWithRecipe {
+  id: string;
+  name: string;
+  price: number;
+  is_active: boolean;
+  recipe_items: Array<{
+    id: string;
+    quantity_per_serving: number;
+    ingredient: RawIngredient;
+  }>;
+}
+
+export const menuListQueryKey = ["menus", "list"] as const;
+
+interface RawMenuRow {
+  id: string;
+  name: string;
+  price: number;
+  is_active: boolean;
+  recipe_items: RawRecipeItem[];
+}
+
+async function fetchMenus(): Promise<MenuRowWithRecipe[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("menus")
+    .select(
+      `
+      id, name, price, is_active,
+      recipe_items (
+        id,
+        quantity_per_serving,
+        ingredient:ingredients (
+          id, name, unit, current_avg_price
+        )
+      )
+    `,
+    )
+    .order("name");
+
+  if (error) {
+    throw new Error(error.message);
+  }
+  const rows = (data ?? []) as unknown as RawMenuRow[];
+  return rows.map((menu) => ({
+    id: menu.id,
+    name: menu.name,
+    price: menu.price,
+    is_active: menu.is_active,
+    recipe_items: menu.recipe_items.filter(
+      (item): item is RawRecipeItem & { ingredient: RawIngredient } => item.ingredient !== null,
+    ),
+  }));
+}
+
+export function useMenus(): UseQueryResult<MenuRowWithRecipe[]> {
+  return useQuery({
+    queryKey: menuListQueryKey,
+    queryFn: fetchMenus,
+  });
+}

--- a/src/features/menu/lib/compute-menu-margin.ts
+++ b/src/features/menu/lib/compute-menu-margin.ts
@@ -1,0 +1,28 @@
+import { calculateMargin, calculateMenuCost, type MarginResult } from "@/lib/domain/margin";
+import type { Decimal } from "@/lib/domain/_decimal";
+import type { MenuRowWithRecipe } from "../hooks/useMenus";
+
+/**
+ * `useMenus`가 반환하는 row 형태에서 직접 원가 + 마진을 산출.
+ * MenuList / MenuDetailCard / 후속 dashboard top-3 / sale 미리보기에서 공유.
+ *
+ * 레시피가 비어 있으면 `cost = 0`이므로 `rate = 100%`가 나오는데,
+ * 그건 호출 측이 "레시피 미등록" placeholder로 처리하는 게 자연스럽다.
+ * 여기서는 raw 계산만 하고 의미 부여는 UI에 위임.
+ */
+
+export interface MenuMargin {
+  cost: Decimal;
+  margin: MarginResult;
+  hasRecipe: boolean;
+}
+
+export function computeMenuMarginFromRow(menu: MenuRowWithRecipe): MenuMargin {
+  const recipe = menu.recipe_items.map((item) => ({
+    quantity: item.quantity_per_serving,
+    avgPrice: item.ingredient.current_avg_price,
+  }));
+  const cost = calculateMenuCost(recipe);
+  const margin = calculateMargin({ price: menu.price, cost });
+  return { cost, margin, hasRecipe: recipe.length > 0 };
+}

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -67,3 +67,27 @@ export function cloneMenuTemplate(
 ): Promise<RpcResult<CloneMenuTemplateRow[]>> {
   return callRpc(client, "clone_menu_template", { p_store_type: args.storeType });
 }
+
+interface SaveMenuArgs {
+  name: string;
+  price: number;
+  recipe: ReadonlyArray<{ ingredientId: string; quantityPerServing: number }>;
+}
+
+interface SaveMenuRow {
+  menu_id: string;
+}
+
+export function saveMenu(
+  client: ClientLike,
+  args: SaveMenuArgs,
+): Promise<RpcResult<SaveMenuRow[]>> {
+  return callRpc(client, "save_menu", {
+    p_name: args.name,
+    p_price: args.price,
+    p_recipe: args.recipe.map((it) => ({
+      ingredient_id: it.ingredientId,
+      quantity_per_serving: it.quantityPerServing,
+    })),
+  });
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -312,6 +312,12 @@ export type Database = {
           success: boolean
         }[]
       }
+      save_menu: {
+        Args: { p_name: string; p_price: number; p_recipe?: Json }
+        Returns: {
+          menu_id: string
+        }[]
+      }
       update_regular_days_off: {
         Args: { p_days_off: Database["public"]["Enums"]["weekday"][] }
         Returns: {

--- a/supabase/migrations/014_save_menu_rpc.sql
+++ b/supabase/migrations/014_save_menu_rpc.sql
@@ -1,0 +1,53 @@
+-- Migration: save_menu RPC (메뉴 + 레시피 트랜잭셔널 저장)
+-- 호출자: 인증된 사용자가 신규 메뉴 등록 (편집은 후속 PR)
+--
+-- 한 트랜잭션으로 menu INSERT + recipe_items INSERT를 묶어
+-- 클라이언트가 user_id를 직접 다루지 않게 한다 (auth.uid()로 자동 채움).
+
+create or replace function public.save_menu(
+  p_name text,
+  p_price numeric,
+  p_recipe jsonb default '[]'::jsonb
+)
+returns table (menu_id uuid)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_menu_id uuid;
+  v_item jsonb;
+begin
+  if v_user_id is null then
+    raise exception 'not authenticated' using errcode = '28000';
+  end if;
+
+  if jsonb_typeof(p_recipe) <> 'array' then
+    raise exception 'recipe must be a JSONB array' using errcode = '22023';
+  end if;
+
+  insert into public.menus (user_id, name, price)
+  values (v_user_id, p_name, p_price)
+  returning id into v_menu_id;
+
+  for v_item in select * from jsonb_array_elements(p_recipe)
+  loop
+    insert into public.recipe_items (menu_id, user_id, ingredient_id, quantity_per_serving)
+    values (
+      v_menu_id,
+      v_user_id,
+      (v_item ->> 'ingredient_id')::uuid,
+      (v_item ->> 'quantity_per_serving')::numeric
+    );
+  end loop;
+
+  return query select v_menu_id;
+end;
+$$;
+
+comment on function public.save_menu(text, numeric, jsonb) is
+  '메뉴 + 레시피 트랜잭셔널 저장. recipe = [{"ingredient_id": uuid, "quantity_per_serving": numeric}, ...]. user_id는 auth.uid()로 자동.';
+
+revoke all on function public.save_menu(text, numeric, jsonb) from public;
+grant execute on function public.save_menu(text, numeric, jsonb) to authenticated;


### PR DESCRIPTION
Phase 3 마지막 PR — 메뉴 화면 UI 와이어업. **머지 전 simplify 패스 통과** (3 에이전트 → 8 fix 반영). 머지 후 Phase 3 완전 종료, Phase 4 (판매 일괄 입력) 진입 가능.

## What

### 마이그레이션 / RPC
- `014_save_menu_rpc.sql` — `save_menu(name, price, recipe[])` 트랜잭셔널 INSERT. `auth.uid()`로 user_id 자동, jsonb 배열로 recipe 받아 menu + recipe_items 묶음. ssr 0.5의 insert 타입 추론 한계 우회.
- `src/lib/supabase/rpc.ts` — `saveMenu` wrapper 추가

### 훅
- `useMenus` — menus + recipe_items + ingredient join 한 번에 fetch. `on delete restrict`로 ingredient null 불가하므로 fetch 시점 좁힘
- `useCloneTemplate` — `cloneMenuTemplate` mutation + GA4 `template_loaded` + `menuListQueryKey` invalidate

### 컴포넌트
- `MenuList` — 메뉴 행 + 마진 칩
- `MenuDetailCard` — hero 마진율 (24px) + 재료 행 + 합계 + `MARGIN_LABEL`
- `MenuForm` — react-hook-form + zod, useFieldArray로 동적 레시피 행
- `TemplateLoadDialog` — 가게 유형 칩 + 미리보기 + 불러오기

### 라우팅
- `/menu` (목록 + 콜드스타트 CTA — 메뉴 0개면 TemplateLoadDialog)
- `/menu/[id]` (상세)
- `/menu/new` (생성 폼)

### 공용 UI 추출 (simplify findings)
- `src/components/ui/field.tsx` — auth/menu/후속 도메인 폼 공유 (4+ 사용)
- `src/components/ui/primary-button.tsx` — 5곳 primary button 중복 통합
- `src/features/menu/lib/compute-menu-margin.ts` — List/Detail 공유 마진 계산

### GA4
- `first_menu_registered` — 메뉴 카운트 0 → 1 전환 시
- `template_loaded` — `store_type`, `new_menus` 파라미터

## Simplify findings (8개)

| # | 항목 | 효과 |
|---|------|------|
| 1 | `Field` 컴포넌트 추출 (auth + menu 중복) | 4+ 사용 단일 출처 |
| 2 | `PrimaryButton` 추출 (5곳 중복) | 단일 출처, drift 방지 |
| 3 | `computeMenuMarginFromRow` 헬퍼 | List/Detail/dashboard top-3/sale 미리보기 공유 |
| 4 | `MarginChip` 임계값 50/30 + amber tone | 디자인 시스템 components.md L75-77 정렬 |
| 5 | `amount.toFixed(0).toLocaleString()` 버그 | `Math.round + toLocaleString("ko-KR")`로 thousands separator 정상 |
| 6 | `router.refresh()` 제거 | `invalidateQueries`만으로 충분, 중복 작업 제거 |
| 7 | `ingredient` null 좁히기 | `on delete restrict`로 orphan 불가, fallback 코드 dead |
| 8 | 0-recipe 메뉴 → "레시피 미등록" placeholder | 마진율 100% 오인 방지 |

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test` ✅ **58/58**
- `npm run build` ✅ /menu, /menu/[id], /menu/new prerender

## Phase 3 종료 체크포인트

> 메뉴 등록 + 템플릿 + 마진 계산 표시 동작. 단, 재료 단가 모두 0원이라 마진 100%로 표시됨 (정상). Phase 4·5 후 실제 단가 반영.

다음 PR: **Phase 4 — 마감 후 판매 일괄 입력 (★ MVP 첫 검증 지점)**.

Closes #24