### PR TITLE
feat(e2e): 골든패스 매입 단계 추가 + CI E2E secrets 활성화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: build
+    # secrets가 설정돼 있으면 실제 cloud 연결, 없으면 placeholder로 fallback —
+    # 골든패스 테스트는 hasSupabaseTestEnv 게이트로 자동 skip.
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -77,13 +83,7 @@ jobs:
       - run: npm install --no-audit --no-fund
       - run: npx playwright install --with-deps chromium
       - run: npm run build
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co"
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder"
       - run: npm run start &
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co"
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder"
       - name: Wait for server
         run: npx wait-on http://localhost:3000 -t 60000
       - run: npm run test:e2e

--- a/src/features/purchase/components/IngredientQuickCreate.tsx
+++ b/src/features/purchase/components/IngredientQuickCreate.tsx
@@ -44,12 +44,10 @@ export function IngredientQuickCreate({
     }
   }
 
+  // 중첩 <form>은 invalid HTML — 외부 PurchaseForm 안에 들어가므로 <div>로 렌더하고
+  // 추가 버튼은 type="button" + handleSubmit() 직접 호출.
   return (
-    <form
-      onSubmit={(e) => void handleSubmit(onSubmit)(e)}
-      className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile"
-      noValidate
-    >
+    <div className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
       <h3 className="text-title-md text-ink-1">새 재료 추가</h3>
 
       <Field label="재료 이름" error={errors.name?.message}>
@@ -88,10 +86,15 @@ export function IngredientQuickCreate({
         >
           취소
         </button>
-        <PrimaryButton type="submit" disabled={isSubmitting} className="ml-auto">
+        <PrimaryButton
+          type="button"
+          onClick={() => void handleSubmit(onSubmit)()}
+          disabled={isSubmitting}
+          className="ml-auto"
+        >
           {isSubmitting ? "추가 중…" : "추가"}
         </PrimaryButton>
       </div>
-    </form>
+    </div>
   );
 }

--- a/src/features/purchase/components/PurchaseForm.tsx
+++ b/src/features/purchase/components/PurchaseForm.tsx
@@ -182,6 +182,7 @@ function VendorPicker({
   return (
     <div className="flex gap-stack-tight">
       <select
+        name="vendorId"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="flex-1 rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
@@ -240,6 +241,7 @@ function ItemRow({
         render={({ field }) => (
           <div className="flex gap-stack-tight">
             <select
+              name={field.name}
               value={field.value}
               onChange={(e) => field.onChange(e.target.value)}
               className="flex-1 rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"

--- a/src/features/purchase/components/VendorQuickCreate.tsx
+++ b/src/features/purchase/components/VendorQuickCreate.tsx
@@ -38,12 +38,10 @@ export function VendorQuickCreate({
     }
   }
 
+  // 중첩 <form>은 invalid HTML — 외부 PurchaseForm 안에 들어가므로 <div>로 렌더하고
+  // 추가 버튼은 type="button" + handleSubmit() 직접 호출.
   return (
-    <form
-      onSubmit={(e) => void handleSubmit(onSubmit)(e)}
-      className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile"
-      noValidate
-    >
+    <div className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
       <h3 className="text-title-md text-ink-1">새 거래처 추가</h3>
 
       <Field label="거래처 이름" error={errors.name?.message}>
@@ -78,10 +76,15 @@ export function VendorQuickCreate({
         >
           취소
         </button>
-        <PrimaryButton type="submit" disabled={isSubmitting} className="ml-auto">
+        <PrimaryButton
+          type="button"
+          onClick={() => void handleSubmit(onSubmit)()}
+          disabled={isSubmitting}
+          className="ml-auto"
+        >
           {isSubmitting ? "추가 중…" : "추가"}
         </PrimaryButton>
       </div>
-    </form>
+    </div>
   );
 }

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -11,13 +11,14 @@ import { dismissConsentBanner } from "./helpers/page";
  * 페르소나 골든패스 (헌법 v1.3.0 E2E 의무).
  *
  * 가입한 사장님이 5분 안에 가치를 느끼는 흐름:
- *   로그인 → 메뉴 템플릿 불러오기 → 판매 입력 → 매출/마진 확인 → 저장.
+ *   로그인 → 메뉴 템플릿 → 매입 등록(단가 형성) → 판매 입력 →
+ *   실제 마진율 확인 → 저장
  *
  * Supabase env 미설정 환경(CI 기본)에선 skip. 로컬 `.env.local`이나 CI에
  * SUPABASE_* secret이 있을 때만 실제 실행.
  */
 
-test.describe("골든패스: 가입 → 메뉴 → 판매 → 마진", () => {
+test.describe("골든패스: 가입 → 메뉴 → 매입 → 판매 → 마진", () => {
   test.skip(!hasSupabaseTestEnv, "Supabase env not configured — golden path E2E skipped");
 
   let user: TestUser;
@@ -30,47 +31,74 @@ test.describe("골든패스: 가입 → 메뉴 → 판매 → 마진", () => {
     if (user?.id) await cleanupTestUser(user.id);
   });
 
-  test("로그인 후 빙수카페 템플릿 불러오기 + 팥빙수 1개 판매 입력", async ({ page }) => {
+  test("템플릿 → 매입(얼음 1000g @ 5000원) → 팥빙수 1개 판매 → 마진 ~83%", async ({ page }) => {
     // 1) 로그인
     await page.goto("/login");
     await dismissConsentBanner(page);
-
     await page.getByLabel("이메일").fill(user.email);
     await page.getByLabel("비밀번호").fill(user.password);
     await page.getByRole("button", { name: /로그인/ }).click();
-
     await expect(page).toHaveURL(/\/today/, { timeout: 10_000 });
 
-    // 2) 메뉴 → 콜드스타트 다이얼로그
+    // 2) 메뉴 템플릿 (빙수카페 8종)
     await page.goto("/menu");
     await expect(page.getByRole("heading", { name: "템플릿으로 빠르게 시작" })).toBeVisible();
-
-    // 빙수카페가 기본 선택. 불러오기 클릭.
     await page.getByRole("button", { name: "템플릿 불러오기" }).click();
-
-    // 8종 메뉴 행 등장 (다이얼로그 자동 사라짐)
     await expect(page.getByRole("link", { name: /팥빙수/ })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByRole("link", { name: /망고빙수/ })).toBeVisible();
 
-    // 3) 판매 입력 화면
+    // 3) 매입 등록 — 얼음만 매입해 단가 형성. 다른 재료는 0원 유지(부분 마진).
+    await page.goto("/purchase");
+
+    // 거래처: 신규 추가. 폼 input들의 name 속성 직접 지정 (라벨이 PurchaseForm 안에서 중복 매칭됨).
+    await page.getByRole("button", { name: "+ 신규" }).first().click();
+    await page.locator('input[name="name"]').fill("E2E 도매상");
+    await page.locator('input[name="leadTimeDays"]').fill("1");
+
+    // save_vendor RPC 응답 + 캐시 invalidate + select 모드 복귀 + 새 vendor가 option으로 등장 — 모두 대기
+    const saveVendorResponse = page.waitForResponse((res) =>
+      res.url().includes("/rest/v1/rpc/save_vendor"),
+    );
+    await page.getByRole("button", { name: "추가", exact: true }).click();
+    await saveVendorResponse;
+    await expect(page.locator('select[name="vendorId"]')).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator('select[name="vendorId"] option', { hasText: "E2E 도매상" }),
+    ).toBeAttached({ timeout: 10_000 });
+
+    // 항목: 얼음 select + 수량 1000 + 금액 5000 (단가 5원/g)
+    // react-hook-form의 name 속성 직접 사용 — 라벨은 중첩 구조로 모호함.
+    await page.locator('select[name="items.0.ingredientId"]').selectOption({ label: "얼음 (g)" });
+    await page.locator('input[name="items.0.quantity"]').fill("1000");
+    await page.locator('input[name="items.0.amount"]').fill("5000");
+
+    // 매입 저장 + RPC 응답 대기. 폼 검증 + 가중평균 계산 + history insert 등으로
+    // 가끔 dev 서버가 느려지는 경우가 있어 timeout 여유.
+    const savePurchaseResponse = page.waitForResponse(
+      (res) => res.url().includes("/rest/v1/rpc/save_purchase"),
+      { timeout: 20_000 },
+    );
+    await page.getByRole("button", { name: "매입 저장" }).click();
+    const response = await savePurchaseResponse;
+    expect(response.status()).toBe(200);
+
+    // 첫 매입 → ±5% alert 없음 → 즉시 /inventory
+    await expect(page).toHaveURL(/\/inventory/, { timeout: 10_000 });
+
+    // 4) 판매 입력: 팥빙수 +1
     await page.goto("/sale");
-
-    // 메뉴 리스트 로딩 대기
     const palbingsuRow = page.getByRole("listitem").filter({ hasText: "팥빙수" });
     await expect(palbingsuRow).toBeVisible({ timeout: 10_000 });
-
-    // 팥빙수 +1
     await palbingsuRow.getByRole("button", { name: /수량 \+1/ }).click();
 
-    // 4) StickyTotalCard에 MARGIN_LABEL 표시 (헌법 III).
-    // 라벨이 보이면 sticky card가 preview를 받아 렌더링된 것 — 매출/원가는
-    // 메뉴 가격 행과 텍스트가 겹쳐 별도 검증하지 않음.
+    // 5) 실시간 마진율 검증
+    // 팥빙수 = 얼음 300g × 5원 = 1500원 원가 (다른 재료 단가 0)
+    // 매출 9000원, 순수익 7500원, 마진율 (7500/9000) × 100 ≈ 83%
     await expect(page.getByText("재료 원가 기준 (이동평균법)")).toBeVisible();
+    await expect(page.getByText(/마진 83%/)).toBeVisible();
+    // 100%이면 매입 흐름이 단가에 반영 안 된 것
+    await expect(page.getByText("마진 100%")).not.toBeVisible();
 
-    // 마진율: 모든 단가 0이라 100% 표시 (Phase 5 매입 후 실제 단가 반영됨)
-    await expect(page.getByText("마진 100%")).toBeVisible();
-
-    // 5) 저장 → /today 복귀
+    // 6) 저장 → /today 복귀
     const saveButton = page.getByRole("button", { name: /1개 저장/ });
     await saveButton.scrollIntoViewIfNeeded();
     await saveButton.click();

--- a/tests/helpers/test-supabase.ts
+++ b/tests/helpers/test-supabase.ts
@@ -16,7 +16,12 @@ const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABAS
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const ANON_KEY = process.env.SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export const hasSupabaseTestEnv = Boolean(SUPABASE_URL && SERVICE_ROLE_KEY && ANON_KEY);
+// CI workflow가 secret 미설정 시 placeholder fallback을 주입하므로 명시적으로 제외.
+const isPlaceholder = (v?: string): boolean =>
+  !v || v === "placeholder" || v.includes("placeholder.supabase.co");
+
+export const hasSupabaseTestEnv =
+  !isPlaceholder(SUPABASE_URL) && !isPlaceholder(SERVICE_ROLE_KEY) && !isPlaceholder(ANON_KEY);
 
 export interface TestUser {
   id: string;


### PR DESCRIPTION
## What

### 1. 골든패스 E2E 확장
이전 4단계(로그인 → 메뉴 → 판매 → 마진)에 **매입 단계 추가**:

```
로그인 → 메뉴 템플릿(빙수카페 8종) → 매입 등록(얼음 1000g @ 5000원)
       → 팥빙수 +1 → 마진 ~83% 검증 → 저장
```

**의의**: 단가 0 콜드스타트가 아닌 **실제 가격 형성 후 마진** 흐름 회귀 가드. 페르소나 5분 가치 사이클 풀 검증.

### 2. 안정성 개선

- `save_vendor` / `save_purchase` RPC 응답을 `waitForResponse`로 명시 대기 — race 방지
- form input/select에 `name` 속성 명시 → 중첩 구조에서도 stable selector
- `VendorQuickCreate` / `IngredientQuickCreate`를 `<div>`로 변경
  - **버그 픽스**: 외부 PurchaseForm `<form>` 안에 들어가는 inline UI라 중첩 form이 invalid HTML이었음. "추가" 버튼 클릭이 외부 form GET 제출로 hijack되어 querystring으로 폭주하던 문제 해결

### 3. CI E2E 활성화

`.github/workflows/ci.yml`의 e2e job:
- `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY`를 GitHub Secrets에서 주입
- secrets 없으면 placeholder fallback → 골든패스만 자동 skip, smoke test는 그대로
- build/start step의 env 중복 제거 (job 레벨 env로 단일 출처)

## ⚠️ 사용자 작업 필요

이 PR 머지 후 CI에서 골든패스를 실제로 돌리려면 GitHub repo Settings → Secrets and variables → Actions에 다음 secrets 추가:

- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
- `SUPABASE_SERVICE_ROLE_KEY`

(로컬 `.env.local` 값 그대로 복사)

추가 안 해도 CI는 그린 — 골든패스 skip만 됨.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test` ✅ **94/94**
- `npm run test:e2e -- golden-path` ✅ **2회 연속 그린, 31~32초**

Closes #40