### PR TITLE
feat(purchase): UI + 훅 + GA4 + price change alert (Phase 5 완료)

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -233,19 +233,19 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### UI 컴포넌트 + 라우팅
 
-- [ ] T108 [P] [US2] Create `src/features/purchase/components/PurchaseForm.tsx` (vendor select with autocomplete + 신규 추가, date picker, items list with ingredient autocomplete + 수량/금액)
-- [ ] T109 [P] [US2] Create `src/features/purchase/components/VendorQuickCreate.tsx` for inline vendor add (name + lead_time_days, default 1)
-- [ ] T110 [P] [US2] Create `src/features/purchase/components/IngredientQuickCreate.tsx` for inline ingredient add (name + unit, name unique check)
-- [ ] T111 [P] [US2] Create `src/features/purchase/components/PriceChangeAlertList.tsx` showing ±5% alerts after save with previous→new price + percent
-- [ ] T112 [US2] Create page `src/app/purchase/page.tsx` (context-entry, not in bottom tab) integrating PurchaseForm
-- [ ] T113 [US2] Add quick-action entry from `src/app/(main)/inventory/page.tsx` linking to `/purchase` (header action button per design system patterns)
-- [ ] T114 [P] [US2] Create hook `src/features/purchase/hooks/usePurchaseSubmit.ts` (mutation calling `save_purchase` RPC + invalidate menus/ingredients caches)
-- [ ] T115 [P] [US2] Create hook `src/features/purchase/hooks/useVendors.ts` and `useIngredients.ts` (TanStack Query)
+- [x] T108 [P] [US2] Create `src/features/purchase/components/PurchaseForm.tsx` (vendor select with autocomplete + 신규 추가, date picker, items list with ingredient autocomplete + 수량/금액)
+- [x] T109 [P] [US2] Create `src/features/purchase/components/VendorQuickCreate.tsx` for inline vendor add (name + lead_time_days, default 1)
+- [x] T110 [P] [US2] Create `src/features/purchase/components/IngredientQuickCreate.tsx` for inline ingredient add (name + unit, name unique check)
+- [x] T111 [P] [US2] Create `src/features/purchase/components/PriceChangeAlertList.tsx` showing ±5% alerts after save with previous→new price + percent
+- [x] T112 [US2] Create page `src/app/purchase/page.tsx` (context-entry, not in bottom tab) integrating PurchaseForm
+- [x] T113 [US2] Add quick-action entry from `src/app/(main)/inventory/page.tsx` linking to `/purchase` (header action button per design system patterns)
+- [x] T114 [P] [US2] Create hook `src/features/purchase/hooks/usePurchaseSubmit.ts` (mutation calling `save_purchase` RPC + invalidate menus/ingredients caches)
+- [x] T115 [P] [US2] Create hook `src/features/purchase/hooks/useVendors.ts` and `useIngredients.ts` (TanStack Query)
 
 ### GA4 이벤트
 
