### PR TITLE
feat(dashboard): 오늘 대시보드 UI + 페이지 + GA4 (Phase 7 PR 35)

### DIFF
--- a/src/app/(main)/today/page.tsx
+++ b/src/app/(main)/today/page.tsx
@@ -1,8 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useTodayDashboard } from "@/features/dashboard/hooks/useTodayDashboard";
+import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
+import { YesterdayKpiCard } from "@/features/dashboard/components/YesterdayKpiCard";
+import { AlertsCard } from "@/features/dashboard/components/AlertsCard";
+import { MarginTop3Card } from "@/features/dashboard/components/MarginTop3Card";
+import { MissingSaleBadge } from "@/features/dashboard/components/MissingSaleBadge";
+import { trackEvent } from "@/lib/analytics/ga4";
+import { formatTodayKo } from "@/lib/utils/format";
+
+/**
+ * 홈 (오늘) 대시보드 — patterns.md "홈" 위계 순서대로 렌더.
+ * 1) 헤더 + 어제 판매 미입력 배지 (FR-091)
+ * 2) 어제 KPI Hero
+ * 3) 오늘 할 일 알림 (발주/만료/입력)
+ * 4) 이번 주 메뉴 마진 TOP 3 + 마진 하락 메뉴
+ * 5) 빠른 입력 (매입 / 판매)
+ *
+ * 발주 알림은 useDepletionForecast로 별도 호출 (useTodayDashboard와 병렬).
+ */
 export default function TodayPage(): React.ReactElement {
+  const dashboard = useTodayDashboard();
+  const forecast = useDepletionForecast();
+  // SSR 렌더 시점과 클라이언트 hydrate 시점이 자정을 넘기면 날짜 라벨이 어긋나 hydration
+  // mismatch를 일으킨다. 클라이언트 마운트 후 effect로 채움.
+  const [todayLabel, setTodayLabel] = useState<string>("");
+
+  useEffect(() => {
+    setTodayLabel(formatTodayKo());
+  }, []);
+
+  useEffect(() => {
+    if (dashboard.data) {
+      trackEvent("dashboard_viewed", {
+        has_yesterday_sale: !dashboard.data.missingYesterdaySale,
+        top3_count: dashboard.data.top3Menus.length,
+      });
+    }
+  }, [dashboard.data]);
+
+  if (dashboard.isLoading) {
+    return <p className="text-body-regular text-ink-3">불러오는 중…</p>;
+  }
+  if (dashboard.error || !dashboard.data) {
+    return (
+      <p className="text-body-regular text-red-deep">
+        데이터를 불러오지 못했어요. 잠시 후 다시 시도해주세요.
+      </p>
+    );
+  }
+
+  const { data } = dashboard;
+
   return (
-    <section className="flex flex-col gap-stack">
-      <h1 className="text-title-lg text-ink-1">오늘</h1>
-      <p className="text-body-regular text-ink-3">대시보드 — 데이터 수집 중 (Phase 7에서 구현)</p>
+    <section className="flex flex-col gap-section">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-title-lg text-ink-1">{data.storeName}</h1>
+          <p className="text-caption text-ink-3">{todayLabel}</p>
+        </div>
+        {data.missingYesterdaySale && <MissingSaleBadge yesterdaySoldAt={data.yesterday.soldAt} />}
+      </header>
+
+      <YesterdayKpiCard yesterday={data.yesterday} weeklyChart={data.weeklyChart} />
+
+      <AlertsCard
+        depletionItems={forecast.data ?? []}
+        expiryAlerts={data.expiryAlerts}
+        missingYesterdaySale={data.missingYesterdaySale}
+        yesterdaySoldAt={data.yesterday.soldAt}
+      />
+
+      <MarginTop3Card top3={data.top3Menus} lowMargin={data.lowMarginMenu} />
+
+      <nav className="grid grid-cols-2 gap-stack">
+        <QuickAction href="/purchase" label="매입 등록" />
+        <QuickAction href="/sale" label="판매 입력" />
+      </nav>
     </section>
+  );
+}
+
+interface QuickActionProps {
+  href: string;
+  label: string;
+}
+
+function QuickAction({ href, label }: QuickActionProps): React.ReactElement {
+  return (
+    <Link
+      href={href}
+      className="flex items-center justify-center rounded-xl border border-border bg-card py-3 text-body text-ink-1"
+    >
+      {label}
+    </Link>
   );
 }

