### PR TITLE
feat(domain): 재고 소진 예측 + 유닛 테스트 (Phase 6 PR 30)

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -264,8 +264,8 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### 도메인 로직 (테스트 우선)
 
-- [ ] T120 [P] [US4] Write unit test `tests/unit/forecast.test.ts` covering: 요일별 가중 평균, 거래처 리드타임, 안전여유 1일, 콜드스타트(7일 이내), ±20% 급증 감지, 정기휴무 제외 (with synthetic 10+ scenarios per research R4)
-- [ ] T121 [US4] Implement domain function `src/lib/domain/forecast.ts` to satisfy T120; consumes regular-days-off helpers
+- [x] T120 [P] [US4] Write unit test `tests/unit/forecast.test.ts` covering: 요일별 가중 평균, 거래처 리드타임, 안전여유 1일, 콜드스타트(7일 이내), ±20% 급증 감지, 정기휴무 제외 (with synthetic 10+ scenarios per research R4)
+- [x] T121 [US4] Implement domain function `src/lib/domain/forecast.ts` to satisfy T120; consumes regular-days-off helpers
 
 ### 데이터 모델 + RPC
 

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -1,0 +1,193 @@
+import { Decimal } from "./_decimal";
+import { isRegularDayOff, weekdayOf, type Weekday } from "./regular-days-off";
+
+/**
+ * 재료 소진 예측 (FR-012/013/018/025/042).
+ *
+ * 입력: 재료의 일별 소비량 + 정기휴무 + 가입일.
+ * 출력: 예상 소진일 + status + trend + 콜드스타트 여부.
+ *
+ * 핵심 로직:
+ *  1. 콜드스타트 (가입 ≤ 7일) → 모든 항목 isColdStart=true, 예측 안 함
+ *  2. 요일별 가중 평균 산정 (정기휴무 제외)
+ *  3. 오늘부터 일별 시뮬레이션 (정기휴무는 소비 0)
+ *  4. 리드타임 + 안전여유 1일 차감해 status 분류
+ *  5. trend는 7일 평균 vs 30일 평균 ±20% 비교
+ */
+
+const COLD_START_DAYS = 7;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const SAFETY_BUFFER_DAYS = 1;
+const MAX_FORECAST_DAYS = 365;
+const TREND_THRESHOLD = 0.2;
+
+export type DepletionStatus = "safe" | "caution" | "order_needed" | "critical";
+export type ConsumptionTrend = "normal" | "rising" | "falling";
+
+export interface DailyConsumption {
+  date: Date;
+  amount: number;
+}
+
+export interface ForecastInput {
+  currentStock: number;
+  leadTimeDays: number;
+  consumptionSamples: readonly DailyConsumption[];
+  daysOff: readonly Weekday[];
+  signupDate: Date;
+  today: Date;
+}
+
+export interface ForecastResult {
+  expectedDepletionDate: Date | null;
+  status: DepletionStatus;
+  trend: ConsumptionTrend;
+  isColdStart: boolean;
+}
+
+export function isColdStart(signupDate: Date, today: Date): boolean {
+  const elapsed = today.getTime() - signupDate.getTime();
+  return elapsed < COLD_START_DAYS * ONE_DAY_MS;
+}
+
+/**
+ * 정기휴무 제외한 요일별 평균 소비량.
+ * 같은 요일의 sample들을 평균. 데이터 없는 요일은 Map에 키 없음 (호출 측 default 0).
+ */
+export function computeWeekdayUsageAverage(
+  samples: readonly DailyConsumption[],
+  daysOff: readonly Weekday[],
+): Map<Weekday, Decimal> {
+  const buckets = new Map<Weekday, { sum: Decimal; count: number }>();
+  for (const s of samples) {
+    if (isRegularDayOff(s.date, daysOff)) continue;
+    const wk = weekdayOf(s.date);
+    const bucket = buckets.get(wk) ?? { sum: new Decimal(0), count: 0 };
+    bucket.sum = bucket.sum.plus(s.amount);
+    bucket.count += 1;
+    buckets.set(wk, bucket);
+  }
+  const avg = new Map<Weekday, Decimal>();
+  for (const [wk, { sum, count }] of buckets) {
+    avg.set(wk, count === 0 ? new Decimal(0) : sum.dividedBy(count));
+  }
+  return avg;
+}
+
+/**
+ * 오늘부터 하루씩 시뮬레이션. 정기휴무는 소비 0.
+ * 1년 내 소진 안 하면 null (충분히 여유).
+ */
+export function predictDepletionDate({
+  currentStock,
+  weekdayAvg,
+  today,
+  daysOff,
+}: {
+  currentStock: number;
+  weekdayAvg: ReadonlyMap<Weekday, Decimal>;
+  today: Date;
+  daysOff: readonly Weekday[];
+}): Date | null {
+  let stock = new Decimal(currentStock);
+
+  for (let offset = 1; offset <= MAX_FORECAST_DAYS; offset++) {
+    const day = new Date(today.getTime() + offset * ONE_DAY_MS);
+    if (isRegularDayOff(day, daysOff)) continue;
+
+    const usage = weekdayAvg.get(weekdayOf(day)) ?? new Decimal(0);
+    if (usage.isZero()) continue; // 데이터 없는 요일 → 소비 미정, 패스
+
+    stock = stock.minus(usage);
+    if (stock.isNegative() || stock.isZero()) return day;
+  }
+  return null;
+}
+
+/**
+ * 리드타임 + 안전여유 1일 빼고 남은 buffer일 수로 status 분류 (FR-013).
+ * - buffer ≤ 1: critical (당일/익일 소진 임박)
+ * - buffer == 2: order_needed (지금 발주해야)
+ * - buffer 3~4: caution
+ * - buffer ≥ 5: safe
+ *
+ * 데이터 부족(depletionDate=null)은 safe.
+ */
+export function classifyStatus(
+  depletionDate: Date | null,
+  leadTimeDays: number,
+  today: Date,
+): DepletionStatus {
+  if (!depletionDate) return "safe";
+
+  const daysUntilDepletion = Math.max(
+    0,
+    Math.floor((depletionDate.getTime() - today.getTime()) / ONE_DAY_MS),
+  );
+  const buffer = daysUntilDepletion - leadTimeDays - SAFETY_BUFFER_DAYS;
+
+  if (buffer <= 1) return "critical";
+  if (buffer === 2) return "order_needed";
+  if (buffer <= 4) return "caution";
+  return "safe";
+}
+
+/**
+ * 7일 평균 vs 30일 평균. ±20% 이상이면 rising/falling.
+ * 데이터 부족 (30일 평균 0) → normal.
+ *
+ * 30일 미만 sample이면 분모가 30 고정이라 평균이 희석됨 — 호출 측이
+ * `isColdStart` 게이트로 가입 7일 이내를 차단한다는 가정 (forecastIngredient는
+ * 그렇게 함). 단독 호출 시 결과 해석에 주의.
+ */
+export function detectTrend(samples: readonly DailyConsumption[], today: Date): ConsumptionTrend {
+  const last7Avg = averageOverDays(samples, today, 7);
+  const last30Avg = averageOverDays(samples, today, 30);
+
+  if (last30Avg.isZero()) return "normal";
+  const ratio = last7Avg.dividedBy(last30Avg).toNumber();
+  if (ratio > 1 + TREND_THRESHOLD) return "rising";
+  if (ratio < 1 - TREND_THRESHOLD) return "falling";
+  return "normal";
+}
+
+function averageOverDays(
+  samples: readonly DailyConsumption[],
+  today: Date,
+  windowDays: number,
+): Decimal {
+  const cutoff = today.getTime() - windowDays * ONE_DAY_MS;
+  const inWindow = samples.filter((s) => s.date.getTime() >= cutoff);
+  if (inWindow.length === 0) return new Decimal(0);
+  const sum = inWindow.reduce((acc, s) => acc.plus(s.amount), new Decimal(0));
+  return sum.dividedBy(windowDays);
+}
+
+/**
+ * 한 재료의 예측 합성 함수 — 호출 측 (UI / RPC) 진입점.
+ */
+export function forecastIngredient(input: ForecastInput): ForecastResult {
+  if (isColdStart(input.signupDate, input.today)) {
+    return {
+      expectedDepletionDate: null,
+      status: "safe",
+      trend: "normal",
+      isColdStart: true,
+    };
+  }
+
+  const weekdayAvg = computeWeekdayUsageAverage(input.consumptionSamples, input.daysOff);
+  const depletionDate = predictDepletionDate({
+    currentStock: input.currentStock,
+    weekdayAvg,
+    today: input.today,
+    daysOff: input.daysOff,
+  });
+
+  return {
+    expectedDepletionDate: depletionDate,
+    status: classifyStatus(depletionDate, input.leadTimeDays, input.today),
+    trend: detectTrend(input.consumptionSamples, input.today),
+    isColdStart: false,
+  };
+}

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import { Decimal } from "@/lib/domain/_decimal";
+import {
+  classifyStatus,
+  computeWeekdayUsageAverage,
+  detectTrend,
+  forecastIngredient,
+  isColdStart,
+  predictDepletionDate,
+  type DailyConsumption,
+} from "@/lib/domain/forecast";
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+const today = new Date("2026-04-30T00:00:00");
+
+function daysAgo(days: number): Date {
+  return new Date(today.getTime() - days * ONE_DAY);
+}
+
+describe("isColdStart (FR-018)", () => {
+  it("가입 후 7일 미만은 콜드스타트", () => {
+    expect(isColdStart(daysAgo(6), today)).toBe(true);
+  });
+
+  it("가입 후 정확히 7일은 콜드스타트 아님 (만 7일 데이터 누적 가정)", () => {
+    expect(isColdStart(daysAgo(7), today)).toBe(false);
+  });
+
+  it("가입 30일 후는 일반", () => {
+    expect(isColdStart(daysAgo(30), today)).toBe(false);
+  });
+});
+
+describe("computeWeekdayUsageAverage", () => {
+  it("같은 요일 sample들의 평균", () => {
+    // 월요일(2026-04-27) 여러 개
+    const samples: DailyConsumption[] = [
+      { date: new Date("2026-04-27"), amount: 10 }, // 월
+      { date: new Date("2026-04-20"), amount: 20 }, // 월
+      { date: new Date("2026-04-13"), amount: 30 }, // 월
+    ];
+    const avg = computeWeekdayUsageAverage(samples, []);
+    expect(avg.get("MON")?.toString()).toBe("20");
+  });
+
+  it("정기휴무 요일은 평균 산정에서 제외 (FR-042)", () => {
+    const samples: DailyConsumption[] = [
+      { date: new Date("2026-04-27"), amount: 100 }, // 월
+      { date: new Date("2026-04-28"), amount: 50 }, // 화 (정기휴무)
+      { date: new Date("2026-04-29"), amount: 80 }, // 수
+    ];
+    const avg = computeWeekdayUsageAverage(samples, ["TUE"]);
+    expect(avg.has("TUE")).toBe(false);
+    expect(avg.get("MON")?.toString()).toBe("100");
+    expect(avg.get("WED")?.toString()).toBe("80");
+  });
+
+  it("샘플 비어있으면 빈 Map", () => {
+    expect(computeWeekdayUsageAverage([], []).size).toBe(0);
+  });
+});
+
+describe("predictDepletionDate", () => {
+  it("재고 100, 매일 10g 소비 → 11일 뒤 소진", () => {
+    const weekdayAvg = new Map([
+      ["MON", new Decimal(10)],
+      ["TUE", new Decimal(10)],
+      ["WED", new Decimal(10)],
+      ["THU", new Decimal(10)],
+      ["FRI", new Decimal(10)],
+      ["SAT", new Decimal(10)],
+      ["SUN", new Decimal(10)],
+    ] as const);
+    const result = predictDepletionDate({
+      currentStock: 100,
+      weekdayAvg,
+      today,
+      daysOff: [],
+    });
+    expect(result).not.toBeNull();
+    // 시작 다음 날부터 -10씩, 10일째에 0 도달
+    const expected = new Date(today.getTime() + 10 * ONE_DAY);
+    expect(result?.toDateString()).toBe(expected.toDateString());
+  });
+
+  it("정기휴무는 소비 0 (재고 보존)", () => {
+    const weekdayAvg = new Map([
+      ["MON", new Decimal(50)],
+      ["TUE", new Decimal(50)],
+      ["WED", new Decimal(50)],
+      ["THU", new Decimal(50)],
+      ["FRI", new Decimal(50)],
+      ["SAT", new Decimal(50)],
+      ["SUN", new Decimal(50)],
+    ] as const);
+    // 오늘 목(2026-04-30), 매일 50g, stock 250g.
+    // daysOff 없음: 금(200) → 토(150) → 일(100) → 월(50) → 화(0) = 5일째 화요일 소진
+    // SUN off: 금(200) → 토(150) → 일(skip) → 월(100) → 화(50) → 수(0) = 6일째 수요일 소진
+    const noSundayResult = predictDepletionDate({
+      currentStock: 250,
+      weekdayAvg,
+      today,
+      daysOff: ["SUN"],
+    });
+    const allDaysResult = predictDepletionDate({
+      currentStock: 250,
+      weekdayAvg,
+      today,
+      daysOff: [],
+    });
+    expect(noSundayResult!.getTime()).toBeGreaterThan(allDaysResult!.getTime());
+  });
+
+  it("예측 1년 내 소진 안 하면 null", () => {
+    const weekdayAvg = new Map([["MON", new Decimal(0.001)]] as const);
+    const result = predictDepletionDate({
+      currentStock: 1_000_000,
+      weekdayAvg,
+      today,
+      daysOff: [],
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("classifyStatus (FR-013)", () => {
+  it("데이터 부족(depletionDate=null) → safe", () => {
+    expect(classifyStatus(null, 1, today)).toBe("safe");
+  });
+
+  it("buffer ≤ 1 → critical", () => {
+    // 소진 1일 후, 리드타임 0, 안전여유 1 → buffer = 0 → critical
+    const date = new Date(today.getTime() + 1 * ONE_DAY);
+    expect(classifyStatus(date, 0, today)).toBe("critical");
+  });
+
+  it("buffer == 2 → order_needed", () => {
+    // 소진 4일 후, 리드타임 1, 안전여유 1 → buffer = 2 → order_needed
+    const date = new Date(today.getTime() + 4 * ONE_DAY);
+    expect(classifyStatus(date, 1, today)).toBe("order_needed");
+  });
+
+  it("buffer 3~4 → caution", () => {
+    // 소진 6일 후, 리드타임 1, 안전여유 1 → buffer = 4 → caution
+    const date = new Date(today.getTime() + 6 * ONE_DAY);
+    expect(classifyStatus(date, 1, today)).toBe("caution");
+  });
+
+  it("buffer ≥ 5 → safe", () => {
+    const date = new Date(today.getTime() + 10 * ONE_DAY);
+    expect(classifyStatus(date, 1, today)).toBe("safe");
+  });
+
+  it("리드타임 긴 거래처는 더 빨리 critical", () => {
+    // 소진 5일 후, 리드타임 5 → buffer = -1 → critical
+    const date = new Date(today.getTime() + 5 * ONE_DAY);
+    expect(classifyStatus(date, 5, today)).toBe("critical");
+  });
+});
+
+describe("detectTrend (FR-025)", () => {
+  it("7일 평균 = 30일 평균 → normal", () => {
+    const samples: DailyConsumption[] = Array.from({ length: 30 }, (_, i) => ({
+      date: daysAgo(i + 1),
+      amount: 100,
+    }));
+    expect(detectTrend(samples, today)).toBe("normal");
+  });
+
+  it("최근 7일이 30일 평균보다 +20% 초과 → rising", () => {
+    const samples: DailyConsumption[] = Array.from({ length: 30 }, (_, i) => ({
+      date: daysAgo(i + 1),
+      // 최근 7일은 200, 그 이후 23일은 100 → 30일 평균 = (7*200 + 23*100) / 30 = 123.3
+      // 7일 평균 = 200, ratio = 200/123.3 = 1.62 → rising
+      amount: i < 7 ? 200 : 100,
+    }));
+    expect(detectTrend(samples, today)).toBe("rising");
+  });
+
+  it("최근 7일이 30일 평균보다 -20% 초과 → falling", () => {
+    const samples: DailyConsumption[] = Array.from({ length: 30 }, (_, i) => ({
+      date: daysAgo(i + 1),
+      amount: i < 7 ? 50 : 100,
+    }));
+    expect(detectTrend(samples, today)).toBe("falling");
+  });
+
+  it("데이터 부족(빈 배열) → normal", () => {
+    expect(detectTrend([], today)).toBe("normal");
+  });
+});
+
+describe("forecastIngredient (합성)", () => {
+  const baseSamples = (): DailyConsumption[] =>
+    Array.from({ length: 30 }, (_, i) => ({
+      date: daysAgo(i + 1),
+      amount: 10,
+    }));
+
+  it("콜드스타트 → 예측 안 함, isColdStart=true", () => {
+    const result = forecastIngredient({
+      currentStock: 100,
+      leadTimeDays: 1,
+      consumptionSamples: baseSamples(),
+      daysOff: [],
+      signupDate: daysAgo(3),
+      today,
+    });
+    expect(result.isColdStart).toBe(true);
+    expect(result.expectedDepletionDate).toBeNull();
+    expect(result.status).toBe("safe");
+    expect(result.trend).toBe("normal");
+  });
+
+  it("정상 영업: 합성 출력 형식 검증", () => {
+    const result = forecastIngredient({
+      currentStock: 50,
+      leadTimeDays: 1,
+      consumptionSamples: baseSamples(),
+      daysOff: [],
+      signupDate: daysAgo(60),
+      today,
+    });
+    expect(result.isColdStart).toBe(false);
+    expect(result.expectedDepletionDate).toBeInstanceOf(Date);
+    expect(["safe", "caution", "order_needed", "critical"]).toContain(result.status);
+    expect(["normal", "rising", "falling"]).toContain(result.trend);
+  });
+
+  it("정기휴무 적용 — daysOff가 예측에 반영됨", () => {
+    const noOffDay = forecastIngredient({
+      currentStock: 100,
+      leadTimeDays: 1,
+      consumptionSamples: baseSamples(),
+      daysOff: [],
+      signupDate: daysAgo(60),
+      today,
+    });
+    const oneOffDay = forecastIngredient({
+      currentStock: 100,
+      leadTimeDays: 1,
+      consumptionSamples: baseSamples(),
+      daysOff: ["SUN"],
+      signupDate: daysAgo(60),
+      today,
+    });
+    if (noOffDay.expectedDepletionDate && oneOffDay.expectedDepletionDate) {
+      expect(oneOffDay.expectedDepletionDate.getTime()).toBeGreaterThanOrEqual(
+        noOffDay.expectedDepletionDate.getTime(),
+      );
+    }
+  });
+});


### PR DESCRIPTION
Phase 6 첫 PR — 재고 소진 예측 핵심 도메인 (TDD). simplify 패스 통과 (1 fix 반영).

## What

`src/lib/domain/forecast.ts`:
- **`isColdStart`** (FR-018): 가입 < 7일
- **`computeWeekdayUsageAverage`**: 정기휴무 제외 요일별 평균 (FR-042)
- **`predictDepletionDate`**: 일별 시뮬레이션 (정기휴무 소비 0)
- **`classifyStatus`** (FR-013): buffer = 소진일수 - 리드타임 - 안전여유1일
  - ≤1: `critical` / ==2: `order_needed` / 3~4: `caution` / ≥5: `safe`
- **`detectTrend`** (FR-025): 7일 평균 vs 30일 평균 ±20%
- **`forecastIngredient`**: 합성 진입점 (콜드스타트 게이트 → 위 함수들 조합)

`tests/unit/forecast.test.ts` — **22 tests**:
- isColdStart 경계 (6/7/30일)
- 요일별 평균 + 정기휴무 제외
- 시뮬레이션 + 1년 내 소진 안 함 → null
- status 분류 4 케이스 + 리드타임 영향
- trend rising/falling/normal
- 합성 동작 (콜드스타트 / 정상 / 정기휴무 영향)

## Simplify (1 fix)

`detectTrend` JSDoc 보강 — 30일 미만 sample이면 평균이 희석되는 점 명시. `forecastIngredient`는 isColdStart 게이트로 막아주지만 단독 호출 시 주의.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test` ✅ **116/116** (22 신규 + 94 기존)
- `npm run build` ✅

## 다음 PR

PR 31: `daily_stock_counts` / `stock_count_items` 마이그레이션 + `apply_stock_count` / `get_depletion_forecast` RPC + Zod + 통합 테스트.

Closes #44