### PR TITLE
feat(domain): Sale 스냅샷 + 7일 lock (T079, T080)

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -176,8 +176,8 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### 도메인 로직 (테스트 우선)
 
-- [ ] T079 [P] [US1] Write unit test `tests/unit/snapshot.test.ts` for sale snapshot: `createSaleSnapshot(items, ingredients)`, `recomputeOnEdit(...)`, 7-day lock detection
-- [ ] T080 [US1] Implement domain function `src/lib/domain/snapshot.ts` to satisfy T079; uses pricing.ts and margin.ts
+- [x] T079 [P] [US1] Write unit test `tests/unit/snapshot.test.ts` for sale snapshot: `createSaleSnapshot(items, ingredients)`, `recomputeOnEdit(...)`, 7-day lock detection
+- [x] T080 [US1] Implement domain function `src/lib/domain/snapshot.ts` to satisfy T079; uses pricing.ts and margin.ts
 
 ### 데이터 모델 + RPC
 

--- a/src/lib/domain/snapshot.ts
+++ b/src/lib/domain/snapshot.ts
@@ -1,0 +1,111 @@
+import { Decimal } from "./_decimal";
+import { calculateMargin, calculateMenuCost, MARGIN_LABEL, type MarginLabel } from "./margin";
+
+/**
+ * 헌법 III: Sale 저장 시 메뉴 원가/판매가 스냅샷 영구 보존.
+ *
+ * 같은 함수가 두 곳에서 사용:
+ * 1. 클라이언트 입력 폼 미리보기 (StickyTotalCard) — 실시간 매출/마진
+ * 2. 서버 RPC `save_sale` 의 검증 — 저장 직전 같은 값 산출
+ *    (RPC는 SQL로 동일 공식 구현, 이 함수는 타입 안전한 클라이언트 미러)
+ *
+ * 7일 lock(FR-030)도 같은 모듈에 묶음 — sale 도메인의 일관성 단위.
+ */
+
+const SALE_EDIT_WINDOW_DAYS = 7;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface MenuForSnapshot {
+  id: string;
+  name: string;
+  price: number;
+  recipeItems: ReadonlyArray<{ quantity: number; avgPrice: number }>;
+}
+
+export interface SaleItemInput {
+  menuId: string;
+  quantity: number;
+}
+
+export interface SaleItemSnapshot {
+  menuId: string;
+  menuName: string;
+  quantity: number;
+  unitPrice: number;
+  menuCostSnapshot: Decimal;
+  lineRevenue: Decimal;
+  lineCost: Decimal;
+}
+
+export interface SaleSnapshotPreview {
+  totalRevenue: Decimal;
+  totalCost: Decimal;
+  totalNetProfit: Decimal;
+  marginRate: Decimal;
+  label: MarginLabel;
+  itemBreakdown: SaleItemSnapshot[];
+}
+
+export function computeSnapshotPreview(
+  items: readonly SaleItemInput[],
+  menus: readonly MenuForSnapshot[],
+): SaleSnapshotPreview {
+  const menuById = new Map(menus.map((m) => [m.id, m]));
+  const breakdown = items.map((item) => buildLineSnapshot(item, menuById));
+  const totalRevenue = breakdown.reduce((sum, line) => sum.plus(line.lineRevenue), new Decimal(0));
+  const totalCost = breakdown.reduce((sum, line) => sum.plus(line.lineCost), new Decimal(0));
+
+  const margin = calculateMargin({ price: totalRevenue.toNumber(), cost: totalCost });
+
+  return {
+    totalRevenue,
+    totalCost,
+    totalNetProfit: margin.amount,
+    marginRate: margin.rate,
+    label: MARGIN_LABEL,
+    itemBreakdown: breakdown,
+  };
+}
+
+function buildLineSnapshot(
+  item: SaleItemInput,
+  menuById: ReadonlyMap<string, MenuForSnapshot>,
+): SaleItemSnapshot {
+  if (item.quantity <= 0) {
+    throw new Error(`sale item quantity must be positive (got ${item.quantity})`);
+  }
+
+  const menu = menuById.get(item.menuId);
+  if (!menu) {
+    throw new Error(`menu not found: ${item.menuId}`);
+  }
+
+  const menuCostSnapshot = calculateMenuCost(menu.recipeItems);
+  const qty = new Decimal(item.quantity);
+
+  return {
+    menuId: menu.id,
+    menuName: menu.name,
+    quantity: item.quantity,
+    unitPrice: menu.price,
+    menuCostSnapshot,
+    lineRevenue: qty.times(menu.price),
+    lineCost: qty.times(menuCostSnapshot),
+  };
+}
+
+/**
+ * FR-030: 7일 초과 sale은 편집/삭제 잠금.
+ * 경계 정책: 정확히 7일은 잠금되지 않음 (사용자에게 7일 보장).
+ */
+export function isSaleLocked(saleCreatedAt: Date, now: Date = new Date()): boolean {
+  const elapsedMs = now.getTime() - saleCreatedAt.getTime();
+  return elapsedMs > SALE_EDIT_WINDOW_DAYS * ONE_DAY_MS;
+}
+
+export function daysUntilLock(saleCreatedAt: Date, now: Date = new Date()): number {
+  const elapsedMs = now.getTime() - saleCreatedAt.getTime();
+  const remainingMs = SALE_EDIT_WINDOW_DAYS * ONE_DAY_MS - elapsedMs;
+  if (remainingMs <= 0) return 0;
+  return Math.ceil(remainingMs / ONE_DAY_MS);
+}

