### PR TITLE
feat(calendar): get_calendar_month RPC + 훅 (Phase 8 PR 36)

### DIFF
--- a/src/features/calendar/hooks/useCalendarMonth.ts
+++ b/src/features/calendar/hooks/useCalendarMonth.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { getCalendarMonth, type CalendarMonthData } from "@/lib/supabase/rpc";
+import { withConsecutiveMissingDays, type EnrichedCalendarCell } from "../lib/consecutive-missing";
+
+export interface CalendarMonthView extends Omit<CalendarMonthData, "cells"> {
+  cells: EnrichedCalendarCell[];
+}
+
+export const calendarMonthQueryKey = (year: number, month: number) =>
+  ["calendar", "month", year, month] as const;
+
+async function fetchCalendarMonth(year: number, month: number): Promise<CalendarMonthView> {
+  const supabase = createClient();
+  const { data, error } = await getCalendarMonth(supabase, { year, month });
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("calendar data missing");
+  return { ...data, cells: withConsecutiveMissingDays(data.cells) };
+}
+
+export function useCalendarMonth(year: number, month: number): UseQueryResult<CalendarMonthView> {
+  return useQuery({
+    queryKey: calendarMonthQueryKey(year, month),
+    queryFn: () => fetchCalendarMonth(year, month),
+    // 월간 데이터는 변동이 적고 sale/purchase 변경 시 명시적 invalidate가 더 정확.
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/features/calendar/lib/consecutive-missing.ts
+++ b/src/features/calendar/lib/consecutive-missing.ts
@@ -1,0 +1,25 @@
+import type { CalendarCell } from "@/lib/supabase/rpc";
+
+/**
+ * RPC가 반환한 날짜순 셀 배열에 `consecutiveMissingDays` 필드를 추가.
+ * - 해당 셀이 누락이면: 직전까지의 연속 누락일 수 + 1
+ * - 누락 아니면 0 (런 종료)
+ *
+ * 헌법 IV: 사용자별 데이터이므로 RPC가 user_id 격리 — 이 함수는 순수 변환.
+ * SQL window 함수 대신 단순 reduce로 처리해 SQL 복잡도 감소.
+ */
+export interface EnrichedCalendarCell extends CalendarCell {
+  consecutiveMissingDays: number;
+}
+
+export function withConsecutiveMissingDays(cells: readonly CalendarCell[]): EnrichedCalendarCell[] {
+  let counter = 0;
+  return cells.map((cell) => {
+    if (cell.isMissing) {
+      counter += 1;
+    } else {
+      counter = 0;
+    }
+    return { ...cell, consecutiveMissingDays: cell.isMissing ? counter : 0 };
+  });
+}

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -305,6 +305,95 @@ export function unsubscribePush(client: ClientLike, endpoint: string): Promise<R
   return callRpc(client, "unsubscribe_push", { p_endpoint: endpoint });
 }
 
+export interface CalendarCumulative {
+  totalRevenue: number;
+  totalNetProfit: number;
+  avgDailyRevenue: number;
+  operatingDays: number;
+}
+
+export interface CalendarCell {
+  date: string;
+  isFuture: boolean;
+  isBeforeSignup: boolean;
+  isRegularDayOff: boolean;
+  hasSale: boolean;
+  hasPurchase: boolean;
+  isMissing: boolean;
+  revenue: number | null;
+  netProfit: number | null;
+}
+
+export interface CalendarMonthData {
+  year: number;
+  month: number;
+  cumulative: CalendarCumulative;
+  cells: CalendarCell[];
+  marginLabel: string;
+}
+
+interface CalendarMonthRaw {
+  year: number;
+  month: number;
+  cumulative: {
+    total_revenue: number;
+    total_net_profit: number;
+    avg_daily_revenue: number;
+    operating_days: number;
+  };
+  cells: Array<{
+    date: string;
+    is_future: boolean;
+    is_before_signup: boolean;
+    is_regular_day_off: boolean;
+    has_sale: boolean;
+    has_purchase: boolean;
+    is_missing: boolean;
+    revenue: number | null;
+    net_profit: number | null;
+  }>;
+  margin_label: string;
+}
+
+export async function getCalendarMonth(
+  client: ClientLike,
+  args: { year: number; month: number },
+): Promise<RpcResult<CalendarMonthData>> {
+  const result = await callRpc<CalendarMonthRaw>(client, "get_calendar_month", {
+    p_year: args.year,
+    p_month: args.month,
+  });
+  if (result.error) {
+    return { data: null, error: result.error };
+  }
+  const raw = result.data!;
+  return {
+    data: {
+      year: raw.year,
+      month: raw.month,
+      cumulative: {
+        totalRevenue: raw.cumulative.total_revenue,
+        totalNetProfit: raw.cumulative.total_net_profit,
+        avgDailyRevenue: raw.cumulative.avg_daily_revenue,
+        operatingDays: raw.cumulative.operating_days,
+      },
+      cells: raw.cells.map((c) => ({
+        date: c.date,
+        isFuture: c.is_future,
+        isBeforeSignup: c.is_before_signup,
+        isRegularDayOff: c.is_regular_day_off,
+        hasSale: c.has_sale,
+        hasPurchase: c.has_purchase,
+        isMissing: c.is_missing,
+        revenue: c.revenue,
+        netProfit: c.net_profit,
+      })),
+      marginLabel: raw.margin_label,
+    },
+    error: null,
+  };
+}
+
 export interface DashboardYesterday {
   soldAt: string;
   revenue: number;

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -716,6 +716,10 @@ export type Database = {
           total_revenue: number
         }[]
       }
+      get_calendar_month: {
+        Args: { p_month: number; p_year: number }
+        Returns: Json
+      }
       get_depletion_forecast: {
         Args: never
         Returns: {

--- a/supabase/migrations/026_get_calendar_month_rpc.sql
+++ b/supabase/migrations/026_get_calendar_month_rpc.sql
@@ -1,0 +1,143 @@
+-- Migration: get_calendar_month RPC (Phase 8 / T155)
+-- Spec: contracts/domain-rpc.md "Calendar", FR-021~024, FR-043, FR-045
+-- 헌법 III: sales 스냅샷 (total_revenue / total_cost_snapshot)만 사용
+-- 헌법 IV: security definer + auth.uid() 격리
+-- consecutive_missing_days는 클라이언트에서 계산 (raw data + flag만 반환)
+
+create or replace function public.get_calendar_month(p_year int, p_month int)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_today date := current_date;
+  v_month_start date;
+  v_month_end date;
+  v_signed_up date;
+  v_days_off public.weekday[];
+  v_total_revenue numeric := 0;
+  v_total_net_profit numeric := 0;
+  v_operating_days int := 0;
+  v_avg_daily numeric := 0;
+  v_cells jsonb;
+begin
+  if v_user_id is null then
+    raise exception 'unauthenticated';
+  end if;
+  if p_month < 1 or p_month > 12 then
+    raise exception 'invalid_month' using errcode = '22023';
+  end if;
+
+  v_month_start := make_date(p_year, p_month, 1);
+  v_month_end := (v_month_start + interval '1 month - 1 day')::date;
+
+  select signed_up_at::date, regular_days_off
+    into v_signed_up, v_days_off
+    from public.users
+   where id = v_user_id;
+
+  -- users row 없거나 signed_up_at NULL이면 비교가 NULL이 되어 jsonb에 null로 직렬화 →
+  -- TS 측 boolean 타입 위반. fallback으로 월 시작일을 사용 (해당 월은 모두 가입 후로 간주).
+  v_signed_up := coalesce(v_signed_up, v_month_start);
+  v_days_off := coalesce(v_days_off, '{}');
+
+  -- 월 누적 (영업일 = sale 있는 날, 정기휴무 제외 자연스럽게)
+  select
+    coalesce(sum(total_revenue), 0),
+    coalesce(sum(total_revenue - total_cost_snapshot), 0),
+    count(*)
+    into v_total_revenue, v_total_net_profit, v_operating_days
+    from public.sales
+   where user_id = v_user_id
+     and sold_at between v_month_start and v_month_end;
+
+  if v_operating_days > 0 then
+    v_avg_daily := round(v_total_revenue / v_operating_days, 0);
+  end if;
+
+  -- 일별 셀 (28~31일)
+  with day_series as (
+    select g::date as d
+    from generate_series(v_month_start, v_month_end, '1 day'::interval) g
+  ),
+  daily_purchases as (
+    select distinct purchased_at as d
+    from public.purchase_orders
+    where user_id = v_user_id
+      and purchased_at between v_month_start and v_month_end
+  ),
+  enriched as (
+    select
+      ds.d,
+      (ds.d > v_today) as is_future,
+      (ds.d < v_signed_up) as is_before_signup,
+      (s.id is not null) as has_sale,
+      (p.d is not null) as has_purchase,
+      s.total_revenue as revenue,
+      case when s.id is not null
+           then s.total_revenue - s.total_cost_snapshot
+           else null
+      end as net_profit,
+      -- FR-045: 정기휴무 요일에 sale 있으면 예외 영업 → is_regular_day_off=false.
+      -- PG dow: 0=SUN, 1=MON, ... 6=SAT. 한 번만 계산해 is_missing에서 재사용.
+      ((case extract(dow from ds.d)::int
+          when 0 then 'SUN'::public.weekday
+          when 1 then 'MON'::public.weekday
+          when 2 then 'TUE'::public.weekday
+          when 3 then 'WED'::public.weekday
+          when 4 then 'THU'::public.weekday
+          when 5 then 'FRI'::public.weekday
+          when 6 then 'SAT'::public.weekday
+        end) = any(v_days_off)
+       and s.id is null) as is_regular_day_off
+    from day_series ds
+    left join public.sales s
+      on s.user_id = v_user_id and s.sold_at = ds.d
+    left join daily_purchases p
+      on p.d = ds.d
+  )
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'date', e.d,
+      'is_future', e.is_future,
+      'is_before_signup', e.is_before_signup,
+      'is_regular_day_off', e.is_regular_day_off,
+      'has_sale', e.has_sale,
+      'has_purchase', e.has_purchase,
+      -- 누락: 영업가능 + 정기휴무 아님 + sale 없음
+      'is_missing', (
+        not e.is_future
+        and not e.is_before_signup
+        and not e.is_regular_day_off
+        and not e.has_sale
+      ),
+      'revenue', e.revenue,
+      'net_profit', e.net_profit
+    )
+    order by e.d asc
+  ), '[]'::jsonb)
+    into v_cells
+    from enriched e;
+
+  return jsonb_build_object(
+    'year', p_year,
+    'month', p_month,
+    'cumulative', jsonb_build_object(
+      'total_revenue', v_total_revenue,
+      'total_net_profit', v_total_net_profit,
+      'avg_daily_revenue', v_avg_daily,
+      'operating_days', v_operating_days
+    ),
+    'cells', v_cells,
+    'margin_label', '재료 원가 기준 (이동평균법)'
+  );
+end;
+$$;
+
+grant execute on function public.get_calendar_month(int, int) to authenticated;
+
+comment on function public.get_calendar_month(int, int) is
+  '월간 캘린더 (FR-021~024, FR-043, FR-045): 월 누적 KPI + 일별 셀 (영업/누락/정기휴무/매입/매출). consecutive_missing_days는 클라이언트에서 셀 배열 순회로 계산. 헌법 III: sales 스냅샷만 사용. 헌법 IV: auth.uid() 격리.';

--- a/tests/integration/calendar-month.test.ts
+++ b/tests/integration/calendar-month.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  cleanupTestUser,
+  createTestUser,
+  getServiceRoleClient,
+  hasSupabaseTestEnv,
+  signInAs,
+  type TestUser,
+} from "../helpers/test-supabase";
+import { cloneMenuTemplate, getCalendarMonth } from "@/lib/supabase/rpc";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * `get_calendar_month` RPC 통합 테스트 (Phase 8 / T155).
+ * - 일별 셀 정확도 (sale 있는 날 has_sale=true / 없는 날 is_missing 판별)
+ * - 정기휴무 요일 처리 (FR-043, FR-045)
+ * - 누적 KPI 계산
+ * - 월 길이 (28~31일)에 따른 셀 개수
+ * - RLS: 다른 사용자 데이터 leak 차단
+ */
+
+const describeCalendar = hasSupabaseTestEnv ? describe : describe.skip;
+
+describeCalendar("get_calendar_month RPC", () => {
+  let user: TestUser;
+  let client: SupabaseClient<Database>;
+  let menuId: string;
+
+  beforeAll(async () => {
+    user = await createTestUser({ storeType: "cafe", storeName: "달력카페" });
+    client = await signInAs(user);
+
+    const cloneResult = await cloneMenuTemplate(client, { storeType: "cafe" });
+    expect(cloneResult.error).toBeNull();
+    const menu = await client.from("menus").select("id").eq("name", "아메리카노").single();
+    menuId = menu.data!.id;
+
+    const admin = getServiceRoleClient();
+    // 1월 셀 검증을 위해 가입일을 1월 이전으로 backdate (그렇지 않으면 1월 셀은
+    // is_before_signup=true → is_missing=false가 되어 누락 판정 검증 불가)
+    await admin.from("users").update({ signed_up_at: "2025-12-01" }).eq("id", user.id);
+    const ing = await admin
+      .from("ingredients")
+      .select("id")
+      .eq("user_id", user.id)
+      .eq("name", "원두")
+      .single();
+    await admin
+      .from("ingredients")
+      .update({ current_stock: 10000, current_avg_price: 50 })
+      .eq("id", ing.data!.id);
+  }, 60_000);
+
+  afterAll(async () => {
+    if (user?.id) await cleanupTestUser(user.id);
+  }, 30_000);
+
+  it("2026년 2월 (28일) 빈 데이터: 28개 셀 + 누적 0", async () => {
+    const { data, error } = await getCalendarMonth(client, { year: 2026, month: 2 });
+    expect(error).toBeNull();
+    expect(data!.year).toBe(2026);
+    expect(data!.month).toBe(2);
+    expect(data!.cells).toHaveLength(28);
+    expect(data!.cumulative.totalRevenue).toBe(0);
+    expect(data!.cumulative.operatingDays).toBe(0);
+    expect(data!.marginLabel).toBe("재료 원가 기준 (이동평균법)");
+  });
+
+  it("2026년 1월 (31일): sale 2건 INSERT 후 누적/셀 정확도", async () => {
+    const admin = getServiceRoleClient();
+
+    // 1월 5일 매출 + 1월 10일 매출 + 1월 8일 매입
+    const sale1 = await admin
+      .from("sales")
+      .insert({
+        user_id: user.id,
+        sold_at: "2026-01-05",
+        total_revenue: 50000,
+        total_cost_snapshot: 10000,
+      })
+      .select("id")
+      .single();
+    await admin.from("sale_items").insert({
+      sale_id: sale1.data!.id,
+      user_id: user.id,
+      menu_id: menuId,
+      quantity: 10,
+      unit_price: 5000,
+      menu_cost_snapshot: 1000,
+    });
+
+    const sale2 = await admin
+      .from("sales")
+      .insert({
+        user_id: user.id,
+        sold_at: "2026-01-10",
+        total_revenue: 30000,
+        total_cost_snapshot: 6000,
+      })
+      .select("id")
+      .single();
+    await admin.from("sale_items").insert({
+      sale_id: sale2.data!.id,
+      user_id: user.id,
+      menu_id: menuId,
+      quantity: 6,
+      unit_price: 5000,
+      menu_cost_snapshot: 1000,
+    });
+
+    // 1월 8일 매입 (vendor 필요)
+    const vendor = await admin
+      .from("vendors")
+      .insert({ user_id: user.id, name: "거래처A", lead_time_days: 1 })
+      .select("id")
+      .single();
+    await admin.from("purchase_orders").insert({
+      user_id: user.id,
+      vendor_id: vendor.data!.id,
+      purchased_at: "2026-01-08",
+      total_amount: 50000,
+    });
+
+    const { data, error } = await getCalendarMonth(client, { year: 2026, month: 1 });
+    expect(error).toBeNull();
+    expect(data!.cells).toHaveLength(31);
+
+    // 누적: 매출 80000, 순익 64000, 영업일 2, 일평균 40000
+    expect(data!.cumulative.totalRevenue).toBe(80000);
+    expect(data!.cumulative.totalNetProfit).toBe(64000);
+    expect(data!.cumulative.operatingDays).toBe(2);
+    expect(data!.cumulative.avgDailyRevenue).toBe(40000);
+
+    const day5 = data!.cells.find((c) => c.date === "2026-01-05")!;
+    expect(day5.hasSale).toBe(true);
+    expect(day5.isMissing).toBe(false);
+    expect(day5.revenue).toBe(50000);
+    expect(day5.netProfit).toBe(40000);
+
+    const day8 = data!.cells.find((c) => c.date === "2026-01-08")!;
+    expect(day8.hasSale).toBe(false);
+    expect(day8.hasPurchase).toBe(true);
+    expect(day8.isMissing).toBe(true);
+
+    const day10 = data!.cells.find((c) => c.date === "2026-01-10")!;
+    expect(day10.hasSale).toBe(true);
+    expect(day10.revenue).toBe(30000);
+  });
+
+  it("정기휴무 요일 + FR-045 예외 영업 (sale 있는 정기휴무일은 영업으로)", async () => {
+    const admin = getServiceRoleClient();
+
+    // 월요일 정기휴무 설정. 2026-01-05는 월요일 (sale 있음, 예외 영업)
+    // 2026-01-12는 월요일 (sale 없음, 정기휴무로 표시되어야)
+    await admin
+      .from("users")
+      .update({ regular_days_off: ["MON"] })
+      .eq("id", user.id);
+
+    // 1/12은 sale 없는 월요일 — 정기휴무 + 누락 아님
+    // 1/19도 sale 없는 월요일 — 정기휴무 + 누락 아님
+    const { data, error } = await getCalendarMonth(client, { year: 2026, month: 1 });
+    expect(error).toBeNull();
+
+    const day5 = data!.cells.find((c) => c.date === "2026-01-05")!; // 월요일 + sale
+    expect(day5.isRegularDayOff).toBe(false);
+    expect(day5.hasSale).toBe(true);
+    expect(day5.isMissing).toBe(false);
+
+    const day12 = data!.cells.find((c) => c.date === "2026-01-12")!; // 월요일 + sale 없음
+    expect(day12.isRegularDayOff).toBe(true);
+    expect(day12.hasSale).toBe(false);
+    expect(day12.isMissing).toBe(false);
+
+    // 사후 정리: 정기휴무 원복 (다음 테스트에 영향 안 가도록)
+    await admin.from("users").update({ regular_days_off: [] }).eq("id", user.id);
+  });
+
+  it("다른 사용자 sale/purchase 누설 차단 (헌법 IV)", async () => {
+    const otherUser = await createTestUser({ storeType: "cafe" });
+    const admin = getServiceRoleClient();
+    await admin.from("sales").insert({
+      user_id: otherUser.id,
+      sold_at: "2026-02-15",
+      total_revenue: 999999,
+      total_cost_snapshot: 0,
+    });
+
+    const { data } = await getCalendarMonth(client, { year: 2026, month: 2 });
+    // 본인 시점 2월은 비어있어야 함
+    expect(data!.cumulative.totalRevenue).toBe(0);
+    const day15 = data!.cells.find((c) => c.date === "2026-02-15")!;
+    expect(day15.hasSale).toBe(false);
+
+    await cleanupTestUser(otherUser.id);
+  });
+});