--- a/src/features/dashboard/components/AlertsCard.tsx
+++ b/src/features/dashboard/components/AlertsCard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { daysUntilDate } from "@/lib/utils/format";
+import type { DashboardExpiryAlert } from "@/lib/supabase/rpc";
+import type { IngredientForecastView } from "@/features/inventory/hooks/useDepletionForecast";
+
+interface AlertsCardProps {
+  depletionItems: readonly IngredientForecastView[];
+  expiryAlerts: readonly DashboardExpiryAlert[];
+  missingYesterdaySale: boolean;
+  yesterdaySoldAt: string;
+}
+
+type AlertTone = "red" | "amber" | "blue";
+
+interface AlertEntry {
+  key: string;
+  tone: AlertTone;
+  title: string;
+  body: string;
+  href: string;
+}
+
+const TONE_CLASS: Record<AlertTone, { bg: string; text: string }> = {
+  red: { bg: "bg-red-soft", text: "text-red-deep" },
+  amber: { bg: "bg-amber-soft", text: "text-amber-deep" },
+  blue: { bg: "bg-blue-soft", text: "text-blue-deep" },
+};
+
+/**
+ * 오늘 할 일 알림 (patterns.md "홈" 위계 #3).
+ * 우선순위: 발주(red) > 만료(amber) > 입력(blue). 최대 4개 노출 — 그 이상은 "더보기" 링크로 위임.
+ */
+export function AlertsCard({
+  depletionItems,
+  expiryAlerts,
+  missingYesterdaySale,
+  yesterdaySoldAt,
+}: AlertsCardProps): React.ReactElement | null {
+  const alerts = buildAlerts(depletionItems, expiryAlerts, missingYesterdaySale, yesterdaySoldAt);
+  if (alerts.length === 0) return null;
+
+  const visible = alerts.slice(0, 4);
+  const remaining = alerts.length - visible.length;
+
+  return (
+    <section className="flex flex-col gap-stack-tight">
+      <h2 className="text-label text-ink-3">오늘 할 일</h2>
+      <ul className="flex flex-col gap-stack-tight">
+        {visible.map((alert) => (
+          <AlertRow key={alert.key} alert={alert} />
+        ))}
+      </ul>
+      {remaining > 0 && (
+        <Link href="/inventory" className="text-caption text-ink-3 underline">
+          + {remaining}개 더 보기
+        </Link>
+      )}
+    </section>
+  );
+}
+
+interface AlertRowProps {
+  alert: AlertEntry;
+}
+
+function AlertRow({ alert }: AlertRowProps): React.ReactElement {
+  const tone = TONE_CLASS[alert.tone];
+  return (
+    <li>
+      <Link
+        href={alert.href}
+        className={cn("flex items-start gap-stack-tight rounded-lg p-tile", tone.bg, tone.text)}
+      >
+        <div className="flex-1">
+          <div className="text-body">{alert.title}</div>
+          <div className="text-caption opacity-85">{alert.body}</div>
+        </div>
+        <span aria-hidden className="text-caption">
+          ›
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+function buildAlerts(
+  depletionItems: readonly IngredientForecastView[],
+  expiryAlerts: readonly DashboardExpiryAlert[],
+  missingYesterdaySale: boolean,
+  yesterdaySoldAt: string,
+): AlertEntry[] {
+  const result: AlertEntry[] = [];
+
+  // 1. 발주 (red) — critical + order_needed
+  for (const item of depletionItems) {
+    if (item.status !== "critical" && item.status !== "order_needed") continue;
+    const tone: AlertTone = item.status === "critical" ? "red" : "amber";
+    result.push({
+      key: `depletion-${item.ingredientId}`,
+      tone,
+      title:
+        item.status === "critical" ? `${item.name} 곧 소진 — 즉시 발주` : `${item.name} 발주 권장`,
+      body: depletionBody(item),
+      href: "/inventory",
+    });
+  }
+
+  // 2. 만료 (amber)
+  for (const e of expiryAlerts) {
+    result.push({
+      key: `expiry-${e.ingredientId}`,
+      tone: "amber",
+      title: `${e.name} 유통기한 ${expiryLabel(e.daysUntilExpiry)}`,
+      body: `만료일 ${e.expiryDate}`,
+      href: "/inventory",
+    });
+  }
+
+  // 3. 어제 입력 누락 (blue)
+  if (missingYesterdaySale) {
+    result.push({
+      key: "missing-sale",
+      tone: "blue",
+      title: "어제 판매 입력이 비어있어요",
+      body: "1분이면 끝나요. 마진이 바로 계산돼요.",
+      href: `/sale/${yesterdaySoldAt}`,
+    });
+  }
+
+  return result;
+}
+
+function depletionBody(item: IngredientForecastView): string {
+  const days = daysUntilDate(item.expectedDepletionDate);
+  if (days === null) return `현재 ${item.currentStock}${item.unit}`;
+  const prefix = days === 0 ? "오늘 소진 예상" : `${days}일 후 소진`;
+  return `${prefix} · 리드타임 ${item.leadTimeDays}일`;
+}
+
+function expiryLabel(days: number): string {
+  if (days <= 0) return "오늘 만료";
+  if (days === 1) return "내일 만료";
+  return `${days}일 남음`;
+}

--- a/src/features/dashboard/components/MarginTop3Card.tsx
+++ b/src/features/dashboard/components/MarginTop3Card.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils/format";
+import type { DashboardLowMarginMenu, DashboardTopMenu } from "@/lib/supabase/rpc";
+
+interface MarginTop3CardProps {
+  top3: readonly DashboardTopMenu[];
+  lowMargin: DashboardLowMarginMenu | null;
+}
+
+/**
+ * 이번 주 메뉴 마진 TOP 3 + 마진 하락 메뉴 1개 (patterns.md "홈" 위계 #4-5).
+ * 헌법 III: sale_items.menu_cost_snapshot 스냅샷 기반이므로 과거 마진 영구 불변.
+ */
+export function MarginTop3Card({
+  top3,
+  lowMargin,
+}: MarginTop3CardProps): React.ReactElement | null {
+  if (top3.length === 0 && !lowMargin) return null;
+
+  return (
+    <section className="flex flex-col gap-stack">
+      {top3.length > 0 && (
+        <div className="flex flex-col gap-stack-tight">
+          <h2 className="text-label text-ink-3">이번 주 마진 TOP 3</h2>
+          <ul className="rounded-xl border border-border bg-card">
+            {top3.map((menu, idx) => (
+              <TopRow
+                key={menu.menuId}
+                rank={idx + 1}
+                menu={menu}
+                isLast={idx === top3.length - 1}
+              />
+            ))}
+          </ul>
+          <p className="text-micro text-ink-3">재료 원가 기준 (이동평균법)</p>
+        </div>
+      )}
+
+      {lowMargin && <LowMarginAlert menu={lowMargin} />}
+    </section>
+  );
+}
+
+interface TopRowProps {
+  rank: number;
+  menu: DashboardTopMenu;
+  isLast: boolean;
+}
+
+function TopRow({ rank, menu, isLast }: TopRowProps): React.ReactElement {
+  const tone = marginTone(menu.marginPercent);
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-stack px-tile py-stack",
+        !isLast && "border-b border-border",
+      )}
+    >
+      <span className="w-5 text-micro tabular-nums text-ink-3">{rank}</span>
+      <span className="flex-1 text-body text-ink-1">{menu.name}</span>
+      <span className="text-caption tabular-nums text-ink-3">{formatNumber(menu.unitsSold)}잔</span>
+      <span className={cn("min-w-12 text-right text-metric-md tabular-nums", tone)}>
+        {menu.marginPercent.toFixed(0)}%
+      </span>
+    </li>
+  );
+}
+
+interface LowMarginAlertProps {
+  menu: DashboardLowMarginMenu;
+}
+
+function LowMarginAlert({ menu }: LowMarginAlertProps): React.ReactElement {
+  return (
+    <div className="flex items-start gap-stack-tight rounded-xl bg-red-soft p-tile">
+      <div className="flex-1">
+        <div className="text-body text-red-deep">
+          {menu.name} 마진 {menu.marginPercent.toFixed(0)}%로 하락
+        </div>
+        {menu.cause && <div className="text-caption text-red-deep opacity-85">{menu.cause}</div>}
+      </div>
+    </div>
+  );
+}
+
+function marginTone(margin: number): string {
+  if (margin >= 50) return "text-green-deep";
+  if (margin >= 30) return "text-amber-deep";
+  return "text-red-deep";
+}

