### PR TITLE
feat(dashboard): get_today_dashboard RPC + hook (Phase 7 PR 34)

### DIFF
--- a/src/features/dashboard/hooks/useTodayDashboard.ts
+++ b/src/features/dashboard/hooks/useTodayDashboard.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { getTodayDashboard, type TodayDashboardData } from "@/lib/supabase/rpc";
+
+export const todayDashboardQueryKey = ["dashboard", "today"] as const;
+
+async function fetchTodayDashboard(): Promise<TodayDashboardData> {
+  const supabase = createClient();
+  const { data, error } = await getTodayDashboard(supabase);
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("dashboard data missing");
+  return data;
+}
+
+export function useTodayDashboard(): UseQueryResult<TodayDashboardData> {
+  return useQuery({
+    queryKey: todayDashboardQueryKey,
+    queryFn: fetchTodayDashboard,
+    staleTime: 60 * 1000,
+  });
+}

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -305,6 +305,140 @@ export function unsubscribePush(client: ClientLike, endpoint: string): Promise<R
   return callRpc(client, "unsubscribe_push", { p_endpoint: endpoint });
 }
 
+export interface DashboardYesterday {
+  soldAt: string;
+  revenue: number;
+  netProfit: number;
+  marginPercent: number;
+  lastWeekRevenue: number;
+  revenueChangePercent: number | null;
+}
+
+export interface DashboardWeeklyChartPoint {
+  soldAt: string;
+  revenue: number;
+}
+
+export interface DashboardExpiryAlert {
+  ingredientId: string;
+  name: string;
+  expiryDate: string;
+  daysUntilExpiry: number;
+}
+
+export interface DashboardTopMenu {
+  menuId: string;
+  name: string;
+  unitsSold: number;
+  revenue: number;
+  netProfit: number;
+  marginPercent: number;
+}
+
+export interface DashboardLowMarginMenu {
+  menuId: string;
+  name: string;
+  marginPercent: number;
+  cause: string | null;
+}
+
+export interface TodayDashboardData {
+  storeName: string;
+  yesterday: DashboardYesterday;
+  weeklyChart: DashboardWeeklyChartPoint[];
+  expiryAlerts: DashboardExpiryAlert[];
+  missingYesterdaySale: boolean;
+  top3Menus: DashboardTopMenu[];
+  lowMarginMenu: DashboardLowMarginMenu | null;
+}
+
+// jsonb_build_object 가 numeric을 JSON number로 직렬화하므로 이 RPC는 모든 숫자가
+// 런타임에서 number 타입. snake_case → camelCase 매핑만 수행.
+interface TodayDashboardRaw {
+  store_name: string;
+  yesterday: {
+    sold_at: string;
+    revenue: number;
+    net_profit: number;
+    margin_percent: number;
+    last_week_revenue: number;
+    revenue_change_percent: number | null;
+  };
+  weekly_chart: Array<{ sold_at: string; revenue: number }>;
+  expiry_alerts: Array<{
+    ingredient_id: string;
+    name: string;
+    expiry_date: string;
+    days_until_expiry: number;
+  }>;
+  missing_yesterday_sale: boolean;
+  top3_menus: Array<{
+    menu_id: string;
+    name: string;
+    units_sold: number;
+    revenue: number;
+    net_profit: number;
+    margin_percent: number;
+  }>;
+  low_margin_menu: {
+    menu_id: string;
+    name: string;
+    margin_percent: number;
+    cause: string | null;
+  } | null;
+}
+
+export async function getTodayDashboard(
+  client: ClientLike,
+): Promise<RpcResult<TodayDashboardData>> {
+  const result = await callRpc<TodayDashboardRaw>(client, "get_today_dashboard");
+  if (result.error) {
+    return { data: null, error: result.error };
+  }
+  const raw = result.data!;
+  return {
+    data: {
+      storeName: raw.store_name,
+      yesterday: {
+        soldAt: raw.yesterday.sold_at,
+        revenue: raw.yesterday.revenue,
+        netProfit: raw.yesterday.net_profit,
+        marginPercent: raw.yesterday.margin_percent,
+        lastWeekRevenue: raw.yesterday.last_week_revenue,
+        revenueChangePercent: raw.yesterday.revenue_change_percent,
+      },
+      weeklyChart: raw.weekly_chart.map((p) => ({
+        soldAt: p.sold_at,
+        revenue: p.revenue,
+      })),
+      expiryAlerts: raw.expiry_alerts.map((e) => ({
+        ingredientId: e.ingredient_id,
+        name: e.name,
+        expiryDate: e.expiry_date,
+        daysUntilExpiry: e.days_until_expiry,
+      })),
+      missingYesterdaySale: raw.missing_yesterday_sale,
+      top3Menus: raw.top3_menus.map((m) => ({
+        menuId: m.menu_id,
+        name: m.name,
+        unitsSold: m.units_sold,
+        revenue: m.revenue,
+        netProfit: m.net_profit,
+        marginPercent: m.margin_percent,
+      })),
+      lowMarginMenu: raw.low_margin_menu
+        ? {
+            menuId: raw.low_margin_menu.menu_id,
+            name: raw.low_margin_menu.name,
+            marginPercent: raw.low_margin_menu.margin_percent,
+            cause: raw.low_margin_menu.cause,
+          }
+        : null,
+    },
+    error: null,
+  };
+}
+
 export async function getDepletionForecast(
   client: ClientLike,
 ): Promise<RpcResult<DepletionForecastRow[]>> {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -729,6 +729,7 @@ export type Database = {
           unit: Database["public"]["Enums"]["ingredient_unit"]
         }[]
       }