--- a/tests/unit/snapshot.test.ts
+++ b/tests/unit/snapshot.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { Decimal } from "@/lib/domain/_decimal";
+import {
+  computeSnapshotPreview,
+  daysUntilLock,
+  isSaleLocked,
+  type MenuForSnapshot,
+  type SaleItemInput,
+} from "@/lib/domain/snapshot";
+
+/**
+ * 헌법 III: Sale 저장 시 메뉴 원가/판매가 스냅샷 영구 보존.
+ * 클라이언트는 입력 폼 미리보기 (StickyTotalCard) 용으로 같은 로직을 사용.
+ *
+ * - computeSnapshotPreview: 입력 항목 → 매출/원가/순수익/마진율 (재료 원가 기준)
+ * - isSaleLocked: 7일 초과 sale은 편집 잠금 (FR-030)
+ */
+
+const palbingsu: MenuForSnapshot = {
+  id: "menu-1",
+  name: "팥빙수",
+  price: 9000,
+  recipeItems: [
+    { quantity: 300, avgPrice: 5 }, // 얼음 1500
+    { quantity: 100, avgPrice: 8 }, // 우유 800
+    { quantity: 80, avgPrice: 30 }, // 팥 2400
+    { quantity: 20, avgPrice: 6 }, // 연유 120
+  ],
+};
+// 메뉴 1개 원가 = 1500 + 800 + 2400 + 120 = 4820
+
+const americano: MenuForSnapshot = {
+  id: "menu-2",
+  name: "아메리카노",
+  price: 4500,
+  recipeItems: [{ quantity: 18, avgPrice: 50 }], // 원두 900
+};
+
+describe("computeSnapshotPreview", () => {
+  it("단일 메뉴 1개: 매출 / 원가 / 순수익", () => {
+    const items: SaleItemInput[] = [{ menuId: "menu-1", quantity: 1 }];
+    const result = computeSnapshotPreview(items, [palbingsu]);
+    expect(result.totalRevenue.toString()).toBe("9000");
+    expect(result.totalCost.toString()).toBe("4820");
+    expect(result.totalNetProfit.toString()).toBe("4180");
+    expect(result.marginRate.toFixed(2)).toBe("46.44");
+  });
+
+  it("복수 메뉴 합산", () => {
+    const items: SaleItemInput[] = [
+      { menuId: "menu-1", quantity: 2 },
+      { menuId: "menu-2", quantity: 3 },
+    ];
+    const result = computeSnapshotPreview(items, [palbingsu, americano]);
+    // revenue = 9000*2 + 4500*3 = 31500
+    // cost = 4820*2 + 900*3 = 12340
+    expect(result.totalRevenue.toString()).toBe("31500");
+    expect(result.totalCost.toString()).toBe("12340");
+    expect(result.totalNetProfit.toString()).toBe("19160");
+  });
+
+  it("라벨이 항상 MARGIN_LABEL과 일치 — UI 표시용", () => {
+    const result = computeSnapshotPreview([{ menuId: "menu-1", quantity: 1 }], [palbingsu]);
+    expect(result.label).toBe("재료 원가 기준 (이동평균법)");
+  });
+
+  it("itemBreakdown으로 메뉴별 스냅샷 반환 — 저장 RPC가 그대로 사용 가능", () => {
+    const items: SaleItemInput[] = [{ menuId: "menu-1", quantity: 2 }];
+    const result = computeSnapshotPreview(items, [palbingsu]);
+    expect(result.itemBreakdown).toHaveLength(1);
+    expect(result.itemBreakdown[0]).toMatchObject({
+      menuId: "menu-1",
+      quantity: 2,
+      unitPrice: 9000,
+    });
+    expect(result.itemBreakdown[0]?.menuCostSnapshot.toString()).toBe("4820");
+  });
+
+  it("빈 입력은 0 / 0 / 0 / rate 0", () => {
+    const result = computeSnapshotPreview([], [palbingsu]);
+    expect(result.totalRevenue.toString()).toBe("0");
+    expect(result.totalCost.toString()).toBe("0");
+    expect(result.marginRate.toString()).toBe("0");
+  });
+
+  it("결과는 모두 Decimal 타입 (정밀도 보존)", () => {
+    const items: SaleItemInput[] = [{ menuId: "menu-1", quantity: 1 }];
+    const result = computeSnapshotPreview(items, [palbingsu]);
+    expect(result.totalRevenue).toBeInstanceOf(Decimal);
+    expect(result.totalCost).toBeInstanceOf(Decimal);
+    expect(result.totalNetProfit).toBeInstanceOf(Decimal);
+    expect(result.marginRate).toBeInstanceOf(Decimal);
+  });
+
+  it("알 수 없는 menuId는 throw — Edge Case 차단 (FR-006 전제)", () => {
+    expect(() => computeSnapshotPreview([{ menuId: "ghost", quantity: 1 }], [palbingsu])).toThrow(
+      /menu not found/,
+    );
+  });
+
+  it("음수 수량은 throw", () => {
+    expect(() =>
+      computeSnapshotPreview([{ menuId: "menu-1", quantity: -1 }], [palbingsu]),
+    ).toThrow();
+  });
+
+  it("0 수량은 throw — 0개 판매는 의미 없음, 호출 측이 사전 필터링해야", () => {
+    expect(() =>
+      computeSnapshotPreview([{ menuId: "menu-1", quantity: 0 }], [palbingsu]),
+    ).toThrow();
+  });
+});
+
+describe("isSaleLocked / daysUntilLock (FR-030)", () => {
+  const now = new Date("2026-04-30T12:00:00");
+
+  it("created_at 6일 23시간 59분 전: lock 안 됨", () => {
+    const created = new Date("2026-04-23T12:00:01");
+    expect(isSaleLocked(created, now)).toBe(false);
+  });
+
+  it("created_at 7일 정확히: lock 안 됨 (경계 포함)", () => {
+    const created = new Date("2026-04-23T12:00:00");
+    expect(isSaleLocked(created, now)).toBe(false);
+  });
+
+  it("created_at 7일 1초 초과: lock", () => {
+    const created = new Date("2026-04-23T11:59:59");
+    expect(isSaleLocked(created, now)).toBe(true);
+  });
+
+  it("daysUntilLock: 방금 만든 sale은 7일", () => {
+    expect(daysUntilLock(now, now)).toBe(7);
+  });
+
+  it("daysUntilLock: 3일 전 sale은 4일 남음", () => {
+    const created = new Date("2026-04-27T12:00:00");
+    expect(daysUntilLock(created, now)).toBe(4);
+  });
+
+  it("daysUntilLock: 7일 초과는 0", () => {
+    const created = new Date("2026-04-22T12:00:00");
+    expect(daysUntilLock(created, now)).toBe(0);
+  });
+});


