### PR TITLE
feat(e2e): 골든패스 시나리오 (로그인 → 메뉴 템플릿 → 판매 → 마진)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ yarn-error.log*
 # Coverage / test
 coverage/
 .nyc_output/
+playwright-report/
+test-results/
 
 # Cache
 .turbo/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
+import { loadEnv } from "vite";
+
+// .env.local 등 dotenv 파일을 process.env에 주입.
+// 로컬: .env.local에서 SUPABASE_* 자동 로드 → 골든패스 E2E 실제 실행
+// CI: GitHub secret이 process.env에 직접 들어가서 그대로 작동.
+Object.assign(process.env, loadEnv("", process.cwd(), ""));
 
 export default defineConfig({
   testDir: "./tests/e2e",

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+import {
+  cleanupTestUser,
+  createTestUser,
+  hasSupabaseTestEnv,
+  type TestUser,
+} from "../helpers/test-supabase";
+import { dismissConsentBanner } from "./helpers/page";
+
+/**
+ * 페르소나 골든패스 (헌법 v1.3.0 E2E 의무).
+ *
+ * 가입한 사장님이 5분 안에 가치를 느끼는 흐름:
+ *   로그인 → 메뉴 템플릿 불러오기 → 판매 입력 → 매출/마진 확인 → 저장.
+ *
+ * Supabase env 미설정 환경(CI 기본)에선 skip. 로컬 `.env.local`이나 CI에
+ * SUPABASE_* secret이 있을 때만 실제 실행.
+ */
+
+test.describe("골든패스: 가입 → 메뉴 → 판매 → 마진", () => {
+  test.skip(!hasSupabaseTestEnv, "Supabase env not configured — golden path E2E skipped");
+
+  let user: TestUser;
+
+  test.beforeAll(async () => {
+    user = await createTestUser({ storeType: "bingsu_cafe", storeName: "E2E 빙수카페" });
+  });
+
+  test.afterAll(async () => {
+    if (user?.id) await cleanupTestUser(user.id);
+  });
+
+  test("로그인 후 빙수카페 템플릿 불러오기 + 팥빙수 1개 판매 입력", async ({ page }) => {
+    // 1) 로그인
+    await page.goto("/login");
+    await dismissConsentBanner(page);
+
+    await page.getByLabel("이메일").fill(user.email);
+    await page.getByLabel("비밀번호").fill(user.password);
+    await page.getByRole("button", { name: /로그인/ }).click();
+
+    await expect(page).toHaveURL(/\/today/, { timeout: 10_000 });
+
+    // 2) 메뉴 → 콜드스타트 다이얼로그
+    await page.goto("/menu");
+    await expect(page.getByRole("heading", { name: "템플릿으로 빠르게 시작" })).toBeVisible();
+
+    // 빙수카페가 기본 선택. 불러오기 클릭.
+    await page.getByRole("button", { name: "템플릿 불러오기" }).click();
+
+    // 8종 메뉴 행 등장 (다이얼로그 자동 사라짐)
+    await expect(page.getByRole("link", { name: /팥빙수/ })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("link", { name: /망고빙수/ })).toBeVisible();
+
+    // 3) 판매 입력 화면
+    await page.goto("/sale");
+
+    // 메뉴 리스트 로딩 대기
+    const palbingsuRow = page.getByRole("listitem").filter({ hasText: "팥빙수" });
+    await expect(palbingsuRow).toBeVisible({ timeout: 10_000 });
+
+    // 팥빙수 +1
+    await palbingsuRow.getByRole("button", { name: /수량 \+1/ }).click();
+
+    // 4) StickyTotalCard에 MARGIN_LABEL 표시 (헌법 III).
+    // 라벨이 보이면 sticky card가 preview를 받아 렌더링된 것 — 매출/원가는
+    // 메뉴 가격 행과 텍스트가 겹쳐 별도 검증하지 않음.
+    await expect(page.getByText("재료 원가 기준 (이동평균법)")).toBeVisible();
+
+    // 마진율: 모든 단가 0이라 100% 표시 (Phase 5 매입 후 실제 단가 반영됨)
+    await expect(page.getByText("마진 100%")).toBeVisible();
+
+    // 5) 저장 → /today 복귀
+    const saveButton = page.getByRole("button", { name: /1개 저장/ });
+    await saveButton.scrollIntoViewIfNeeded();
+    await saveButton.click();
+    await expect(page).toHaveURL(/\/today/, { timeout: 10_000 });
+  });
+});

--- a/tests/e2e/helpers/page.ts
+++ b/tests/e2e/helpers/page.ts
@@ -1,0 +1,23 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * E2E 헬퍼.
+ * 모든 시나리오에서 공통으로 필요한 페이지 상호작용 (배너 dismiss 등).
+ */
+
+/**
+ * PIPA 쿠키 동의 배너를 즉시 dismiss.
+ * 배너는 z-50으로 화면 하단을 점유 → 저장/액션 버튼을 가려서 click 인터셉트.
+ *
+ * 첫 방문 시 mount 타이밍에 따라 isVisible 반환 시점에 따라 race가 있어
+ * waitFor + catch로 "안 뜨면 그냥 패스"하게 한다.
+ */
+export async function dismissConsentBanner(page: Page): Promise<void> {
+  const banner = page.getByRole("dialog", { name: "쿠키 동의" });
+  await banner.waitFor({ state: "visible", timeout: 2000 }).catch(() => {
+    /* 배너가 안 뜨는 환경(이미 처리됨) — 무시 */
+  });
+  if (await banner.isVisible()) {
+    await banner.getByRole("button", { name: "거부" }).click();
+  }
+}


### PR DESCRIPTION
헌법 v1.3.0 E2E 의무 충족 — 페르소나 골든패스 1개 자동화. **로컬에서 실제 실행 확인 (31초, ✅).**

## 시나리오

1. 빙수카페 테스트 유저 생성 (Supabase admin)
2. `/login` → 이메일/패스워드 → `/today`
3. `/menu` → 템플릿 다이얼로그 → 빙수카페 8종 클론 검증
4. `/sale` → 팥빙수 `+1` → `MARGIN_LABEL` "재료 원가 기준 (이동평균법)" + 마진 100% (콜드스타트, 단가 0)
5. 저장 → `/today` 복귀
6. afterAll cleanup (admin.auth.admin.deleteUser → CASCADE)

## 환경 게이트

- `hasSupabaseTestEnv` 없으면 `test.skip` (CI 기본 placeholder env에서 자동 skip)
- 로컬 `.env.local` 있으면 자동 실행 — 실제 클라우드 hit
- CI 활성화는 GitHub secret 추가 후 follow-up PR (이번 PR 범위 밖)

## Simplify 패스 (2 fix)

| # | 항목 | 효과 |
|---|------|------|
| 1 | `dismissConsentBanner` 헬퍼 추출 (`tests/e2e/helpers/page.ts`) | PIPA 쿠키 배너 z-50이 저장 버튼 가림 — 후속 시나리오에서도 재사용 |
| 2 | `waitFor + catch` race 방지 | 배너 mount 타이밍 다양 — `isVisible` 단독 체크는 false-negative 위험 |

## 기타

- `playwright.config.ts`: `loadEnv("")`로 `.env.local` 주입 (vitest와 동일 패턴)
- `.gitignore`: `playwright-report/` + `test-results/` 추가 (artifact 추적 방지)

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test` ✅ **86/86**
- `npm run test:e2e -- golden-path` ✅ **1/1** (로컬 31초)

## 의의

페르소나 5분 골든패스(가입→메뉴→판매→마진)가 **자동 회귀 검증**됨. 다음 변경(매입/캘린더/대시보드)이 이 흐름을 깨면 즉시 알 수 있음.

Closes #34