### PR TITLE
feat(sale): SaleEditDialog (T091) + SaleSaveBar 추출 + formatWon 헬퍼

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -194,7 +194,7 @@ description: "Task list for 001-mvp-core feature implementation"
 - [x] T088 [P] [US1] Create `src/features/sale/components/MenuRow.tsx` with +/- buttons (큼직), direct number input, auto-hide on quantity 0
 - [x] T089 [P] [US1] Create `src/features/sale/components/StickyTotalCard.tsx` showing 매출/원가/순수익 with "재료 원가 기준 (이동평균법)" label, real-time updates from form state
 - [x] T090 [P] [US1] Create `src/features/sale/components/SaleInputForm.tsx` integrating MenuRow list (sorted by 7-day favorites) + StickyTotalCard + date picker (today + 7-day retroactive)
-- [ ] T091 [P] [US1] Create `src/features/sale/components/SaleEditDialog.tsx` for editing existing sale with reason input + 7-day lock check
+- [x] T091 [P] [US1] Create `src/features/sale/components/SaleEditDialog.tsx` for editing existing sale with reason input + 7-day lock check
 - [x] T092 [US1] Create page `src/app/(main)/sale/page.tsx` integrating SaleInputForm
 - [x] T093 [US1] Create page `src/app/(main)/sale/[date]/page.tsx` for retroactive input (date param) and view/edit existing sale
 - [x] T094 [P] [US1] Create hook `src/features/sale/hooks/useSaleSubmit.ts` (mutation calling `save_sale` RPC + cache invalidation)

--- a/src/app/(main)/sale/[date]/page.tsx
+++ b/src/app/(main)/sale/[date]/page.tsx
@@ -3,14 +3,21 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { SaleInputForm } from "@/features/sale/components/SaleInputForm";
+import { SaleEditDialog } from "@/features/sale/components/SaleEditDialog";
 import { useIsFirstSale } from "@/features/sale/hooks/useIsFirstSale";