--- a/src/features/dashboard/components/MissingSaleBadge.tsx
+++ b/src/features/dashboard/components/MissingSaleBadge.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+
+interface MissingSaleBadgeProps {
+  yesterdaySoldAt: string;
+}
+
+/**
+ * 어제 판매 미입력 알림 배지 (FR-091).
+ * 홈 헤더 옆 또는 하단에 배치 — AlertsCard의 입력 알림과 별개로 시각적 강조.
+ */
+export function MissingSaleBadge({ yesterdaySoldAt }: MissingSaleBadgeProps): React.ReactElement {
+  return (
+    <Link
+      href={`/sale/${yesterdaySoldAt}`}
+      aria-label="어제 판매 미입력 — 입력하러 가기"
+      className="inline-flex items-center gap-1 rounded-full bg-red px-2 py-0.5 text-micro text-bg"
+    >
+      <span aria-hidden>●</span>
+      어제 판매 미입력
+    </Link>
+  );
+}

--- a/src/features/dashboard/components/YesterdayKpiCard.tsx
+++ b/src/features/dashboard/components/YesterdayKpiCard.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatWon, weekdayKoFromIso } from "@/lib/utils/format";
+import type { DashboardYesterday, DashboardWeeklyChartPoint } from "@/lib/supabase/rpc";
+
+interface YesterdayKpiCardProps {
+  yesterday: DashboardYesterday;
+  weeklyChart: readonly DashboardWeeklyChartPoint[];
+}
+
+/**
+ * 어제 KPI Hero 카드 (patterns.md "홈" 위계 #2).
+ * - 매출 hero + 지난주 같은 요일 比 chip (FR-020)
+ * - 순수익 / 마진율 분리 표시 + "재료 원가 기준 (이동평균법)" 라벨 (FR-019)
+ * - 7일 미니 막대 차트 (어제만 ink-1, 나머지 ink-4)
+ */
+export function YesterdayKpiCard({
+  yesterday,
+  weeklyChart,
+}: YesterdayKpiCardProps): React.ReactElement {
+  const hasRevenue = yesterday.revenue > 0;
+  const maxRevenue = Math.max(...weeklyChart.map((p) => p.revenue), 1);
+
+  return (
+    <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
+      <header className="flex items-baseline justify-between">
+        <span className="text-caption text-ink-3">어제 매출</span>
+        <ChangeChip value={yesterday.revenueChangePercent} />
+      </header>
+
+      <div className="text-metric-hero tabular-nums text-ink-1">
+        {formatWon(yesterday.revenue)}
+        <span className="ml-1 text-caption text-ink-3">원</span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-stack border-t border-border pt-stack">
+        <KpiSlot label="순수익" value={hasRevenue ? `${formatWon(yesterday.netProfit)}원` : "—"} />
+        <KpiSlot
+          label="마진율"
+          value={hasRevenue ? `${yesterday.marginPercent.toFixed(1)}%` : "—"}
+        />
+      </div>
+
+      <p className="text-micro text-ink-3">재료 원가 기준 (이동평균법)</p>
+
+      <WeeklyMiniChart data={weeklyChart} maxRevenue={maxRevenue} highlightKey={yesterday.soldAt} />
+    </article>
+  );
+}
+
+interface KpiSlotProps {
+  label: string;
+  value: string;
+}
+
+function KpiSlot({ label, value }: KpiSlotProps): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-micro text-ink-3">{label}</span>
+      <span className="text-metric-md tabular-nums text-ink-1">{value}</span>
+    </div>
+  );
+}
+
+interface ChangeChipProps {
+  value: number | null;
+}
+
+function ChangeChip({ value }: ChangeChipProps): React.ReactElement | null {
+  if (value === null) {
+    return <span className="text-micro text-ink-3">지난주 데이터 없음</span>;
+  }
+  const isPositive = value >= 0;
+  return (
+    <span
+      className={cn(
+        "rounded-md px-2 py-0.5 text-micro tabular-nums",
+        isPositive ? "bg-green-soft text-green-deep" : "bg-red-soft text-red-deep",
+      )}
+    >
+      지난주 比 {isPositive ? "+" : ""}
+      {value.toFixed(1)}%
+    </span>
+  );
+}
+
+interface WeeklyMiniChartProps {
+  data: readonly DashboardWeeklyChartPoint[];
+  maxRevenue: number;
+  highlightKey: string;
+}
+
+function WeeklyMiniChart({
+  data,
+  maxRevenue,
+  highlightKey,
+}: WeeklyMiniChartProps): React.ReactElement {
+  return (
+    <div className="flex items-end gap-1 pt-stack-tight" aria-label="지난 7일 매출 차트">
+      {data.map((p) => {
+        const heightPct = (p.revenue / maxRevenue) * 100;
+        const isYesterday = p.soldAt === highlightKey;
+        const day = weekdayKoFromIso(p.soldAt);
+        return (
+          <div key={p.soldAt} className="flex flex-1 flex-col items-center gap-1">
+            <div className="flex h-10 w-full items-end">
+              <div
+                className={cn("w-full rounded-sm", isYesterday ? "bg-ink-1" : "bg-ink-4")}
+                style={{ height: `${Math.max(heightPct, 2)}%` }}
+              />
+            </div>
+            <span
+              className={cn(
+                "text-micro tabular-nums",
+                isYesterday ? "font-bold text-ink-1" : "text-ink-3",
+              )}
+            >
+              {day}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { formatNumber } from "@/lib/utils/format";
+import { daysUntilDate, formatNumber } from "@/lib/utils/format";
 import type { DepletionStatus } from "@/lib/domain/forecast";
 import type { IngredientForecastView } from "../hooks/useDepletionForecast";
 
@@ -88,12 +88,8 @@ function toneClass(status: DepletionStatus): string {
 }
 
 function formatDepletion(item: IngredientForecastView): string {
-  if (!item.expectedDepletionDate) return "예측 데이터 부족";
-  const today = new Date();
-  const days = Math.max(
-    0,
-    Math.floor((item.expectedDepletionDate.getTime() - today.getTime()) / (24 * 60 * 60 * 1000)),
-  );
+  const days = daysUntilDate(item.expectedDepletionDate);
+  if (days === null) return "예측 데이터 부족";
   if (days === 0) return "오늘 소진";
   return `${days}일 후 소진`;
 }

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,7 +1,9 @@
 /**
- * 한국어 화폐 / 숫자 포맷 유틸.
+ * 한국어 화폐 / 숫자 / 날짜 포맷 유틸.
  * 도메인 함수는 Decimal로 정밀도 보존, UI 표시 직전에 이 헬퍼로 변환.
  */
+
+import { differenceInCalendarDays } from "date-fns";
 
 export function formatWon(value: number): string {
   return Math.round(value).toLocaleString("ko-KR");
@@ -9,4 +11,40 @@ export function formatWon(value: number): string {
 
 export function formatNumber(value: number): string {
   return value.toLocaleString("ko-KR");
+}
+
+const WEEKDAY_KO = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+/**
+ * "YYYY-MM-DD" 문자열을 한국어 한 글자 요일로 변환.
+ * timezone 해석 회피 위해 date 부품을 직접 분해 (Date 생성자에 ISO 문자열 + Z 패스
+ * 사용 시 호스트 tz에 따라 ±1일 오차 가능).
+ */
+export function weekdayKoFromIso(iso: string): string {
+  const parts = iso.split("-").map(Number);
+  const [y, m, d] = parts;
+  if (y === undefined || m === undefined || d === undefined) return "";
+  return WEEKDAY_KO[new Date(y, m - 1, d).getDay()] ?? "";
+}
+
+/**
+ * 오늘 날짜를 "M월 D일 (요일)" 한국어 라벨로 반환.
+ * 클라이언트에서만 호출 — `new Date()`가 SSR/CSR 경계에서 다른 시각이 될 수 있어
+ * 서버 렌더링 본문에 직접 박지 말 것 (useEffect 또는 useState lazy init 권장).
+ */
+export function formatTodayKo(now: Date = new Date()): string {
+  const month = now.getMonth() + 1;
+  const date = now.getDate();
+  const day = WEEKDAY_KO[now.getDay()];
+  return `${month}월 ${date}일 (${day})`;
+}
+
+/**
+ * 예상 소진일까지 캘린더 일수 (오늘 기준). 시계 시각이 아니라 0시 기준 day diff —
+ * 23:59 vs 00:00 같은 날 안 차이가 1일로 잘못 보고되는 off-by-one 차단.
+ * `expectedDepletionDate`이 null이면 null 반환 (호출 측에서 "예측 부족" 처리).
+ */
+export function daysUntilDate(target: Date | null, now: Date = new Date()): number | null {
+  if (!target) return null;
+  return Math.max(0, differenceInCalendarDays(target, now));
 }


### PR DESCRIPTION
## Summary

Phase 7 PR 35 — 홈(오늘) 탭 UI 통합. T147~T151 + T153. PR 34에서 만든 `useTodayDashboard` 훅 + `useDepletionForecast` 훅을 단일 페이지에 결합.

### 변경 내역

**컴포넌트 4개 (`src/features/dashboard/components/`)**

- **`YesterdayKpiCard`** — 어제 매출 hero + 지난주 同요일 比 chip (FR-020) + 순수익/마진율 분리 + "재료 원가 기준 (이동평균법)" 라벨 (FR-019) + 7일 미니 막대 차트 (어제만 ink-1, 나머지 ink-4)
- **`AlertsCard`** — 발주(red) > 만료(amber) > 입력(blue) 순. `useDepletionForecast`(critical/order_needed) + `useTodayDashboard.expiryAlerts` + `missingYesterdaySale` 결합. 4개 초과 시 `/inventory` "더보기" 위임
- **`MarginTop3Card`** — 이번 주 마진 % 정렬 리스트 + 마진 30% 미만 메뉴 1개 + 원인 텍스트
- **`MissingSaleBadge`** — 어제 미입력 시 헤더 우측 빨간 pill (FR-091, aria-label 포함)

**페이지 (`src/app/(main)/today/page.tsx`)**
- `useTodayDashboard` + `useDepletionForecast` 병렬 호출
- patterns.md "홈" 위계 순서대로 렌더 (헤더 → KPI Hero → 알림 → TOP3 → 빠른 입력)
- `dashboard_viewed` GA4 발화 (T153)
- Loading/Error fallback

**유틸 (`src/lib/utils/format.ts`)**
- `weekdayKoFromIso(iso)` — date 부품 분해 기반 한국어 1글자 요일
- `formatTodayKo(now)` — "M월 D일 (요일)" 라벨
- `daysUntilDate(target, now)` — `differenceInCalendarDays` 기반 (off-by-one 차단)

### simplify 적용 사항 (3-agent 리뷰 → 5건 모두 적용)

| # | 카테고리 | 내용 |
|---|---------|------|
| 1 | 코드 재사용 | `WEEKDAY_KO` 두 파일 중복 → `weekdayKoFromIso` / `formatTodayKo` 통합 |
| 2 | 코드 재사용 | `AlertsCard.depletionBody`와 `IngredientStatusList.formatDepletion` 동일 days-until 계산 → `daysUntilDate` 공통화 |
| 3 | 정확성 | days-until 계산이 시계 시각 차이 사용 → `differenceInCalendarDays` (캘린더 일수 기준 off-by-one 차단) |
| 4 | 정확성 | `YesterdayKpiCard` 요일 계산이 `new Date(iso + "T00:00:00Z")` UTC 해석 fragile → date 부품 직접 분해 |
| 5 | 정확성 | `today/page.tsx` `formatTodayKo` SSR/CSR drift (자정 경계 hydration mismatch) → `useState` + `useEffect` 마운트 후 세팅 |
| 6 | 접근성 | `MissingSaleBadge` `aria-label="어제 판매 미입력 — 입력하러 가기"` 추가 |

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 128/128 ✅ (UI 컴포넌트 단위 테스트는 헌법 v1.3.0 의무 제외)
- build ✅

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [ ] **수동 UX 검증 (T154)**: 모바일 폭(375x667)에서 페르소나 1분 체크 흐름 — 어제 KPI 즉시 보임, 오늘 할 일 4개 이내, 마진 TOP3 한 화면, 빠른 입력 버튼 thumb-zone 안. 머지 후 `npm run dev`로 확인.

Refs T147 T148 T149 T150 T151 T153

🤖 Generated with [Claude Code](https://claude.com/claude-code)