### PR TITLE
chore(ci): SUPABASE_URL / SUPABASE_ANON_KEY (non-prefixed) secrets 허용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,10 @@ jobs:
     needs: build
     # secrets가 설정돼 있으면 실제 cloud 연결, 없으면 placeholder로 fallback —
     # 골든패스 테스트는 hasSupabaseTestEnv 게이트로 자동 skip.
+    # NEXT_PUBLIC_ prefix 없는 secret도 허용 (supabase CLI 컨벤션).
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder' }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.SUPABASE_URL || 'https://placeholder.supabase.co' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.SUPABASE_ANON_KEY || 'placeholder' }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
사용자 repo가 이미 supabase CLI 컨벤션으로 등록한 secrets:
- `SUPABASE_URL` (NEXT_PUBLIC_ prefix 없음)
- `SUPABASE_ANON_KEY`
- `SUPABASE_SERVICE_ROLE_KEY`

기존 workflow는 `NEXT_PUBLIC_SUPABASE_URL`만 봐서 cloud 연결 안 됐음. 양쪽 이름 모두 인식하도록 fallback chain 추가:

```yaml
NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.SUPABASE_URL || 'https://placeholder.supabase.co' }}
```

머지 후 다음 PR부터 CI에서 골든패스 E2E 실제 실행 (cloud DB hit).