+import { useSaleByDate } from "@/features/sale/hooks/useSaleByDate";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 export default function RetroactiveSalePage(): React.ReactElement {
   const { date } = useParams<{ date: string }>();
-  const { data: isFirstSale, isLoading } = useIsFirstSale();
   const isValid = ISO_DATE_PATTERN.test(date);
+
+  const { data: existingSale, isLoading: saleLoading } = useSaleByDate(date);
+  const { data: isFirstSale, isLoading: firstSaleLoading } = useIsFirstSale();
+
+  const isLoading = saleLoading || firstSaleLoading;
+  const mode = existingSale ? "edit" : "input";
 
   return (
     <section className="flex flex-col gap-section">
@@ -21,12 +28,16 @@ export default function RetroactiveSalePage(): React.ReactElement {
         <span className="text-caption text-ink-3 tabular-nums">{date}</span>
       </header>
 
-      <h1 className="text-title-lg text-ink-1">{date} 판매 입력</h1>
+      <h1 className="text-title-lg text-ink-1">
+        {date} {mode === "edit" ? "판매 수정" : "판매 입력"}
+      </h1>
 
       {!isValid ? (
         <p className="text-body-regular text-red">잘못된 날짜 형식입니다.</p>
       ) : isLoading || isFirstSale === undefined ? (
         <p className="text-body-regular text-ink-3">불러오는 중…</p>
+      ) : existingSale ? (
+        <SaleEditDialog sale={existingSale} />
       ) : (
         <SaleInputForm soldAt={date} isFirstSale={isFirstSale} />
       )}

--- a/src/features/menu/components/MenuDetailCard.tsx
+++ b/src/features/menu/components/MenuDetailCard.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { MARGIN_LABEL } from "@/lib/domain/margin";
+import { formatWon } from "@/lib/utils/format";
 import { computeMenuMarginFromRow } from "../lib/compute-menu-margin";
 import type { MenuRowWithRecipe } from "../hooks/useMenus";
 
 interface MenuDetailCardProps {
   menu: MenuRowWithRecipe;
 }
-
-const fmt = (value: number): string => Math.round(value).toLocaleString("ko-KR");
 
 export function MenuDetailCard({ menu }: MenuDetailCardProps): React.ReactElement {
   const { cost, margin, hasRecipe } = computeMenuMarginFromRow(menu);
@@ -18,7 +17,9 @@ export function MenuDetailCard({ menu }: MenuDetailCardProps): React.ReactElemen
       <header className="flex items-start justify-between">
         <div className="flex flex-col gap-1">
           <h2 className="text-title-md text-ink-1">{menu.name}</h2>
-          <span className="text-caption text-ink-3 tabular-nums">판매가 {fmt(menu.price)}원</span>
+          <span className="text-caption text-ink-3 tabular-nums">
+            판매가 {formatWon(menu.price)}원
+          </span>
         </div>
         {hasRecipe ? (
           <div className="flex flex-col items-end gap-1">
@@ -45,11 +46,11 @@ export function MenuDetailCard({ menu }: MenuDetailCardProps): React.ReactElemen
           <div className="flex flex-col gap-1">
             <span className="text-caption text-ink-3">{MARGIN_LABEL}</span>
             <span className="text-body-regular text-ink-2 tabular-nums">
-              마진 금액 {fmt(margin.amount.toNumber())}원
+              마진 금액 {formatWon(margin.amount.toNumber())}원
             </span>
           </div>
           <span className="text-metric-md text-ink-1 tabular-nums">
-            원가 {fmt(cost.toNumber())}원
+            원가 {formatWon(cost.toNumber())}원
           </span>
         </footer>
       )}
@@ -71,7 +72,7 @@ function RecipeRow({
         {item.quantity_per_serving}
         {item.ingredient.unit}
       </span>
-      <span className="text-body-regular text-ink-2 tabular-nums">{fmt(lineCost)}원</span>
+      <span className="text-body-regular text-ink-2 tabular-nums">{formatWon(lineCost)}원</span>
     </li>
   );
 }

--- a/src/features/menu/components/MenuList.tsx
+++ b/src/features/menu/components/MenuList.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { cn } from "@/lib/utils";
+import { formatWon } from "@/lib/utils/format";
 import { computeMenuMarginFromRow } from "../lib/compute-menu-margin";
 import type { MenuRowWithRecipe } from "../hooks/useMenus";
 
@@ -31,11 +32,11 @@ function MenuListRow({ menu }: { menu: MenuRowWithRecipe }): React.ReactElement 
         <div className="flex flex-col gap-1">
           <span className="text-body text-ink-1">{menu.name}</span>
           <span className="text-caption text-ink-3 tabular-nums">
-            {menu.price.toLocaleString("ko-KR")}원
+            {formatWon(menu.price)}원
             {hasRecipe && (
               <>
                 <span className="text-ink-4"> · </span>
-                원가 {Math.round(cost.toNumber()).toLocaleString("ko-KR")}원
+                원가 {formatWon(cost.toNumber())}원
               </>
             )}
           </span>

--- a/src/features/sale/components/MenuRow.tsx
+++ b/src/features/sale/components/MenuRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils/format";
 import type { MenuRowWithRecipe } from "@/features/menu/hooks/useMenus";
 
 interface MenuRowProps {
@@ -8,8 +9,6 @@ interface MenuRowProps {
   quantity: number;
   onChange: (next: number) => void;
 }
-
-const fmt = (n: number): string => n.toLocaleString("ko-KR");
 
 export function MenuRow({ menu, quantity, onChange }: MenuRowProps): React.ReactElement {
   const active = quantity > 0;
@@ -23,7 +22,7 @@ export function MenuRow({ menu, quantity, onChange }: MenuRowProps): React.React
     >
       <div className="flex flex-col gap-1">
         <span className={cn("text-body", active ? "text-ink-1" : "text-ink-2")}>{menu.name}</span>
-        <span className="text-caption text-ink-3 tabular-nums">{fmt(menu.price)}원</span>
+        <span className="text-caption text-ink-3 tabular-nums">{formatNumber(menu.price)}원</span>
       </div>
 
       <div className="flex items-center gap-2">

--- a/src/features/sale/components/SaleEditDialog.tsx
+++ b/src/features/sale/components/SaleEditDialog.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMenus } from "@/features/menu/hooks/useMenus";
+import { computeSnapshotPreview, daysUntilLock, isSaleLocked } from "@/lib/domain/snapshot";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { cn } from "@/lib/utils";
+import { MenuRow } from "./MenuRow";
+import { StickyTotalCard } from "./StickyTotalCard";
+import { SaleSaveBar } from "./SaleSaveBar";
+import { formatWon } from "@/lib/utils/format";
+import { useSaleEdit, useSaleDelete } from "../hooks/useSaleEdit";
+import { toSnapshotMenu } from "../lib/to-snapshot-menu";
+import type { SaleWithItems } from "../hooks/useSaleByDate";
+
+interface SaleEditDialogProps {
+  sale: SaleWithItems;
+}
+
+export function SaleEditDialog({ sale }: SaleEditDialogProps): React.ReactElement {
+  const router = useRouter();
+  const { data: menus } = useMenus();
+  const editMutation = useSaleEdit();
+  const deleteMutation = useSaleDelete();
+
+  const createdAt = useMemo(() => new Date(sale.created_at), [sale.created_at]);
+  const locked = isSaleLocked(createdAt);
+  const daysLeft = daysUntilLock(createdAt);
+
+  const initialQuantities = useMemo(
+    () => new Map(sale.items.map((it) => [it.menu_id, it.quantity])),
+    [sale.items],
+  );
+
+  const [quantities, setQuantities] = useState<Map<string, number>>(initialQuantities);
+  const [reason, setReason] = useState("");
+
+  const items = useMemo(
+    () =>
+      Array.from(quantities.entries())
+        .filter(([, qty]) => qty > 0)
+        .map(([menuId, quantity]) => ({ menuId, quantity })),
+    [quantities],
+  );
+
+  const preview = useMemo(() => {
+    if (!menus || menus.length === 0 || items.length === 0) return null;
+    return computeSnapshotPreview(items, menus.map(toSnapshotMenu));
+  }, [items, menus]);
+
+  function setQuantity(menuId: string, next: number): void {
+    setQuantities((prev) => {
+      const updated = new Map(prev);
+      if (next <= 0) {
+        updated.delete(menuId);
+      } else {
+        updated.set(menuId, next);
+      }
+      return updated;
+    });
+  }
+
+  function handleSave(): void {
+    editMutation.mutate(
+      { saleId: sale.id, newItems: items, reason: reason.trim() || undefined },
+      { onSuccess: () => router.push("/today") },
+    );
+  }
+
+  function handleDelete(): void {
+    // TODO(design-system): AlertDialog 패턴 추가 시 교체.
+    if (!confirm(`${sale.sold_at} 판매 기록을 삭제할까요? 재고는 자동 되돌립니다.`)) return;
+    deleteMutation.mutate(sale.id, { onSuccess: () => router.push("/today") });
+  }
+
+  if (locked) {
+    return <LockedView sale={sale} />;
+  }
+
+  if (!menus) {
+    return <p className="text-body-regular text-ink-3">메뉴를 불러오는 중…</p>;
+  }
+
+  const totalQuantity = items.reduce((sum, it) => sum + it.quantity, 0);
+  const isPending = editMutation.isPending || deleteMutation.isPending;
+
+  return (
+    <div className="flex flex-col gap-stack pb-44">
+      <DaysLeftHint daysLeft={daysLeft} />
+
+      <ul className="flex flex-col gap-stack-tight">
+        {menus.map((menu) => (
+          <MenuRow
+            key={menu.id}
+            menu={menu}
+            quantity={quantities.get(menu.id) ?? 0}
+            onChange={(next) => setQuantity(menu.id, next)}
+          />
+        ))}
+      </ul>
+
+      <Field label="수정 사유 (선택, 200자 이내)" error={undefined}>
+        <textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value.slice(0, 200))}
+          rows={2}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+          placeholder="예: 손님 환불, 잘못 입력 등"
+        />
+      </Field>
+
+      {(editMutation.error || deleteMutation.error) && (
+        <p role="alert" className="text-caption text-red">
+          {editMutation.error?.message ?? deleteMutation.error?.message}
+        </p>
+      )}
+
+      {preview && totalQuantity > 0 && <StickyTotalCard preview={preview} />}
+
+      <SaleSaveBar
+        left={
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={isPending}
+            className={cn(
+              "rounded-md border border-border px-stack py-stack text-body-regular text-red hover:bg-red-soft",
+              isPending && "opacity-50",
+            )}
+          >
+            {deleteMutation.isPending ? "삭제 중…" : "삭제"}
+          </button>
+        }
+        right={
+          <PrimaryButton
+            type="button"
+            onClick={handleSave}
+            disabled={totalQuantity === 0 || isPending}
+          >
+            {editMutation.isPending ? "저장 중…" : "수정 저장"}
+          </PrimaryButton>
+        }
+      />
+    </div>
+  );
+}
+
+function DaysLeftHint({ daysLeft }: { daysLeft: number }): React.ReactElement {
+  const tone = daysLeft <= 1 ? "red" : daysLeft <= 3 ? "amber" : "ink-3";
+  return (
+    <p
+      className={cn(
+        "text-caption",
+        tone === "red" && "text-red-deep",
+        tone === "amber" && "text-amber-deep",
+        tone === "ink-3" && "text-ink-3",
+      )}
+    >
+      편집 가능 기간 {daysLeft}일 남음 (저장 후 7일까지 수정 가능)
+    </p>
+  );
+}
+
+function LockedView({ sale }: { sale: SaleWithItems }): React.ReactElement {
+  return (
+    <article className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
+      <div className="rounded-md bg-amber-soft p-stack text-body-regular text-amber-deep">
+        저장 후 7일이 지나 수정할 수 없습니다. 기록은 보존됩니다.
+      </div>
+      <ul className="flex flex-col gap-1 text-body-regular text-ink-2 tabular-nums">
+        <li className="flex justify-between">
+          <span>매출</span>
+          <span>{formatWon(sale.total_revenue)}원</span>
+        </li>
+        <li className="flex justify-between">
+          <span>원가</span>
+          <span>{formatWon(sale.total_cost_snapshot)}원</span>
+        </li>
+        <li className="flex justify-between">
+          <span>순수익</span>
+          <span>{formatWon(sale.total_revenue - sale.total_cost_snapshot)}원</span>
+        </li>
+      </ul>
+    </article>
+  );
+}

--- a/src/features/sale/components/SaleInputForm.tsx
+++ b/src/features/sale/components/SaleInputForm.tsx
@@ -8,6 +8,7 @@ import { computeSnapshotPreview } from "@/lib/domain/snapshot";
 import { PrimaryButton } from "@/components/ui/primary-button";
 import { MenuRow } from "./MenuRow";
 import { StickyTotalCard } from "./StickyTotalCard";
+import { SaleSaveBar } from "./SaleSaveBar";
 import { useSaleSubmit } from "../hooks/useSaleSubmit";
 import { useFavoriteMenus } from "../hooks/useFavoriteMenus";
 import { toSnapshotMenu } from "../lib/to-snapshot-menu";
@@ -93,23 +94,24 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
 
       {preview && totalQuantity > 0 && <StickyTotalCard preview={preview} />}
 
-      <div className="fixed inset-x-0 bottom-16 z-40 border-t border-border bg-bg px-screen py-stack">
-        <div className="mx-auto flex max-w-screen-md items-center gap-stack">
-          {submit.isError && (
+      <SaleSaveBar
+        left={
+          submit.isError && (
             <p role="alert" className="flex-1 text-caption text-red">
               {submit.error.message}
             </p>
-          )}
+          )
+        }
+        right={
           <PrimaryButton
             type="button"
             onClick={handleSubmit}
             disabled={totalQuantity === 0 || submit.isPending}
-            className="ml-auto"
           >
             {submit.isPending ? "저장 중…" : `${totalQuantity}개 저장`}
           </PrimaryButton>
-        </div>
-      </div>
+        }
+      />
     </div>
   );
 }

--- a/src/features/sale/components/SaleSaveBar.tsx
+++ b/src/features/sale/components/SaleSaveBar.tsx
@@ -1,0 +1,23 @@
+/**
+ * 판매 입력/편집 화면 하단 고정 액션 바.
+ * BottomTabNav(64px) 바로 위에 띄움 (bottom-16 = 64px).
+ *
+ * 입력 폼: primary 1개 (저장)
+ * 편집 다이얼로그: secondary 1개 (삭제) + primary 1개 (수정 저장)
+ */
+
+interface SaleSaveBarProps {
+  left?: React.ReactNode;
+  right: React.ReactNode;
+}
+
+export function SaleSaveBar({ left, right }: SaleSaveBarProps): React.ReactElement {
+  return (
+    <div className="fixed inset-x-0 bottom-16 z-40 border-t border-border bg-bg px-screen py-stack">
+      <div className="mx-auto flex max-w-screen-md items-center gap-stack">
+        {left}
+        <div className="ml-auto">{right}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/sale/components/StickyTotalCard.tsx
+++ b/src/features/sale/components/StickyTotalCard.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { MARGIN_LABEL } from "@/lib/domain/margin";
+import { formatWon } from "@/lib/utils/format";
 import type { SaleSnapshotPreview } from "@/lib/domain/snapshot";
 
 interface StickyTotalCardProps {
   preview: SaleSnapshotPreview;
 }
-
-const fmt = (n: number): string => Math.round(n).toLocaleString("ko-KR");
 
 export function StickyTotalCard({ preview }: StickyTotalCardProps): React.ReactElement {
   const revenue = preview.totalRevenue.toNumber();
@@ -18,9 +17,9 @@ export function StickyTotalCard({ preview }: StickyTotalCardProps): React.ReactE
   return (
     <div className="sticky bottom-20 z-30 mx-[-16px] border-t border-border bg-card px-screen py-stack">
       <div className="grid grid-cols-3 items-end gap-stack">
-        <Metric label="매출" value={fmt(revenue)} accent />
-        <Metric label="원가" value={fmt(cost)} />
-        <Metric label="순수익" value={fmt(profit)} accent />
+        <Metric label="매출" value={formatWon(revenue)} accent />
+        <Metric label="원가" value={formatWon(cost)} />
+        <Metric label="순수익" value={formatWon(profit)} accent />
       </div>
       <p className="mt-stack-tight flex items-baseline justify-between text-caption text-ink-3">
         <span>{MARGIN_LABEL}</span>

--- a/src/features/sale/hooks/useSaleByDate.ts
+++ b/src/features/sale/hooks/useSaleByDate.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * 특정 날짜의 사용자 sale + items + 메뉴 join.
+ * 편집 흐름에서 기존 데이터 prefill + 7일 lock 판단(created_at)에 사용.
+ */
+
+export interface SaleWithItems {
+  id: string;
+  sold_at: string;
+  created_at: string;
+  total_revenue: number;
+  total_cost_snapshot: number;
+  items: Array<{
+    id: string;
+    menu_id: string;
+    quantity: number;
+    unit_price: number;
+    menu_cost_snapshot: number;
+  }>;
+}
+
+interface RawRow {
+  id: string;
+  sold_at: string;
+  created_at: string;
+  total_revenue: number;
+  total_cost_snapshot: number;
+  sale_items: Array<{
+    id: string;
+    menu_id: string;
+    quantity: number;
+    unit_price: number;
+    menu_cost_snapshot: number;
+  }>;
+}
+
+async function fetchSaleByDate(date: string): Promise<SaleWithItems | null> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("sales")
+    .select(
+      `
+      id, sold_at, created_at, total_revenue, total_cost_snapshot,
+      sale_items (id, menu_id, quantity, unit_price, menu_cost_snapshot)
+    `,
+    )
+    .eq("sold_at", date)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+
+  const row = data as unknown as RawRow;
+  return {
+    id: row.id,
+    sold_at: row.sold_at,
+    created_at: row.created_at,
+    total_revenue: Number(row.total_revenue),
+    total_cost_snapshot: Number(row.total_cost_snapshot),
+    items: row.sale_items.map((si) => ({
+      id: si.id,
+      menu_id: si.menu_id,
+      quantity: si.quantity,
+      unit_price: Number(si.unit_price),
+      menu_cost_snapshot: Number(si.menu_cost_snapshot),
+    })),
+  };
+}
+
+export function saleByDateQueryKey(date: string): readonly unknown[] {
+  return ["sales", "by-date", date] as const;
+}
+
+export function useSaleByDate(date: string): UseQueryResult<SaleWithItems | null> {
+  return useQuery({
+    queryKey: saleByDateQueryKey(date),
+    queryFn: () => fetchSaleByDate(date),
+  });
+}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,12 @@
+/**
+ * 한국어 화폐 / 숫자 포맷 유틸.
+ * 도메인 함수는 Decimal로 정밀도 보존, UI 표시 직전에 이 헬퍼로 변환.
+ */
+
+export function formatWon(value: number): string {
+  return Math.round(value).toLocaleString("ko-KR");
+}
+
+export function formatNumber(value: number): string {
+  return value.toLocaleString("ko-KR");
+}


### PR DESCRIPTION
PR 24에서 임의로 미뤘던 T091 정리. simplify 패스에서 함께 발견된 중복 2건 정리.

## What

### T091 SaleEditDialog
- `useSaleByDate(date)` — sale + items + created_at fetch
- `SaleEditDialog` — 7일 lock 판정 (`isSaleLocked` / `daysUntilLock`), 잠금 시 LockedView, 미잠금 시 MenuRow 편집 + 사유 + 삭제
- `/sale/[date]` 페이지 통합 — existingSale 있으면 Edit, 없으면 SaveInput. 제목도 분기

### Simplify findings (2 fix)

| # | 항목 | 효과 |
|---|------|------|
| 1 | `SaleSaveBar` 추출 | SaleInputForm + SaleEditDialog 둘 다 동일한 `fixed bottom-16 z-40` 액션 바 → 한 컴포넌트 (left/right 슬롯) |
| 2 | `formatWon` / `formatNumber` 유틸 추출 | 5곳 흩어진 `Math.round + toLocaleString("ko-KR")` 통일. `src/lib/utils/format.ts` |

### 미반영 (premature)
- AlertDialog 디자인 시스템 패턴 → 추가될 때 confirm 교체 (TODO 주석)

## Verification
- typecheck / lint / format / test **86/86** / build 모두 ✅

## 결과

Phase 4가 진짜로 끝났습니다. 페르소나 정정 흐름 (저장 → 7일 이내 편집/삭제 → 재고 자동 되돌림 + 이력 기록)이 UI까지 완성. 헌법 IV (RLS) + 헌법 III (스냅샷 보존)이 사용자 시나리오에서 모두 검증됨.

Closes #32