--- a/tests/unit/consecutive-missing.test.ts
+++ b/tests/unit/consecutive-missing.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { withConsecutiveMissingDays } from "@/features/calendar/lib/consecutive-missing";
+import type { CalendarCell } from "@/lib/supabase/rpc";
+
+const baseCell = (overrides: Partial<CalendarCell>): CalendarCell => ({
+  date: overrides.date ?? "2026-04-01",
+  isFuture: false,
+  isBeforeSignup: false,
+  isRegularDayOff: false,
+  hasSale: false,
+  hasPurchase: false,
+  isMissing: false,
+  revenue: null,
+  netProfit: null,
+  ...overrides,
+});
+
+describe("withConsecutiveMissingDays", () => {
+  it("연속 누락일에 1, 2, 3 누적", () => {
+    const cells: CalendarCell[] = [
+      baseCell({ date: "2026-04-01", hasSale: true }),
+      baseCell({ date: "2026-04-02", isMissing: true }),
+      baseCell({ date: "2026-04-03", isMissing: true }),
+      baseCell({ date: "2026-04-04", isMissing: true }),
+      baseCell({ date: "2026-04-05", hasSale: true }),
+    ];
+    const result = withConsecutiveMissingDays(cells);
+    expect(result.map((c) => c.consecutiveMissingDays)).toEqual([0, 1, 2, 3, 0]);
+  });
+
+  it("정기휴무·미래·가입전 셀이 끼면 런이 끊긴다 (isMissing=false 기준)", () => {
+    const cells: CalendarCell[] = [
+      baseCell({ date: "2026-04-01", isMissing: true }),
+      baseCell({ date: "2026-04-02", isRegularDayOff: true }),
+      baseCell({ date: "2026-04-03", isMissing: true }),
+      baseCell({ date: "2026-04-04", isFuture: true }),
+      baseCell({ date: "2026-04-05", isMissing: true }),
+      baseCell({ date: "2026-04-06", isBeforeSignup: true }),
+      baseCell({ date: "2026-04-07", isMissing: true }),
+    ];
+    const result = withConsecutiveMissingDays(cells);
+    expect(result.map((c) => c.consecutiveMissingDays)).toEqual([1, 0, 1, 0, 1, 0, 1]);
+  });
+
+  it("빈 배열 통과", () => {
+    expect(withConsecutiveMissingDays([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 8 PR 36 — 월간 캘린더 데이터 레이어 (T155 RPC + T162 hook). UI는 PR 37, d7_active GA4 + d7-tracker Edge Function은 PR 38.

### 변경 내역

- **`supabase/migrations/026_get_calendar_month_rpc.sql`** — `jsonb` 반환:
  - `cumulative`: 월 누적 매출/순익/일평균/영업일수
  - `cells[]`: 28~31개 일별 셀 with `is_future`/`is_before_signup`/`is_regular_day_off`/`has_sale`/`has_purchase`/`is_missing`/`revenue`/`net_profit`
  - **FR-043 + FR-045** 정기휴무 요일에 sale 있으면 `isRegularDayOff=false` (예외 영업)
  - `consecutive_missing_days`는 SQL이 아니라 클라이언트에서 단순 reduce (get_depletion_forecast 패턴)

- **`src/lib/supabase/rpc.ts`** — `getCalendarMonth` wrapper + `CalendarMonthData` / `CalendarCell` types

- **`src/features/calendar/lib/consecutive-missing.ts`** — `withConsecutiveMissingDays(cells)` 순수 변환

- **`src/features/calendar/hooks/useCalendarMonth.ts`** — TanStack Query, staleTime 5분

- **테스트**
  - `tests/unit/consecutive-missing.test.ts` — 3 케이스 (런 누적 / 끊김 / 빈 배열)
  - `tests/integration/calendar-month.test.ts` — 4 케이스 (빈 월 / 31일 sale 누적 / **FR-045 정기휴무 예외 영업** / RLS 누설 차단)

### simplify 적용 사항 (3-agent 리뷰 → 4건 모두 적용)

| # | 카테고리 | 내용 |
|---|---------|------|
| 1 | SQL 정확성 | `signed_up_at` NULL 시 비교가 NULL → jsonb null 직렬화로 TS `boolean` 타입 위반. `coalesce(v_signed_up, v_month_start)` + `coalesce(v_days_off, '{}')` fallback |
| 2 | SQL 효율 | `(wd = any(v_days_off) and not has_sale)` 식이 `is_regular_day_off` + `is_missing` 두 곳에서 중복 계산 → `enriched` CTE에 `is_regular_day_off` 컬럼 hoist |
| 3 | 단위 테스트 | "정기휴무·미래·가입전" 제목과 본문 불일치 (regular만 있었음) → `isFuture` / `isBeforeSignup` 셀 추가 |
| 4 | 통합 테스트 | FR-043/FR-045가 헤더에만 명시되고 실제 검증 없음 → "정기휴무 요일 + 예외 영업" 케이스 추가 |
| 5 | 훅 | staleTime 60s → 5분 (과거 월은 변동 없음, mutations에서 명시적 invalidate) |

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 135/135 ✅ (calendar 단위 +3 / 통합 +4)
- build ✅
- 마이그레이션 026 클라우드 적용 완료

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [ ] PR 37 UI 통합 후 모바일 폭에서 `npm run dev` 수동 확인

Refs T155 T162

🤖 Generated with [Claude Code](https://claude.com/claude-code)