+      get_today_dashboard: { Args: never; Returns: Json }
       request_withdrawal: {
         Args: never
         Returns: {

--- a/supabase/migrations/025_get_today_dashboard_rpc.sql
+++ b/supabase/migrations/025_get_today_dashboard_rpc.sql
@@ -1,0 +1,202 @@
+-- Migration: get_today_dashboard RPC (Phase 7 / T146)
+-- Spec: FR-019/020/091, contracts/domain-rpc.md, patterns.md "홈 (오늘)"
+-- 헌법 III: 메뉴 마진은 sale_items.unit_price - menu_cost_snapshot (스냅샷, 영구 불변)
+-- 헌법 IV: security definer + auth.uid() 격리
+
+create or replace function public.get_today_dashboard()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_today date := current_date;
+  v_yesterday date := v_today - 1;
+  v_last_week_yesterday date := v_yesterday - 7;
+  v_week_start date := v_yesterday - 6;
+  v_store_name text;
+  v_y_revenue numeric := 0;
+  v_y_cost numeric := 0;
+  v_lw_revenue numeric := 0;
+  v_change_pct numeric;
+  v_missing_yesterday boolean;
+  v_weekly_chart jsonb;
+  v_expiry_alerts jsonb;
+  v_top3 jsonb;
+  v_low_id uuid;
+  v_low_name text;
+  v_low_margin_pct numeric;
+  v_low_margin jsonb;
+  v_cause_text text;
+begin
+  if v_user_id is null then
+    raise exception 'unauthenticated';
+  end if;
+
+  select store_name into v_store_name
+  from public.users
+  where id = v_user_id;
+
+  -- 어제 매출 + 원가. plpgsql SELECT INTO는 0 row 시 declared default를 NULL로 덮어쓰므로
+  -- 이후 coalesce로 다시 0 할당 (NULL 산술 방지).
+  select total_revenue, total_cost_snapshot
+    into v_y_revenue, v_y_cost
+    from public.sales
+   where user_id = v_user_id and sold_at = v_yesterday;
+
+  v_missing_yesterday := not found;
+  v_y_revenue := coalesce(v_y_revenue, 0);
+  v_y_cost := coalesce(v_y_cost, 0);
+
+  -- 지난주 같은 요일 매출 (FR-020)
+  select total_revenue
+    into v_lw_revenue
+    from public.sales
+   where user_id = v_user_id and sold_at = v_last_week_yesterday;
+
+  v_lw_revenue := coalesce(v_lw_revenue, 0);
+
+  if v_lw_revenue > 0 then
+    v_change_pct := round((v_y_revenue - v_lw_revenue) / v_lw_revenue * 100, 1);
+  end if;
+
+  -- 지난 7일 일별 매출 (어제까지). generate_series 결과를 select에서 ::date로 캐스팅 —
+  -- 인터벌 시리즈를 left join 키로 직접 쓰면 timestamp 비교가 발생해 left join이 어긋난다.
+  with day_series as (
+    select g::date as d
+    from generate_series(v_week_start, v_yesterday, '1 day'::interval) g
+  )
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'sold_at', day_series.d,
+      'revenue', coalesce(s.total_revenue, 0)
+    )
+    order by day_series.d asc
+  ), '[]'::jsonb)
+    into v_weekly_chart
+    from day_series
+    left join public.sales s
+      on s.user_id = v_user_id and s.sold_at = day_series.d;
+
+  -- 유통기한 임박 (오늘 ~ +3일)
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'ingredient_id', id,
+      'name', name,
+      'expiry_date', expiry_date,
+      'days_until_expiry', (expiry_date - v_today)
+    )
+    order by expiry_date asc
+  ), '[]'::jsonb)
+    into v_expiry_alerts
+    from public.ingredients
+   where user_id = v_user_id
+     and is_active = true
+     and expiry_date is not null
+     and expiry_date >= v_today
+     and expiry_date <= v_today + 3;
+
+  -- 이번 주 (지난 7일) 메뉴별 마진 집계 → top3 + 마진 하락 메뉴 1개를 단일 CTE로 한번만 산출.
+  -- order by에 menu_id 보조 키 추가 → 동률 시 결정적 순서 보장.
+  with menu_aggs as (
+    select
+      m.id as menu_id,
+      m.name,
+      sum(si.quantity)::int as units_sold,
+      sum(si.unit_price * si.quantity) as revenue,
+      sum((si.unit_price - si.menu_cost_snapshot) * si.quantity) as net_profit
+    from public.menus m
+    join public.sale_items si on si.menu_id = m.id and si.user_id = v_user_id
+    join public.sales s on s.id = si.sale_id and s.user_id = v_user_id
+    where m.user_id = v_user_id
+      and s.sold_at between v_week_start and v_yesterday
+    group by m.id, m.name
+    having sum(si.unit_price * si.quantity) > 0
+  ),
+  ranked as (
+    select menu_id, name, units_sold, revenue, net_profit,
+           net_profit / revenue as margin_ratio
+    from menu_aggs
+  ),
+  top3_rows as (
+    select * from ranked
+    order by margin_ratio desc, menu_id asc
+    limit 3
+  ),
+  low_row as (
+    select * from ranked
+    where margin_ratio < 0.30
+    order by margin_ratio asc, menu_id asc
+    limit 1
+  )
+  select
+    coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'menu_id', menu_id,
+        'name', name,
+        'units_sold', units_sold,
+        'revenue', revenue,
+        'net_profit', net_profit,
+        'margin_percent', round(margin_ratio * 100, 1)
+      ) order by margin_ratio desc, menu_id asc)
+      from top3_rows
+    ), '[]'::jsonb),
+    (select menu_id from low_row),
+    (select name from low_row),
+    (select round(margin_ratio * 100, 1) from low_row)
+    into v_top3, v_low_id, v_low_name, v_low_margin_pct;
+
+  if v_low_id is not null then
+    -- 원인 추정: 해당 메뉴 레시피 재료 중 최근 14일 단가 인상폭 가장 큰 재료
+    select i.name || ' 단가 ' ||
+           round((ph.new_avg_price - ph.previous_avg_price) / ph.previous_avg_price * 100)::text ||
+           '% 인상 영향'
+      into v_cause_text
+      from public.ingredient_price_history ph
+      join public.ingredients i on i.id = ph.ingredient_id
+      join public.recipe_items r on r.ingredient_id = ph.ingredient_id and r.menu_id = v_low_id
+     where ph.user_id = v_user_id
+       and ph.reason = 'purchase'
+       and ph.changed_at >= now() - interval '14 days'
+       and ph.new_avg_price > ph.previous_avg_price
+       and ph.previous_avg_price > 0
+     order by (ph.new_avg_price - ph.previous_avg_price) / ph.previous_avg_price desc
+     limit 1;
+
+    v_low_margin := jsonb_build_object(
+      'menu_id', v_low_id,
+      'name', v_low_name,
+      'margin_percent', v_low_margin_pct,
+      'cause', v_cause_text
+    );
+  end if;
+
+  return jsonb_build_object(
+    'store_name', v_store_name,
+    'yesterday', jsonb_build_object(
+      'sold_at', v_yesterday,
+      'revenue', v_y_revenue,
+      'net_profit', v_y_revenue - v_y_cost,
+      'margin_percent',
+        case when v_y_revenue > 0
+          then round((v_y_revenue - v_y_cost) / v_y_revenue * 100, 1)
+          else 0
+        end,
+      'last_week_revenue', v_lw_revenue,
+      'revenue_change_percent', v_change_pct
+    ),
+    'weekly_chart', v_weekly_chart,
+    'expiry_alerts', v_expiry_alerts,
+    'missing_yesterday_sale', v_missing_yesterday,
+    'top3_menus', v_top3,
+    'low_margin_menu', v_low_margin
+  );
+end;
+$$;
+
+grant execute on function public.get_today_dashboard() to authenticated;
+
+comment on function public.get_today_dashboard() is
+  '오늘 대시보드 (FR-019/020/091): 어제 KPI + 지난주 같은 요일 비교 + 7일 차트 + 유통기한 알림 + 이번 주 TOP3 메뉴 마진 + 마진 하락 메뉴 1개. 발주 알림(소진 예측)은 get_depletion_forecast()로 별도 호출. 헌법 III: sale_items.menu_cost_snapshot/unit_price 스냅샷만 사용 — 과거 마진 영구 불변.';