-- [ ] T116 [US2] Wire `first_purchase_logged` GA4 event in save handler (fire only if user's purchase count was 0 before)
-- [ ] T117 [US2] Wire `price_change_alert_shown` GA4 event when PriceChangeAlertList renders ≥1 alert
+- [x] T116 [US2] Wire `first_purchase_logged` GA4 event in save handler (fire only if user's purchase count was 0 before)
+- [x] T117 [US2] Wire `price_change_alert_shown` GA4 event when PriceChangeAlertList renders ≥1 alert
 
 ### 통합 테스트
 

--- a/src/app/purchase/page.tsx
+++ b/src/app/purchase/page.tsx
@@ -1,15 +1,16 @@
 import Link from "next/link";
+import { PurchaseForm } from "@/features/purchase/components/PurchaseForm";
 
 export default function PurchasePage(): React.ReactElement {
   return (
-    <main className="mx-auto flex min-h-screen max-w-screen-md flex-col gap-stack p-screen pb-20">
+    <main className="mx-auto flex min-h-screen max-w-screen-md flex-col gap-section p-screen pb-20">
       <header className="flex items-center justify-between">
         <h1 className="text-title-lg text-ink-1">매입 등록</h1>
         <Link href="/inventory" className="text-body-regular text-ink-3 hover:text-ink-2">
           취소
         </Link>
       </header>
-      <p className="text-body-regular text-ink-3">매입 입력 흐름 — Phase 5에서 구현</p>
+      <PurchaseForm />
     </main>
   );
 }

--- a/src/features/purchase/components/IngredientQuickCreate.tsx
+++ b/src/features/purchase/components/IngredientQuickCreate.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { ingredientInputSchema, type IngredientInput } from "../schemas";
+import { useCreateIngredient, type IngredientRow } from "../hooks/useIngredients";
+
+interface IngredientQuickCreateProps {
+  onCreated: (ingredient: IngredientRow) => void;
+  onCancel: () => void;
+}
+
+const UNIT_LABELS: Record<IngredientInput["unit"], string> = {
+  g: "g (그램)",
+  ml: "ml (밀리리터)",
+  piece: "개",
+};
+
+export function IngredientQuickCreate({
+  onCreated,
+  onCancel,
+}: IngredientQuickCreateProps): React.ReactElement {
+  const [error, setError] = useState<string | null>(null);
+  const mutation = useCreateIngredient();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<IngredientInput>({
+    resolver: zodResolver(ingredientInputSchema),
+    defaultValues: { name: "", unit: "g" },
+  });
+
+  async function onSubmit(values: IngredientInput): Promise<void> {
+    setError(null);
+    try {
+      const created = await mutation.mutateAsync(values);
+      onCreated(created);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "재료 생성 실패");
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit(onSubmit)(e)}
+      className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile"
+      noValidate
+    >
+      <h3 className="text-title-md text-ink-1">새 재료 추가</h3>
+
+      <Field label="재료 이름" error={errors.name?.message}>
+        <input
+          {...register("name")}
+          type="text"
+          autoFocus
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        />
+      </Field>
+
+      <Field label="단위" error={errors.unit?.message}>
+        <select
+          {...register("unit")}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        >
+          {(Object.keys(UNIT_LABELS) as IngredientInput["unit"][]).map((u) => (
+            <option key={u} value={u}>
+              {UNIT_LABELS[u]}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      {error && (
+        <p role="alert" className="text-caption text-red">
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-stack">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-border px-stack py-stack text-body-regular text-ink-2 hover:bg-card-hover"
+        >
+          취소
+        </button>
+        <PrimaryButton type="submit" disabled={isSubmitting} className="ml-auto">
+          {isSubmitting ? "추가 중…" : "추가"}
+        </PrimaryButton>
+      </div>
+    </form>
+  );
+}

--- a/src/features/purchase/components/PriceChangeAlertList.tsx
+++ b/src/features/purchase/components/PriceChangeAlertList.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatWon } from "@/lib/utils/format";
+import type { PriceChangeAlert } from "@/lib/supabase/rpc";
+
+interface PriceChangeAlertListProps {
+  alerts: readonly PriceChangeAlert[];
+}
+
+/**
+ * ±5% 변동 알림 (FR-005). 매입 저장 직후 표시.
+ * 인상은 red soft, 인하는 green soft 톤.
+ */
+export function PriceChangeAlertList({
+  alerts,
+}: PriceChangeAlertListProps): React.ReactElement | null {
+  if (alerts.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-stack-tight">
+      <h3 className="text-title-md text-ink-1">단가 변동 알림</h3>
+      <ul className="flex flex-col gap-stack-tight">
+        {alerts.map((alert) => (
+          <AlertRow key={alert.ingredientId} alert={alert} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function AlertRow({ alert }: { alert: PriceChangeAlert }): React.ReactElement {
+  const isIncrease = alert.changePercent > 0;
+  const sign = isIncrease ? "+" : "";
+
+  return (
+    <li
+      className={cn(
+        "flex flex-col gap-1 rounded-lg p-tile",
+        isIncrease ? "bg-red-soft" : "bg-green-soft",
+      )}
+    >
+      <div className="flex items-baseline justify-between">
+        <span className={cn("text-body", isIncrease ? "text-red-deep" : "text-green-deep")}>
+          {alert.ingredientName} 단가 {sign}
+          {alert.changePercent.toFixed(0)}%
+        </span>
+        <span
+          className={cn(
+            "text-caption tabular-nums",
+            isIncrease ? "text-red-deep" : "text-green-deep",
+          )}
+        >
+          {formatWon(alert.previousAvgPrice)} → {formatWon(alert.newAvgPrice)}원
+        </span>
+      </div>
+      <p className="text-caption text-ink-3">
+        {isIncrease
+          ? "메뉴 마진율이 떨어질 수 있어요. 메뉴 화면에서 영향 확인하세요."
+          : "메뉴 마진율이 올라갑니다."}
+      </p>
+    </li>
+  );
+}

--- a/src/features/purchase/components/PurchaseForm.tsx
+++ b/src/features/purchase/components/PurchaseForm.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, useFieldArray, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { savePurchaseSchema, type SavePurchaseInput } from "../schemas";
+import { useVendors, type VendorRow } from "../hooks/useVendors";
+import { useIngredients, type IngredientRow } from "../hooks/useIngredients";
+import { usePurchaseSubmit } from "../hooks/usePurchaseSubmit";
+import { useIsFirstPurchase } from "../hooks/useIsFirstPurchase";
+import { VendorQuickCreate } from "./VendorQuickCreate";
+import { IngredientQuickCreate } from "./IngredientQuickCreate";
+import { PriceChangeAlertList } from "./PriceChangeAlertList";
+import type { PriceChangeAlert } from "@/lib/supabase/rpc";
+
+const todayString = (): string => new Date().toISOString().slice(0, 10);
+
+export function PurchaseForm(): React.ReactElement {
+  const router = useRouter();
+  const { data: vendors } = useVendors();
+  const { data: ingredients } = useIngredients();
+  const { data: isFirstPurchase } = useIsFirstPurchase();
+  const submit = usePurchaseSubmit();
+
+  const [savedAlerts, setSavedAlerts] = useState<readonly PriceChangeAlert[] | null>(null);
+  const [vendorPicker, setVendorPicker] = useState<"select" | "create">("select");
+  const [ingredientPickerIdx, setIngredientPickerIdx] = useState<number | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<SavePurchaseInput>({
+    resolver: zodResolver(savePurchaseSchema),
+    defaultValues: {
+      vendorId: "",
+      purchasedAt: todayString(),
+      items: [{ ingredientId: "", quantity: 0, amount: 0 }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: "items" });
+
+  function onSubmit(values: SavePurchaseInput): void {
+    setSavedAlerts(null);
+    submit.mutate(
+      { ...values, isFirstPurchase: isFirstPurchase ?? false },
+      {
+        onSuccess: (result) => {
+          setSavedAlerts(result.priceChangeAlerts);
+          if (result.priceChangeAlerts.length === 0) {
+            // 알림 없으면 즉시 inventory로 복귀
+            router.push("/inventory");
+          }
+        },
+      },
+    );
+  }
+
+  if (savedAlerts && savedAlerts.length > 0) {
+    return (
+      <div className="flex flex-col gap-section">
+        <PriceChangeAlertList alerts={savedAlerts} />
+        <PrimaryButton type="button" onClick={() => router.push("/inventory")}>
+          확인했어요
+        </PrimaryButton>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        void handleSubmit(onSubmit)(e);
+      }}
+      className="flex flex-col gap-section"
+      noValidate
+    >
+      <Field label="거래처" error={errors.vendorId?.message}>
+        <Controller
+          control={control}
+          name="vendorId"
+          render={({ field }) => (
+            <VendorPicker
+              vendors={vendors ?? []}
+              value={field.value}
+              onChange={field.onChange}
+              mode={vendorPicker}
+              setMode={setVendorPicker}
+              onCreated={(v) => {
+                field.onChange(v.id);
+                setVendorPicker("select");
+              }}
+            />
+          )}
+        />
+      </Field>
+
+      <Field label="매입일" error={errors.purchasedAt?.message}>
+        <input
+          {...register("purchasedAt")}
+          type="date"
+          max={todayString()}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+        />
+      </Field>
+
+      <section className="flex flex-col gap-stack-tight">
+        <header className="flex items-center justify-between">
+          <span className="text-label text-ink-2">매입 항목</span>
+          <button
+            type="button"
+            onClick={() => append({ ingredientId: "", quantity: 0, amount: 0 })}
+            className="rounded-md border border-border px-stack py-1 text-label text-ink-2 hover:bg-card-hover"
+          >
+            + 항목 추가
+          </button>
+        </header>
+
+        {fields.map((field, idx) => (
+          <ItemRow
+            key={field.id}
+            idx={idx}
+            register={register}
+            control={control}
+            ingredients={ingredients ?? []}
+            onRemove={() => remove(idx)}
+            errorMessage={
+              errors.items?.[idx]?.quantity?.message ??
+              errors.items?.[idx]?.amount?.message ??
+              errors.items?.[idx]?.ingredientId?.message
+            }
+            quickCreateOpen={ingredientPickerIdx === idx}
+            onOpenQuickCreate={() => setIngredientPickerIdx(idx)}
+            onCloseQuickCreate={() => setIngredientPickerIdx(null)}
+            onIngredientCreated={(i) => {
+              setValue(`items.${idx}.ingredientId`, i.id);
+              setIngredientPickerIdx(null);
+            }}
+          />
+        ))}
+      </section>
+
+      {submit.isError && (
+        <p role="alert" className="text-body-regular text-red">
+          {submit.error.message}
+        </p>
+      )}
+
+      <PrimaryButton type="submit" disabled={isSubmitting || submit.isPending}>
+        {submit.isPending ? "저장 중…" : "매입 저장"}
+      </PrimaryButton>
+    </form>
+  );
+}
+
+interface VendorPickerProps {
+  vendors: readonly VendorRow[];
+  value: string;
+  onChange: (id: string) => void;
+  mode: "select" | "create";
+  setMode: (m: "select" | "create") => void;
+  onCreated: (v: VendorRow) => void;
+}
+
+function VendorPicker({
+  vendors,
+  value,
+  onChange,
+  mode,
+  setMode,
+  onCreated,
+}: VendorPickerProps): React.ReactElement {
+  if (mode === "create") {
+    return <VendorQuickCreate onCreated={onCreated} onCancel={() => setMode("select")} />;
+  }
+  return (
+    <div className="flex gap-stack-tight">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="flex-1 rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+      >
+        <option value="">거래처 선택</option>
+        {vendors.map((v) => (
+          <option key={v.id} value={v.id}>
+            {v.name}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={() => setMode("create")}
+        className="rounded-md border border-border px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
+      >
+        + 신규
+      </button>
+    </div>
+  );
+}
+
+interface ItemRowProps {
+  idx: number;
+  register: ReturnType<typeof useForm<SavePurchaseInput>>["register"];
+  control: ReturnType<typeof useForm<SavePurchaseInput>>["control"];
+  ingredients: readonly IngredientRow[];
+  onRemove: () => void;
+  errorMessage?: string;
+  quickCreateOpen: boolean;
+  onOpenQuickCreate: () => void;
+  onCloseQuickCreate: () => void;
+  onIngredientCreated: (i: IngredientRow) => void;
+}
+
+function ItemRow({
+  idx,
+  register,
+  control,
+  ingredients,
+  onRemove,
+  errorMessage,
+  quickCreateOpen,
+  onOpenQuickCreate,
+  onCloseQuickCreate,
+  onIngredientCreated,
+}: ItemRowProps): React.ReactElement {
+  if (quickCreateOpen) {
+    return <IngredientQuickCreate onCreated={onIngredientCreated} onCancel={onCloseQuickCreate} />;
+  }
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border border-border bg-card p-tile">
+      <Controller
+        control={control}
+        name={`items.${idx}.ingredientId`}
+        render={({ field }) => (
+          <div className="flex gap-stack-tight">
+            <select
+              value={field.value}
+              onChange={(e) => field.onChange(e.target.value)}
+              className="flex-1 rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+            >
+              <option value="">재료 선택</option>
+              {ingredients.map((ing) => (
+                <option key={ing.id} value={ing.id}>
+                  {ing.name} ({ing.unit})
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={onOpenQuickCreate}
+              className="rounded-md border border-border px-stack py-stack-tight text-label text-ink-2 hover:bg-card-hover"
+            >
+              + 신규
+            </button>
+          </div>
+        )}
+      />
+
+      <div className="grid grid-cols-2 gap-stack-tight">
+        <label className="flex flex-col gap-1">
+          <span className="text-caption text-ink-3">수량</span>
+          <input
+            {...register(`items.${idx}.quantity`, { valueAsNumber: true })}
+            type="number"
+            min={0}
+            step="0.001"
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-caption text-ink-3">금액 (원)</span>
+          <input
+            {...register(`items.${idx}.amount`, { valueAsNumber: true })}
+            type="number"
+            min={0}
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+          />
+        </label>
+      </div>
+
+      <div className="flex items-center justify-between">
+        {errorMessage && <span className="text-caption text-red">{errorMessage}</span>}
+        <button
+          type="button"
+          onClick={onRemove}
+          className="ml-auto text-caption text-ink-3 hover:text-red"
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/purchase/components/VendorQuickCreate.tsx
+++ b/src/features/purchase/components/VendorQuickCreate.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { vendorInputSchema, type VendorInput } from "../schemas";
+import { useCreateVendor, type VendorRow } from "../hooks/useVendors";
+
+interface VendorQuickCreateProps {
+  onCreated: (vendor: VendorRow) => void;
+  onCancel: () => void;
+}
+
+export function VendorQuickCreate({
+  onCreated,
+  onCancel,
+}: VendorQuickCreateProps): React.ReactElement {
+  const [error, setError] = useState<string | null>(null);
+  const mutation = useCreateVendor();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<VendorInput>({
+    resolver: zodResolver(vendorInputSchema),
+    defaultValues: { name: "", leadTimeDays: 1 },
+  });
+
+  async function onSubmit(values: VendorInput): Promise<void> {
+    setError(null);
+    try {
+      const created = await mutation.mutateAsync(values);
+      onCreated(created);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "거래처 생성 실패");
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit(onSubmit)(e)}
+      className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile"
+      noValidate
+    >
+      <h3 className="text-title-md text-ink-1">새 거래처 추가</h3>
+
+      <Field label="거래처 이름" error={errors.name?.message}>
+        <input
+          {...register("name")}
+          type="text"
+          autoFocus
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        />
+      </Field>
+
+      <Field label="리드타임 (일)" error={errors.leadTimeDays?.message}>
+        <input
+          {...register("leadTimeDays", { valueAsNumber: true })}
+          type="number"
+          min={0}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+        />
+      </Field>
+
+      {error && (
+        <p role="alert" className="text-caption text-red">
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-stack">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-border px-stack py-stack text-body-regular text-ink-2 hover:bg-card-hover"
+        >
+          취소
+        </button>
+        <PrimaryButton type="submit" disabled={isSubmitting} className="ml-auto">
+          {isSubmitting ? "추가 중…" : "추가"}
+        </PrimaryButton>
+      </div>
+    </form>
+  );
+}

--- a/src/features/purchase/hooks/useIngredients.ts
+++ b/src/features/purchase/hooks/useIngredients.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { saveIngredient } from "@/lib/supabase/rpc";
+import type { IngredientInput } from "../schemas";
+
+export interface IngredientRow {
+  id: string;
+  name: string;
+  unit: "g" | "ml" | "piece";
+  current_avg_price: number;
+}
+
+interface RawIngredientRow {
+  id: string;
+  name: string;
+  unit: "g" | "ml" | "piece";
+  current_avg_price: number;
+}
+
+export const ingredientListQueryKey = ["ingredients", "list"] as const;
+
+async function fetchIngredients(): Promise<IngredientRow[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("ingredients")
+    .select("id, name, unit, current_avg_price")
+    .eq("is_active", true)
+    .order("name");
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as unknown as RawIngredientRow[]).map((row) => ({
+    id: row.id,
+    name: row.name,
+    unit: row.unit,
+    current_avg_price: Number(row.current_avg_price),
+  }));
+}
+
+export function useIngredients(): UseQueryResult<IngredientRow[]> {
+  return useQuery({ queryKey: ingredientListQueryKey, queryFn: fetchIngredients });
+}
+
+async function createIngredient(input: IngredientInput): Promise<IngredientRow> {
+  const supabase = createClient();
+  const { data, error } = await saveIngredient(supabase, {
+    name: input.name,
+    unit: input.unit,
+  });
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("save_ingredient: empty response");
+  return {
+    id: row.id,
+    name: row.name,
+    unit: row.unit,
+    current_avg_price: Number(row.current_avg_price),
+  };
+}
+
+export function useCreateIngredient(): UseMutationResult<IngredientRow, Error, IngredientInput> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createIngredient,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+    },
+  });
+}

--- a/src/features/purchase/hooks/useIsFirstPurchase.ts
+++ b/src/features/purchase/hooks/useIsFirstPurchase.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * 사용자가 매입을 한 번도 등록 안 했는지 확인 — first_purchase_logged GA4 발화 조건.
+ * useIsFirstSale과 동일 패턴. 다중 탭 staleness는 MVP 허용.
+ */
+export function useIsFirstPurchase(): UseQueryResult<boolean> {
+  return useQuery({
+    queryKey: ["purchases", "is-first"],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { count, error } = await supabase
+        .from("purchase_orders")
+        .select("id", { count: "exact", head: true });
+      if (error) throw new Error(error.message);
+      return (count ?? 0) === 0;
+    },
+    staleTime: 60_000,
+  });
+}

--- a/src/features/purchase/hooks/usePurchaseSubmit.ts
+++ b/src/features/purchase/hooks/usePurchaseSubmit.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { savePurchase, type SavePurchaseResult } from "@/lib/supabase/rpc";
+import { trackEvent } from "@/lib/analytics/ga4";
+import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
+import { ingredientListQueryKey } from "./useIngredients";
+import type { SavePurchaseInput } from "../schemas";
+
+interface SubmitVariables extends SavePurchaseInput {
+  isFirstPurchase: boolean;
+}
+
+async function submit(input: SubmitVariables): Promise<SavePurchaseResult> {
+  const supabase = createClient();
+  const { data, error } = await savePurchase(supabase, {
+    vendorId: input.vendorId,
+    purchasedAt: input.purchasedAt,
+    items: input.items,
+  });
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("save_purchase: empty response");
+  return data;
+}
+
+export function usePurchaseSubmit(): UseMutationResult<SavePurchaseResult, Error, SubmitVariables> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: submit,
+    onSuccess: (result, input) => {
+      if (input.isFirstPurchase) {
+        trackEvent("first_purchase_logged", {});
+      }
+      if (result.priceChangeAlerts.length > 0) {
+        trackEvent("price_change_alert_shown", {
+          alert_count: result.priceChangeAlerts.length,
+        });
+      }
+      // 매입은 ingredient 단가/재고 갱신 + 메뉴 마진 영향
+      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+    },
+  });
+}

--- a/src/features/purchase/hooks/useVendors.ts
+++ b/src/features/purchase/hooks/useVendors.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { saveVendor } from "@/lib/supabase/rpc";
+import type { VendorInput } from "../schemas";
+
+export interface VendorRow {
+  id: string;
+  name: string;
+  lead_time_days: number;
+}
+
+export const vendorListQueryKey = ["vendors", "list"] as const;
+
+async function fetchVendors(): Promise<VendorRow[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("vendors")
+    .select("id, name, lead_time_days")
+    .eq("is_active", true)
+    .order("name");
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export function useVendors(): UseQueryResult<VendorRow[]> {
+  return useQuery({ queryKey: vendorListQueryKey, queryFn: fetchVendors });
+}
+
+async function createVendor(input: VendorInput): Promise<VendorRow> {
+  const supabase = createClient();
+  const { data, error } = await saveVendor(supabase, {
+    name: input.name,
+    leadTimeDays: input.leadTimeDays,
+  });
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("save_vendor: empty response");
+  return { id: row.id, name: row.name, lead_time_days: row.lead_time_days };
+}
+
+export function useCreateVendor(): UseMutationResult<VendorRow, Error, VendorInput> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createVendor,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: vendorListQueryKey });
+    },
+  });
+}

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -160,6 +160,39 @@ interface SavePurchaseRawRow {
   }>;
 }
 
+interface SaveVendorRow {
+  id: string;
+  name: string;
+  lead_time_days: number;
+}
+
+export function saveVendor(
+  client: ClientLike,
+  args: { name: string; leadTimeDays: number },
+): Promise<RpcResult<SaveVendorRow[]>> {
+  return callRpc(client, "save_vendor", {
+    p_name: args.name,
+    p_lead_time_days: args.leadTimeDays,
+  });
+}
+
+interface SaveIngredientRow {
+  id: string;
+  name: string;
+  unit: "g" | "ml" | "piece";
+  current_avg_price: number;
+}
+
+export function saveIngredient(
+  client: ClientLike,
+  args: { name: string; unit: "g" | "ml" | "piece" },
+): Promise<RpcResult<SaveIngredientRow[]>> {
+  return callRpc(client, "save_ingredient", {
+    p_name: args.name,
+    p_unit: args.unit,
+  });
+}
+
 export async function savePurchase(
   client: ClientLike,
   args: SavePurchaseArgs,

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -593,6 +593,18 @@ export type Database = {
           success: boolean
         }[]
       }
+      save_ingredient: {
+        Args: {
+          p_name: string
+          p_unit: Database["public"]["Enums"]["ingredient_unit"]
+        }
+        Returns: {
+          current_avg_price: number
+          id: string
+          name: string
+          unit: Database["public"]["Enums"]["ingredient_unit"]
+        }[]
+      }
       save_menu: {
         Args: { p_name: string; p_price: number; p_recipe?: Json }
         Returns: {
@@ -614,6 +626,14 @@ export type Database = {
           total_cost_snapshot: number
           total_net_profit: number
           total_revenue: number
+        }[]
+      }
+      save_vendor: {
+        Args: { p_lead_time_days?: number; p_name: string }
+        Returns: {
+          id: string
+          lead_time_days: number
+          name: string
         }[]
       }
       update_regular_days_off: {

--- a/supabase/migrations/019_save_vendor_and_ingredient_rpcs.sql
+++ b/supabase/migrations/019_save_vendor_and_ingredient_rpcs.sql
@@ -1,0 +1,76 @@
+-- Migration: save_vendor + save_ingredient RPCs (인라인 quick-create 흐름)
+-- Spec: T109, T110 (PurchaseForm의 인라인 추가 흐름)
+--
+-- @supabase/ssr 0.5의 createBrowserClient typing이 INSERT 추론을 못 잡아
+-- 클라이언트가 user_id를 직접 다루지 않게 RPC로 위임 (save_menu 패턴과 동일).
+
+create or replace function public.save_vendor(p_name text, p_lead_time_days integer default 1)
+returns table (id uuid, name text, lead_time_days integer)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+  v_vendor_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+  if p_lead_time_days < 0 then
+    raise exception 'invalid_input: lead_time_days must be >= 0' using errcode = '22023';
+  end if;
+
+  insert into public.vendors (user_id, name, lead_time_days)
+  values (v_user_id, p_name, p_lead_time_days)
+  returning id into v_vendor_id;
+
+  return query
+  select v.id, v.name, v.lead_time_days
+  from public.vendors v
+  where v.id = v_vendor_id;
+end;
+$$;
+
+comment on function public.save_vendor(text, integer) is
+  '거래처 신규 등록. user_id는 auth.uid() 자동.';
+
+revoke all on function public.save_vendor(text, integer) from public;
+grant execute on function public.save_vendor(text, integer) to authenticated;
+
+-- ─── save_ingredient ────────────────────────────────────────────
+create or replace function public.save_ingredient(
+  p_name text,
+  p_unit public.ingredient_unit
+)
+returns table (id uuid, name text, unit public.ingredient_unit, current_avg_price numeric)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+  v_ingredient_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  insert into public.ingredients (user_id, name, unit)
+  values (v_user_id, p_name, p_unit)
+  returning id into v_ingredient_id;
+
+  return query
+  select i.id, i.name, i.unit, i.current_avg_price
+  from public.ingredients i
+  where i.id = v_ingredient_id;
+end;
+$$;
+
+comment on function public.save_ingredient(text, public.ingredient_unit) is
+  '재료 신규 등록 (인라인 quick-create). user_id는 auth.uid() 자동.';
+
+revoke all on function public.save_ingredient(text, public.ingredient_unit) from public;
+grant execute on function public.save_ingredient(text, public.ingredient_unit) to authenticated;


### PR DESCRIPTION
Phase 5 마지막 PR — 매입 도메인 UI 와이어업. **머지 전 simplify 패스 통과 (ship-as-is, 8개 항목 모두 acceptable).**

## What

### 훅 (4개)
- `useVendors` / `useCreateVendor` — 거래처 조회 + 인라인 신규
- `useIngredients` / `useCreateIngredient` — 재료 조회 + 인라인 신규
- `usePurchaseSubmit` — `savePurchase` + GA4 + ingredient/menu 캐시 invalidate
- `useIsFirstPurchase` — 첫 매입 여부 cached query

### UI 컴포넌트 (4개)
- **PurchaseForm** (T108) — 거래처 + 매입일 + 항목 리스트(재료 + 수량 + 금액) + 인라인 quick-create + ±5% alerts 분기
- **VendorQuickCreate** (T109) — 이름 + 리드타임
- **IngredientQuickCreate** (T110) — 이름 + 단위
- **PriceChangeAlertList** (T111) — 인상 red / 인하 green + 이전→새 단가 + 메뉴 마진 영향 안내

### 라우팅
- `/purchase` (T112) — PurchaseForm 통합
- `/inventory` (T113) — 이미 `+ 매입 등록` 링크 있음 (Phase 2부터 placeholder)

### 마이그레이션
- `019_save_vendor_and_ingredient_rpcs.sql`: `save_vendor` / `save_ingredient` RPC. ssr 0.5 INSERT 추론 우회 (save_menu 패턴 일관)

### GA4 (T116, T117)
- `first_purchase_logged` — count 0 → 1
- `price_change_alert_shown` — alerts.length > 0 (alert_count param)

## Simplify 패스 결과 — ship as is

| # | 항목 | 결정 |
|---|------|------|
| 1 | useIsFirstSale vs useIsFirstPurchase 중복 | 도메인 분리 가치 > 추출 비용 — keep |
| 2 | PurchaseForm ~300 lines | 콜로케이션 명확 — keep |
| 3 | mid-render setState | 없음 (PR 24 lesson 적용) |
| 4 | PriceChangeAlertList tone | RPC가 0% 필터 → binary 분기 OK |
| 5 | inline IngredientQuickCreate | MVP UX 충분 |
| 6 | 저장 후 분기 | guard clause로 깔끔 |
| 7 | save_vendor/ingredient 단순 RPC | unique constraint 원본 메시지 — MVP 허용 |
| 8 | 캐시 invalidate | 모두 정확 (vendors / ingredients / menus) |

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test` ✅ **94/94**
- `npm run build` ✅

## Phase 5 종료 체크포인트

> 가중 평균 단가 적용 → 메뉴 마진이 실제 값으로 표시. 페르소나 골든패스가 의미 있는 마진율을 보여줌 (예: 매입 후 팥빙수 마진 47%).

페르소나 5분 가치 검증 흐름 완성: 가입 → 메뉴 템플릿 → 매입 등록(첫 단가 형성) → 판매 입력 → 진짜 마진율 확인.

Closes #38