### PR TITLE
chore(ci): test-unit job에도 SUPABASE secrets 주입 (RLS/통합 테스트 활성화)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
     name: Unit + Integration Tests
     runs-on: ubuntu-latest
     needs: lint-and-typecheck
+    # secrets 있으면 통합/RLS 테스트도 cloud hit, 없으면 hasSupabaseTestEnv로 skip.
+    # (e2e job과 동일한 fallback chain — supabase CLI / Next.js 양쪽 컨벤션 모두 허용)
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.SUPABASE_URL || '' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.SUPABASE_ANON_KEY || '' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
기존엔 e2e job만 cloud hit. unit job은 통합/RLS 테스트 **37개를 자동 skip**.

이 PR로 unit job에도 동일 secrets 주입 → 매 PR마다 통합/RLS 테스트도 cloud DB에서 회귀 검증.

## 효과

| 이전 | 이후 |
|------|------|
| CI Unit job: 57 통과 / **37 skip** | CI Unit job: **94/94 통과** |
| RLS 정책 회귀 / 트랜잭션 순서 버그 → 로컬에서만 잡힘 | PR 단계에서 즉시 잡힘 |

## Trade-off

- CI 실행 시간 ~30초 증가 (RLS 19 + sale 9 + purchase 5 + menu 4 = 37 tests, cloud RTT)
- Cloud DB에 테스트 유저 일시 생성 (createTestUser → cleanupTestUser cascade로 자동 정리)
- Free 플랜 한도 내 — 테스트 유저는 즉시 삭제되어 누적 안 됨

## env fallback (e2e job과 동일)

- `NEXT_PUBLIC_SUPABASE_URL || SUPABASE_URL || ''`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY || SUPABASE_ANON_KEY || ''`
- `SUPABASE_SERVICE_ROLE_KEY`

빈 값이면 `hasSupabaseTestEnv` false → skip. placeholder 주입 불필요 (test는 prod build 안 함).