### PR DESCRIPTION
Phase 4 첫 PR — 헌법 III 핵심 (스냅샷 영구 보존) + FR-030 (7일 편집 윈도우)의 도메인 로직 + 테스트 우선. **머지 전 simplify 패스 통과.**

## What

### `src/lib/domain/snapshot.ts`

- `computeSnapshotPreview(items, menus)` — 입력 항목별 line snapshot + 매출/원가/순수익/마진율 합산. 결과는 모두 `Decimal` — 정밀도 보존
- `isSaleLocked(saleCreatedAt, now)` — 7일 초과 strict 비교. 정확히 7일은 미잠금 (사용자에게 만 7일 보장)
- `daysUntilLock(saleCreatedAt, now)` — 남은 일수 ceil

### `tests/unit/snapshot.test.ts` (15 tests)

- 단일 / 복수 메뉴 합산
- 라벨 일치 (`MARGIN_LABEL`)
- `itemBreakdown` 형식 (server RPC가 그대로 사용)
- 빈 입력 / Decimal 타입 / unknown menuId / 음수 / 0 수량
- 7일 경계 3개 (6일 23:59:59, 7일 정확, 7일 1초 초과)
- `daysUntilLock` 3개

## 사용처 (예고)

1. **클라이언트** StickyTotalCard 실시간 매출 미리보기 (PR 24)
2. **서버** `save_sale` RPC가 SQL로 동일 공식 구현 (PR 23) — 이 TS는 미러

## Simplify 적용

| 항목 | Action |
|------|--------|
| `if (qty <= 0)` + `assertNonNegative` 중복 | `assertNonNegative` 제거 (sale은 0도 invalid이므로 strict `<=` throw가 옳음) |
| 상수 위치 / `menuById` Map JSDoc | 현재 위치 유지 (premature abstraction 회피) |
| `MenuRowWithRecipe → MenuForSnapshot` adapter | PR 24에서 추출 (사용 시점에) |

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test` ✅ **73/73** (15 신규 + 58 기존)
- `npm run build` ✅

## 다음 PR

PR 23: `sales` / `sale_items` / `sale_edit_history` 마이그레이션 + `save_sale` / `edit_sale` / `delete_sale` RPC + Zod + 통합 테스트.

Closes #26