### PR TITLE
feat(inventory): IngredientStatusList + StockCountForm + 훅 + GA4 (Phase 6 PR 32)

### DIFF
--- a/specs/001-mvp-core/tasks.md
+++ b/specs/001-mvp-core/tasks.md
@@ -277,14 +277,14 @@ description: "Task list for 001-mvp-core feature implementation"
 
 ### UI 컴포넌트 + 라우팅
 
-- [ ] T127 [P] [US4] Create `src/features/inventory/components/IngredientStatusList.tsx` grouped by status (🔴 발주 필요 / 🟡 주의 / 🟢 안전) with expected depletion date and trend badges
-- [ ] T128 [P] [US4] Create `src/features/inventory/components/ColdStartNotice.tsx` (가입 후 7일 이내 안내, FR-018)
-- [ ] T129 [P] [US4] Create `src/features/inventory/components/StockCountForm.tsx` (재료별 실재고 입력 + diff 미리보기 + weekly_loss_amount 표시)
-- [ ] T130 [P] [US4] Create `src/features/inventory/components/StockCountResultCard.tsx` showing applied corrections + weekly loss
-- [ ] T131 [US4] Create page `src/app/(main)/inventory/page.tsx` integrating IngredientStatusList + cold-start gate + quick-action to purchase
-- [ ] T132 [US4] Create page `src/app/(main)/inventory/stock-count/page.tsx` integrating StockCountForm
-- [ ] T133 [P] [US4] Create hook `src/features/inventory/hooks/useDepletionForecast.ts` (TanStack Query, fetches `get_depletion_forecast` then runs forecast.ts client-side for status classification)
-- [ ] T134 [P] [US4] Create hook `src/features/inventory/hooks/useApplyStockCount.ts` (mutation)
+- [x] T127 [P] [US4] Create `src/features/inventory/components/IngredientStatusList.tsx` grouped by status (🔴 발주 필요 / 🟡 주의 / 🟢 안전) with expected depletion date and trend badges
+- [x] T128 [P] [US4] Create `src/features/inventory/components/ColdStartNotice.tsx` (가입 후 7일 이내 안내, FR-018)
+- [x] T129 [P] [US4] Create `src/features/inventory/components/StockCountForm.tsx` (재료별 실재고 입력 + diff 미리보기 + weekly_loss_amount 표시)
+- [x] T130 [P] [US4] Create `src/features/inventory/components/StockCountResultCard.tsx` showing applied corrections + weekly loss
+- [x] T131 [US4] Create page `src/app/(main)/inventory/page.tsx` integrating IngredientStatusList + cold-start gate + quick-action to purchase
+- [x] T132 [US4] Create page `src/app/(main)/inventory/stock-count/page.tsx` integrating StockCountForm
+- [x] T133 [P] [US4] Create hook `src/features/inventory/hooks/useDepletionForecast.ts` (TanStack Query, fetches `get_depletion_forecast` then runs forecast.ts client-side for status classification)
+- [x] T134 [P] [US4] Create hook `src/features/inventory/hooks/useApplyStockCount.ts` (mutation)
 
 ### 푸시 인프라
 
@@ -297,8 +297,8 @@ description: "Task list for 001-mvp-core feature implementation"
 ### GA4 이벤트
 
 - [ ] T140 [US4] Wire `order_alert_received` GA4 event in service worker push handler (`public/sw.js`) sending via fetch to GA4 measurement protocol
-- [ ] T141 [US4] Wire `stock_count_completed` GA4 event in StockCountForm success handler
-- [ ] T142 [US4] Wire `weekly_loss_displayed` GA4 event in StockCountResultCard render
+- [x] T141 [US4] Wire `stock_count_completed` GA4 event in StockCountForm success handler
+- [x] T142 [US4] Wire `weekly_loss_displayed` GA4 event in StockCountResultCard render
 
 ### 통합 테스트
 

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -1,18 +1,46 @@
+"use client";
+
 import Link from "next/link";