--- a/tests/integration/dashboard.test.ts
+++ b/tests/integration/dashboard.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  cleanupTestUser,
+  createTestUser,
+  getServiceRoleClient,
+  hasSupabaseTestEnv,
+  signInAs,
+  type TestUser,
+} from "../helpers/test-supabase";
+import { cloneMenuTemplate, getTodayDashboard } from "@/lib/supabase/rpc";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * `get_today_dashboard` RPC 통합 테스트 (Phase 7 / T146).
+ * - 어제 KPI 계산 (revenue, net_profit, margin)
+ * - 7일 차트 7개 entry
+ * - 지난주 같은 요일 비교 (admin client로 -8일 sale 직접 INSERT, save_sale 7일 윈도우 우회)
+ * - missing_yesterday_sale 토글
+ * - top3 메뉴 마진 정렬
+ */
+
+const describeDashboard = hasSupabaseTestEnv ? describe : describe.skip;
+
+// RPC가 server-side `current_date` (UTC) 기준이므로 클라이언트도 UTC 기준 날짜 산술.
+// setDate는 로컬 타임존 기반이라 DST 전환일 등 ±1일 오차 가능.
+const isoDate = (offsetDays: number): string => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+};
+
+describeDashboard("get_today_dashboard RPC", () => {
+  let user: TestUser;
+  let client: SupabaseClient<Database>;
+  let menuId: string;
+
+  beforeAll(async () => {
+    user = await createTestUser({ storeType: "cafe", storeName: "지영카페" });
+    client = await signInAs(user);
+
+    const cloneResult = await cloneMenuTemplate(client, { storeType: "cafe" });
+    expect(cloneResult.error).toBeNull();
+
+    const menu = await client.from("menus").select("id").eq("name", "아메리카노").single();
+    menuId = menu.data!.id;
+
+    const admin = getServiceRoleClient();
+    const ing = await admin
+      .from("ingredients")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("name", "원두")
+      .single();
+
+    await admin
+      .from("ingredients")
+      .update({ current_stock: 10000, current_avg_price: 50 })
+      .eq("id", ing.data!.id);
+  }, 60_000);
+
+  afterAll(async () => {
+    if (user?.id) await cleanupTestUser(user.id);
+  }, 30_000);
+
+  it("어제 sale 없을 때 missing_yesterday_sale=true + KPI 0", async () => {
+    const { data, error } = await getTodayDashboard(client);
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+    expect(data!.storeName).toBe("지영카페");
+    expect(data!.missingYesterdaySale).toBe(true);
+    expect(data!.yesterday.revenue).toBe(0);
+    expect(data!.yesterday.netProfit).toBe(0);
+    expect(data!.yesterday.marginPercent).toBe(0);
+    expect(data!.weeklyChart).toHaveLength(7);
+    expect(data!.top3Menus).toEqual([]);
+  });
+
+  it("다른 사용자의 sale은 누설되지 않는다 (헌법 IV)", async () => {
+    const otherUser = await createTestUser({ storeType: "cafe", storeName: "다른가게" });
+    const admin = getServiceRoleClient();
+
+    // 다른 사용자에게 거대 매출 sale 직접 INSERT
+    await admin.from("sales").insert({
+      user_id: otherUser.id,
+      sold_at: isoDate(-1),
+      total_revenue: 999999,
+      total_cost_snapshot: 0,
+    });
+
+    const { data, error } = await getTodayDashboard(client);
+    expect(error).toBeNull();
+    // 본인은 어제 sale 아직 없음 → revenue 0 / missing true 그대로
+    expect(data!.yesterday.revenue).toBe(0);
+    expect(data!.missingYesterdaySale).toBe(true);
+
+    await cleanupTestUser(otherUser.id);
+  });
+
+  it("어제 + 8일 전 sale 직접 INSERT → KPI + 지난주 비교 + top3 채움", async () => {
+    const admin = getServiceRoleClient();
+
+    // 어제 sale: 아메리카노 4500원 × 5 = 22500, 원두 18g × 50원 × 5 = 4500 cost
+    const yesterdaySale = await admin
+      .from("sales")
+      .insert({
+        user_id: user.id,
+        sold_at: isoDate(-1),
+        total_revenue: 22500,
+        total_cost_snapshot: 4500,
+      })
+      .select("id")
+      .single();
+    await admin.from("sale_items").insert({
+      sale_id: yesterdaySale.data!.id,
+      user_id: user.id,
+      menu_id: menuId,
+      quantity: 5,
+      unit_price: 4500,
+      menu_cost_snapshot: 900,
+    });
+
+    // 8일 전 sale (지난주 같은 요일): 매출 30000원 (어제보다 25% 낮음 → 어제 -25% 변화율 X, 어제가 22500/30000 = -25%)
+    const lastWeekSale = await admin
+      .from("sales")
+      .insert({
+        user_id: user.id,
+        sold_at: isoDate(-8),
+        total_revenue: 30000,
+        total_cost_snapshot: 6000,
+      })
+      .select("id")
+      .single();
+    await admin.from("sale_items").insert({
+      sale_id: lastWeekSale.data!.id,
+      user_id: user.id,
+      menu_id: menuId,
+      quantity: 6,
+      unit_price: 5000,
+      menu_cost_snapshot: 1000,
+    });
+
+    const { data, error } = await getTodayDashboard(client);
+    expect(error).toBeNull();
+
+    expect(data!.missingYesterdaySale).toBe(false);
+    expect(data!.yesterday.revenue).toBe(22500);
+    expect(data!.yesterday.netProfit).toBe(18000);
+    expect(data!.yesterday.marginPercent).toBe(80);
+    expect(data!.yesterday.lastWeekRevenue).toBe(30000);
+    expect(data!.yesterday.revenueChangePercent).toBe(-25);
+
+    // top3에 아메리카노 1개 (이번 주 윈도우는 7일이라 -8일은 제외)
+    expect(data!.top3Menus).toHaveLength(1);
+    expect(data!.top3Menus[0]?.name).toBe("아메리카노");
+    expect(data!.top3Menus[0]?.unitsSold).toBe(5);
+    expect(data!.top3Menus[0]?.marginPercent).toBe(80);
+    // 어제 차트 포인트 = 22500
+    const lastEntry = data!.weeklyChart[data!.weeklyChart.length - 1];
+    expect(lastEntry?.revenue).toBe(22500);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 7 PR 34 — 홈(오늘) 대시보드 데이터 레이어. T146 (`get_today_dashboard` RPC) + T152 (`useTodayDashboard` hook). UI 컴포넌트 + 페이지는 PR 35에서 별도 구현.

### 변경 내역

- **`supabase/migrations/025_get_today_dashboard_rpc.sql`** — `jsonb` 반환. 단일 호출로:
  - `yesterday`: 매출 / 순수익 / 마진율 + 지난주 같은 요일 매출 + 변화율 (FR-019/020)
  - `weekly_chart`: 지난 7일 일별 매출 (어제까지)
  - `expiry_alerts`: 유통기한 임박 (오늘 ~ +3일)
  - `missing_yesterday_sale`: 어제 sale 미입력 boolean (FR-091)
  - `top3_menus`: 이번 주 (지난 7일) 메뉴별 마진율 상위 3개
  - `low_margin_menu`: 30% 미만 최저 마진 메뉴 1개 + 원인 텍스트 (최근 14일 단가 인상 재료)
  - 발주 알림은 기존 `get_depletion_forecast()`로 별도 호출 (중복 회피)

- **`src/lib/supabase/rpc.ts`** — `getTodayDashboard` wrapper + `TodayDashboardData` types (camelCase 도메인 형태)

- **`src/features/dashboard/hooks/useTodayDashboard.ts`** — TanStack Query hook, staleTime 60s

- **`tests/integration/dashboard.test.ts`** — 3 케이스
  1. 어제 sale 없을 때 `missing_yesterday_sale=true` + KPI 0
  2. **다른 사용자 sale 누설 차단** (헌법 IV)
  3. 어제 + 8일 전 sale 직접 INSERT 시 KPI / 지난주 비교 / top3 정확도

### simplify 적용 사항 (3-agent 리뷰 → 6건 모두 적용)

| # | 카테고리 | 내용 |
|---|---------|------|
| 1 | SQL 버그 | `SELECT INTO`가 0 row 시 declared default를 NULL로 덮어씀 → `coalesce` 후처리 |
| 2 | SQL 버그 | `generate_series` cast 위치로 left join 키 timestamp 비교 발생 → select 절에서 `::date` 캐스팅 |
| 3 | SQL 결정성 | `top3` 동률 시 비결정적 순서 → `order by margin_ratio desc, menu_id asc` |
| 4 | SQL 효율 | `top3` + `low_margin` 중복 menu_aggs 집계 → 단일 CTE 공유 |
| 5 | TS 효율 | `number \| string` 유니온 + 모든 `Number()` 래핑 제거 (jsonb는 JSON number로 직렬화) |
| 6 | 테스트 | `setDate` (로컬 tz, DST 위험) → `setUTCDate` (서버 `current_date`와 일치) |

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 128/128 ✅ (dashboard 통합 +3)
- build ✅
- 마이그레이션 025 클라우드 적용 완료

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [ ] PR 35에서 UI 컴포넌트 통합 후 모바일 폭(375px)에서 페르소나 1분 흐름 수동 검증 (T154)

Refs T146 T152

🤖 Generated with [Claude Code](https://claude.com/claude-code)