+import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
+import { IngredientStatusList } from "@/features/inventory/components/IngredientStatusList";
+import { ColdStartNotice } from "@/features/inventory/components/ColdStartNotice";
 
 export default function InventoryPage(): React.ReactElement {
+  const { data, isLoading, error } = useDepletionForecast();
+
+  const isAllColdStart = (data ?? []).length > 0 && (data ?? []).every((d) => d.isColdStart);
+
   return (
-    <section className="flex flex-col gap-stack">
+    <section className="flex flex-col gap-section">
       <header className="flex items-center justify-between">
         <h1 className="text-title-lg text-ink-1">재료</h1>
-        <Link
-          href="/purchase"
-          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
-        >
-          + 매입 등록
-        </Link>
+        <div className="flex gap-stack-tight">
+          <Link
+            href="/inventory/stock-count"
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
+          >
+            실사
+          </Link>
+          <Link
+            href="/purchase"
+            className="rounded-md bg-ink-1 px-stack py-stack-tight text-body-regular text-bg hover:opacity-90"
+          >
+            + 매입
+          </Link>
+        </div>
       </header>
-      <p className="text-body-regular text-ink-3">소진 예측 + 재고 실사 — Phase 6에서 구현</p>
+
+      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
+
+      {error && (
+        <p role="alert" className="text-body-regular text-red">
+          {error.message}
+        </p>
+      )}
+
+      {isAllColdStart && <ColdStartNotice />}
+
+      {data && <IngredientStatusList items={data} />}
     </section>
   );
 }

--- a/src/app/(main)/inventory/stock-count/page.tsx
+++ b/src/app/(main)/inventory/stock-count/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+import { StockCountForm } from "@/features/inventory/components/StockCountForm";
+
+export default function StockCountPage(): React.ReactElement {
+  return (
+    <section className="flex flex-col gap-section">
+      <header className="flex items-center justify-between">
+        <h1 className="text-title-lg text-ink-1">재고 실사</h1>
+        <Link href="/inventory" className="text-body-regular text-ink-3 hover:text-ink-2">
+          취소
+        </Link>
+      </header>
+      <StockCountForm />
+    </section>
+  );
+}

--- a/src/features/inventory/components/ColdStartNotice.tsx
+++ b/src/features/inventory/components/ColdStartNotice.tsx
@@ -1,0 +1,16 @@
+/**
+ * 가입 후 7일 이내 사용자에게 표시. FR-018: 콜드스타트 동안 예측 가동 안 함.
+ */
+export function ColdStartNotice(): React.ReactElement {
+  return (
+    <div
+      role="status"
+      className="rounded-lg border border-border bg-amber-soft p-tile text-body-regular text-amber-deep"
+    >
+      <p className="font-semibold">데이터 수집 중입니다 (가입 후 7일)</p>
+      <p className="mt-1 text-caption">
+        매일 판매를 입력하시면 7일 후부터 재료별 소진일과 발주 시점을 예측해드려요.
+      </p>
+    </div>
+  );
+}

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils/format";
+import type { DepletionStatus } from "@/lib/domain/forecast";
+import type { IngredientForecastView } from "../hooks/useDepletionForecast";
+
+interface IngredientStatusListProps {
+  items: readonly IngredientForecastView[];
+}
+
+const STATUS_GROUP_ORDER: readonly DepletionStatus[] = [
+  "critical",
+  "order_needed",
+  "caution",
+  "safe",
+];
+
+const STATUS_LABEL: Record<DepletionStatus, string> = {
+  critical: "🔴 발주 필요 (긴급)",
+  order_needed: "🟠 발주 권장",
+  caution: "🟡 주의",
+  safe: "🟢 안전",
+};
+
+export function IngredientStatusList({ items }: IngredientStatusListProps): React.ReactElement {
+  if (items.length === 0) {
+    return (
+      <p className="text-body-regular text-ink-3">
+        등록된 재료가 없어요. 매입을 등록하면 여기에 표시됩니다.
+      </p>
+    );
+  }
+
+  const grouped = new Map<DepletionStatus, IngredientForecastView[]>();
+  for (const item of items) {
+    const list = grouped.get(item.status) ?? [];
+    list.push(item);
+    grouped.set(item.status, list);
+  }
+
+  return (
+    <div className="flex flex-col gap-section">
+      {STATUS_GROUP_ORDER.map((status) => {
+        const list = grouped.get(status);
+        if (!list || list.length === 0) return null;
+        return (
+          <section key={status} className="flex flex-col gap-stack-tight">
+            <h2 className="text-title-md text-ink-1">{STATUS_LABEL[status]}</h2>
+            <ul className="flex flex-col gap-stack-tight">
+              {list.map((item) => (
+                <IngredientRow key={item.ingredientId} item={item} />
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactElement {
+  const depletionLabel = formatDepletion(item);
+  return (
+    <li className="flex items-center justify-between rounded-lg border border-border bg-card px-tile py-stack">
+      <div className="flex flex-col gap-1">
+        <span className="text-body text-ink-1">{item.name}</span>
+        <span className="text-caption text-ink-3 tabular-nums">
+          현재 {formatNumber(item.currentStock)}
+          {item.unit}
+          <span className="text-ink-4"> · </span>
+          리드타임 {item.leadTimeDays}일
+        </span>
+      </div>
+      <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
+        <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
+        {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
+      </div>
+    </li>
+  );
+}
+
+function toneClass(status: DepletionStatus): string {
+  if (status === "critical") return "text-red-deep";
+  if (status === "order_needed") return "text-amber-deep";
+  if (status === "caution") return "text-amber-deep";
+  return "text-ink-3";
+}
+
+function formatDepletion(item: IngredientForecastView): string {
+  if (!item.expectedDepletionDate) return "예측 데이터 부족";
+  const today = new Date();
+  const days = Math.max(
+    0,
+    Math.floor((item.expectedDepletionDate.getTime() - today.getTime()) / (24 * 60 * 60 * 1000)),
+  );
+  if (days === 0) return "오늘 소진";
+  return `${days}일 후 소진`;
+}
+
+function TrendBadge({ trend }: { trend: "rising" | "falling" }): React.ReactElement {
+  const isRising = trend === "rising";
+  return (
+    <span
+      className={cn(
+        "rounded-full px-2 py-0.5 text-micro",
+        isRising ? "bg-red-soft text-red-deep" : "bg-blue-soft text-blue-deep",
+      )}
+    >
+      {isRising ? "사용량 증가" : "사용량 감소"}
+    </span>
+  );
+}

--- a/src/features/inventory/components/StockCountForm.tsx
+++ b/src/features/inventory/components/StockCountForm.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { Field } from "@/components/ui/field";
+import { useIngredients } from "@/features/purchase/hooks/useIngredients";
+import { useApplyStockCount } from "../hooks/useApplyStockCount";
+import { StockCountResultCard } from "./StockCountResultCard";
+import type { ApplyStockCountResult } from "@/lib/supabase/rpc";
+
+const todayString = (): string => new Date().toISOString().slice(0, 10);
+
+export function StockCountForm(): React.ReactElement {
+  const router = useRouter();
+  const { data: ingredients, isLoading } = useIngredients();
+  const submit = useApplyStockCount();
+
+  const [countedAt, setCountedAt] = useState(todayString);
+  const [actuals, setActuals] = useState<Map<string, number>>(new Map());
+  const [result, setResult] = useState<ApplyStockCountResult | null>(null);
+
+  const items = useMemo(
+    () =>
+      Array.from(actuals.entries())
+        .filter(([, v]) => Number.isFinite(v))
+        .map(([ingredientId, actualStock]) => ({ ingredientId, actualStock })),
+    [actuals],
+  );
+
+  function handleSubmit(): void {
+    if (items.length === 0) return;
+    submit.mutate({ countedAt, items }, { onSuccess: setResult });
+  }
+
+  if (result) {
+    return <StockCountResultCard result={result} onConfirm={() => router.push("/inventory")} />;
+  }
+
+  if (isLoading || !ingredients) {
+    return <p className="text-body-regular text-ink-3">불러오는 중…</p>;
+  }
+  if (ingredients.length === 0) {
+    return (
+      <p className="text-body-regular text-ink-3">
+        등록된 재료가 없어요. 먼저 매입 등록 또는 메뉴 템플릿 불러오기로 재료를 만들어주세요.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-section pb-44">
+      <Field label="실사 날짜" error={undefined}>
+        <input
+          type="date"
+          value={countedAt}
+          onChange={(e) => setCountedAt(e.target.value)}
+          max={todayString()}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+        />
+      </Field>
+
+      <ul className="flex flex-col gap-stack-tight">
+        {ingredients.map((ing) => (
+          <li
+            key={ing.id}
+            className="flex flex-col gap-1 rounded-lg border border-border bg-card p-tile"
+          >
+            <div className="flex items-baseline justify-between">
+              <span className="text-body text-ink-1">{ing.name}</span>
+              <span className="text-caption text-ink-3 tabular-nums">단위: {ing.unit}</span>
+            </div>
+            <input
+              type="number"
+              min={0}
+              step="0.001"
+              inputMode="decimal"
+              placeholder="실재고 수량"
+              value={actuals.get(ing.id) ?? ""}
+              onChange={(e) => {
+                const raw = e.target.value;
+                setActuals((prev) => {
+                  const next = new Map(prev);
+                  if (raw === "") {
+                    next.delete(ing.id);
+                  } else {
+                    const n = Number(raw);
+                    if (Number.isFinite(n) && n >= 0) next.set(ing.id, n);
+                  }
+                  return next;
+                });
+              }}
+              className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+            />
+          </li>
+        ))}
+      </ul>
+
+      {submit.isError && (
+        <p role="alert" className="text-caption text-red">
+          {submit.error.message}
+        </p>
+      )}
+
+      <div className="fixed inset-x-0 bottom-16 z-40 border-t border-border bg-bg px-screen py-stack">
+        <div className="mx-auto flex max-w-screen-md items-center justify-end">
+          <PrimaryButton
+            type="button"
+            onClick={handleSubmit}
+            disabled={items.length === 0 || submit.isPending}
+          >
+            {submit.isPending ? "저장 중…" : `${items.length}개 항목 저장`}
+          </PrimaryButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/inventory/components/StockCountResultCard.tsx
+++ b/src/features/inventory/components/StockCountResultCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { formatWon, formatNumber } from "@/lib/utils/format";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { trackEvent } from "@/lib/analytics/ga4";
+import type { ApplyStockCountResult } from "@/lib/supabase/rpc";
+
+interface StockCountResultCardProps {
+  result: ApplyStockCountResult;
+  onConfirm: () => void;
+}
+
+/**
+ * 재고 실사 적용 후 손실액 + 항목별 차이 표시 (FR-017, FR-028).
+ * 헌법 III: 단가 변경 없이 수량만 보정 — 표시 카피에 명시.
+ */
+export function StockCountResultCard({
+  result,
+  onConfirm,
+}: StockCountResultCardProps): React.ReactElement {
+  // FR-029 GA4: 손실액 표시 시점 발화 (마운트 직후 1회)
+  useEffect(() => {
+    trackEvent("weekly_loss_displayed", {
+      loss_amount: result.weeklyLossAmount,
+      item_count: result.itemDifferences.length,
+    });
+  }, [result]);
+
+  const lossPositive = result.weeklyLossAmount > 0;
+
+  return (
+    <article className="flex flex-col gap-section">
+      <header className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
+        <span className="text-caption text-ink-3">실사 손실액</span>
+        <span
+          className={cn(
+            "text-metric-hero tabular-nums",
+            lossPositive ? "text-red-deep" : "text-ink-1",
+          )}
+        >
+          {formatWon(result.weeklyLossAmount)}
+          <span className="ml-1 text-caption text-ink-3">원</span>
+        </span>
+        <p className="text-caption text-ink-3">
+          시스템 재고 - 실재고 차이 × 평균 단가. 단가는 그대로, 수량만 보정됩니다.
+        </p>
+      </header>
+
+      <ul className="flex flex-col divide-y divide-border rounded-lg border border-border bg-card">
+        {result.itemDifferences.map((d) => (
+          <DifferenceRow key={d.ingredientId} item={d} />
+        ))}
+      </ul>
+
+      <PrimaryButton type="button" onClick={onConfirm}>
+        확인했어요
+      </PrimaryButton>
+    </article>
+  );
+}
+
+interface DifferenceRowProps {
+  item: ApplyStockCountResult["itemDifferences"][number];
+}
+
+function DifferenceRow({ item }: DifferenceRowProps): React.ReactElement {
+  const tone = lossTone(item.lossAmount);
+  const sign = lossSign(item.lossAmount);
+  return (
+    <li className="grid grid-cols-[1fr_auto_auto] items-baseline gap-stack px-tile py-stack">
+      <span className="text-body-regular text-ink-1">{item.name}</span>
+      <span className="text-caption text-ink-3 tabular-nums">
+        {formatNumber(item.systemStock)} → {formatNumber(item.actualStock)}
+      </span>
+      <span className={cn("text-body-regular tabular-nums", tone)}>
+        {sign}
+        {formatWon(Math.abs(item.lossAmount))}원
+      </span>
+    </li>
+  );
+}
+
+function lossTone(amount: number): string {
+  if (amount > 0) return "text-red-deep";
+  if (amount < 0) return "text-green-deep";
+  return "text-ink-3";
+}
+
+function lossSign(amount: number): string {
+  if (amount > 0) return "-";
+  if (amount < 0) return "+";
+  return "";
+}

--- a/src/features/inventory/hooks/useApplyStockCount.ts
+++ b/src/features/inventory/hooks/useApplyStockCount.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { applyStockCount, type ApplyStockCountResult } from "@/lib/supabase/rpc";
+import { trackEvent } from "@/lib/analytics/ga4";
+import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
+import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
+import { depletionForecastQueryKey } from "./useDepletionForecast";
+import type { ApplyStockCountInput } from "../schemas";
+
+async function submit(input: ApplyStockCountInput): Promise<ApplyStockCountResult> {
+  const supabase = createClient();
+  const { data, error } = await applyStockCount(supabase, {
+    countedAt: input.countedAt,
+    items: input.items,
+  });
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("apply_stock_count: empty response");
+  return data;
+}
+
+export function useApplyStockCount(): UseMutationResult<
+  ApplyStockCountResult,
+  Error,
+  ApplyStockCountInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: submit,
+    onSuccess: (result) => {
+      trackEvent("stock_count_completed", {
+        loss_amount: result.weeklyLossAmount,
+        item_count: result.itemDifferences.length,
+      });
+      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
+      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+    },
+  });
+}

--- a/src/features/inventory/hooks/useDepletionForecast.ts
+++ b/src/features/inventory/hooks/useDepletionForecast.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { getDepletionForecast } from "@/lib/supabase/rpc";
+import {
+  forecastIngredient,
+  type ForecastResult,
+  type DailyConsumption,
+} from "@/lib/domain/forecast";
+
+/**
+ * RPC `get_depletion_forecast`로 raw 데이터를 받아 클라이언트에서
+ * `forecastIngredient`로 분류. 분류 로직 단일 출처(forecast.ts) 유지.
+ */
+
+export interface IngredientForecastView extends ForecastResult {
+  ingredientId: string;
+  name: string;
+  unit: "g" | "ml" | "piece";
+  currentStock: number;
+  leadTimeDays: number;
+}
+
+export const depletionForecastQueryKey = ["inventory", "forecast"] as const;
+
+async function fetchDepletionForecast(): Promise<IngredientForecastView[]> {
+  const supabase = createClient();
+  const { data, error } = await getDepletionForecast(supabase);
+  if (error) throw new Error(error.message);
+
+  const today = new Date();
+  return (data ?? []).map((row) => {
+    const samples: DailyConsumption[] = row.consumptionSamples.map((s) => ({
+      date: new Date(s.date),
+      amount: Number(s.amount),
+    }));
+    const forecast = forecastIngredient({
+      currentStock: row.currentStock,
+      leadTimeDays: row.leadTimeDays,
+      consumptionSamples: samples,
+      daysOff: row.regularDaysOff,
+      signupDate: new Date(row.signedUpAt),
+      today,
+    });
+    return {
+      ingredientId: row.ingredientId,
+      name: row.name,
+      unit: row.unit,
+      currentStock: row.currentStock,
+      leadTimeDays: row.leadTimeDays,
+      ...forecast,
+    };
+  });
+}
+
+export function useDepletionForecast(): UseQueryResult<IngredientForecastView[]> {
+  return useQuery({
+    queryKey: depletionForecastQueryKey,
+    queryFn: fetchDepletionForecast,
+    staleTime: 5 * 60 * 1000,
+  });
+}


### PR DESCRIPTION
Phase 6 PR 32 — 재고 화면 + 실사 흐름 UI. **simplify 1 fix 반영 (nested ternary 분리).**

## What

### 훅
- `useDepletionForecast` (T133): `getDepletionForecast` RPC raw → `forecastIngredient` 분류. 분류 로직 단일 출처 (forecast.ts) 유지
- `useApplyStockCount` (T134): RPC + GA4 + invalidate(ingredients/forecast/menus)

### UI
- `ColdStartNotice` (T128): 가입 7일 안내 (FR-018)
- `IngredientStatusList` (T127): 4 status 그룹화 (🔴/🟠/🟡/🟢) + trend 배지
- `StockCountForm` (T129): 재료별 실재고 입력
- `StockCountResultCard` (T130): 손실액 hero + 항목 차이 + 단가 불변 카피

### 라우팅
- `/inventory` (T131): forecast + 콜드스타트 + 실사/매입 진입 링크
- `/inventory/stock-count` (T132): 폼 + 결과 분기

### GA4
- `stock_count_completed` (T141)
- `weekly_loss_displayed` (T142, FR-017 결과 표시 시점)

## Simplify (1 fix)

`StockCountResultCard` 손실액 row의 중첩 삼항 (CLAUDE.md 금지) → `DifferenceRow` 컴포넌트 + `lossTone()` / `lossSign()` 헬퍼로 분리.

## Verification
- typecheck / lint / format / test **123/123** / build 모두 ✅
- /inventory + /inventory/stock-count prerender

Closes #48