### PR TITLE
feat(calendar): 월간 캘린더 UI + 페이지 + GA4 (Phase 8 PR 37)

### DIFF
--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -1,8 +1,126 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useCalendarMonth } from "@/features/calendar/hooks/useCalendarMonth";
+import { MonthHeader } from "@/features/calendar/components/MonthHeader";
+import { MonthCumulativeCard } from "@/features/calendar/components/MonthCumulativeCard";
+import { CalendarGrid } from "@/features/calendar/components/CalendarGrid";
+import { CellDetailPanel } from "@/features/calendar/components/CellDetailPanel";
+import { CalendarLegend } from "@/features/calendar/components/CalendarLegend";
+import { trackEvent } from "@/lib/analytics/ga4";
+import { useTodayIso } from "@/lib/utils/use-today-iso";
+import type { EnrichedCalendarCell } from "@/features/calendar/lib/consecutive-missing";
+
+/**
+ * 월간 캘린더 페이지 — patterns.md "캘린더" 위계대로 렌더.
+ * 1) 헤더 (월 네비)
+ * 2) 월 누적 KPI
+ * 3) 7×6 그리드 + 범례
+ * 4) 선택일 상세 (선택 시)
+ *
+ * 셀 클릭 → 선택 셀 갱신 + 누락일이면 calendar_missing_day_clicked GA4 발화 (T165, D7 funnel 핵심).
+ * 페이지 mount → calendar_viewed GA4 발화 (T164).
+ */
 export default function CalendarPage(): React.ReactElement {
+  const todayIso = useTodayIso();
+  const [year, setYear] = useState<number | null>(null);
+  const [month, setMonth] = useState<number | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  // 초기 mount 시 클라이언트 시각으로 현재 연/월 세팅 (SSR/CSR drift 차단)
+  useEffect(() => {
+    const now = new Date();
+    setYear(now.getFullYear());
+    setMonth(now.getMonth() + 1);
+  }, []);
+
+  const query = useCalendarMonth(year, month);
+
+  // monthKey + operating_days만 dep으로 두면 같은 월의 refetch (참조만 다른 동일 데이터)에는
+  // 중복 발화하지 않음. 값이 실제로 변하는 경우에만 트래킹.
+  const monthKey = year !== null && month !== null ? `${year}-${month}` : null;
+  const operatingDays = query.data?.cumulative.operatingDays ?? null;
+  useEffect(() => {
+    if (operatingDays === null || !monthKey) return;
+    const [y, m] = monthKey.split("-").map(Number);
+    trackEvent("calendar_viewed", {
+      year: y as number,
+      month: m as number,
+      operating_days: operatingDays,
+    });
+  }, [monthKey, operatingDays]);
+
+  function handleSelect(cell: EnrichedCalendarCell): void {
+    setSelectedDate(cell.date);
+    if (cell.isMissing) {
+      trackEvent("calendar_missing_day_clicked", {
+        date: cell.date,
+        consecutive_missing_days: cell.consecutiveMissingDays,
+      });
+    }
+  }
+
+  function navigate(delta: number): void {
+    if (year === null || month === null) return;
+    const nextRaw = month + delta;
+    if (nextRaw < 1) {
+      setYear(year - 1);
+      setMonth(12);
+    } else if (nextRaw > 12) {
+      setYear(year + 1);
+      setMonth(1);
+    } else {
+      setMonth(nextRaw);
+    }
+    setSelectedDate(null);
+  }
+
+  function jumpToday(): void {
+    const now = new Date();
+    setYear(now.getFullYear());
+    setMonth(now.getMonth() + 1);
+    setSelectedDate(null);
+  }
+
+  if (year === null || month === null || query.isLoading) {
+    return <p className="text-body-regular text-ink-3">불러오는 중…</p>;
+  }
+  if (query.error || !query.data) {
+    return (
+      <p className="text-body-regular text-red-deep">
+        데이터를 불러오지 못했어요. 잠시 후 다시 시도해주세요.
+      </p>
+    );
+  }
+
+  const selectedCell =
+    selectedDate !== null ? (query.data.cells.find((c) => c.date === selectedDate) ?? null) : null;
+
   return (
-    <section className="flex flex-col gap-stack">
-      <h1 className="text-title-lg text-ink-1">월간 장부</h1>
-      <p className="text-body-regular text-ink-3">캘린더 — Phase 8에서 구현</p>
+    <section className="flex flex-col gap-section">
+      <MonthHeader
+        year={year}
+        month={month}
+        onPrev={() => navigate(-1)}
+        onNext={() => navigate(1)}
+        onToday={jumpToday}
+      />
+      <MonthCumulativeCard
+        cumulative={query.data.cumulative}
+        marginLabel={query.data.marginLabel}
+      />
+      <CalendarGrid
+        year={year}
+        month={month}
+        cells={query.data.cells}
+        selectedDate={selectedDate}
+        todayIso={todayIso}
+        onSelect={handleSelect}
+      />
+      <CalendarLegend />
+      {/* todayIso는 mount 후 채워짐 — null이면 CellDetailPanel의 daysFromToday 계산이
+          1970 fallback에 의존하게 되므로 명시적으로 null guard. */}
+      {selectedCell && todayIso && <CellDetailPanel cell={selectedCell} todayIso={todayIso} />}
     </section>
   );
 }

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { parseLocalDateFromIso } from "@/lib/utils/format";
+import type { EnrichedCalendarCell } from "../lib/consecutive-missing";
+
+interface CalendarGridProps {
+  year: number;
+  month: number;
+  cells: readonly EnrichedCalendarCell[];
+  selectedDate: string | null;
+  todayIso: string | null;
+  onSelect: (cell: EnrichedCalendarCell) => void;
+}
+
+/**
+ * 7×6 월간 그리드 (patterns.md "캘린더" 위계 #3).
+ * 셀 배경 = 매출 인텐시티 5단계, 우상 도트 = 매입(amber)/누락(red),
+ * 좌하 = 매출 만원 단위, 미래/가입전/정기휴무는 회색 처리.
+ *
+ * 헌법 IV: 셀 데이터는 RPC가 user_id로 격리 — 이 컴포넌트는 표시 전용.
+ */
+export function CalendarGrid({
+  year,
+  month,
+  cells,
+  selectedDate,
+  todayIso,
+  onSelect,
+}: CalendarGridProps): React.ReactElement {
+  const maxRevenue = Math.max(0, ...cells.map((c) => c.revenue ?? 0));
+  // 1일이 어떤 요일에 시작하는지 계산 → 그리드 앞쪽 빈 칸 수
+  const firstDay = new Date(year, month - 1, 1);
+  const leadingBlanks = firstDay.getDay();
+  // 항상 6주 = 42칸 표시 (월 길이에 따른 trailing blanks 자동 채움)
+  const totalCells = 42;
+  const trailingBlanks = totalCells - leadingBlanks - cells.length;
+
+  return (
+    <div className="flex flex-col gap-stack-tight">
+      <WeekdayHeader />
+      <div className="grid grid-cols-7 gap-1">
+        {Array.from({ length: leadingBlanks }, (_, i) => (
+          <BlankCell key={`lead-${i}`} />
+        ))}
+        {cells.map((cell) => (
+          <DayCell
+            key={cell.date}
+            cell={cell}
+            maxRevenue={maxRevenue}
+            isSelected={cell.date === selectedDate}
+            isToday={cell.date === todayIso}
+            onSelect={onSelect}
+          />
+        ))}
+        {Array.from({ length: Math.max(0, trailingBlanks) }, (_, i) => (
+          <BlankCell key={`trail-${i}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+function WeekdayHeader(): React.ReactElement {
+  return (
+    <div className="grid grid-cols-7 gap-1">
+      {WEEKDAY_LABELS.map((label, idx) => (
+        <span key={label} className={cn("text-center text-micro", weekdayTone(idx, false))}>
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function BlankCell(): React.ReactElement {
+  return <div className="aspect-square rounded-md bg-bg" aria-hidden />;
+}
+
+interface DayCellProps {
+  cell: EnrichedCalendarCell;
+  maxRevenue: number;
+  isSelected: boolean;
+  isToday: boolean;
+  onSelect: (cell: EnrichedCalendarCell) => void;
+}
+
+function DayCell({
+  cell,
+  maxRevenue,
+  isSelected,
+  isToday,
+  onSelect,
+}: DayCellProps): React.ReactElement {
+  const day = parseInt(cell.date.slice(8, 10), 10);
+  const weekday = parseLocalDateFromIso(cell.date)?.getDay() ?? 0;
+  const isInactive = cell.isFuture || cell.isBeforeSignup || cell.isRegularDayOff;
+  const intensityPct = computeIntensityPercent(cell.revenue ?? 0, maxRevenue, isInactive);
+  const isStrongMissing = cell.isMissing && cell.consecutiveMissingDays >= 2;
+
+  return (
+    <button
+      type="button"
+      aria-label={`${cell.date} ${cellAriaSummary(cell)}`}
+      onClick={() => onSelect(cell)}
+      className={cn(
+        "relative aspect-square rounded-md p-1 text-left transition-colors",
+        isSelected ? "bg-ink-1 text-bg" : "text-ink-1",
+        isToday && !isSelected && "border border-blue ring-1 ring-blue",
+        !isToday && "border border-transparent",
+      )}
+      style={
+        isSelected
+          ? undefined
+          : { backgroundColor: `color-mix(in srgb, var(--ink-1) ${intensityPct}%, var(--card))` }
+      }
+    >
+      <span
+        className={cn("text-micro tabular-nums", !isSelected && weekdayTone(weekday, isInactive))}
+      >
+        {day}
+      </span>
+
+      {!isSelected && <BottomLabel cell={cell} isStrongMissing={isStrongMissing} />}
+
+      <DotIndicators cell={cell} />
+    </button>
+  );
+}
+
+interface BottomLabelProps {
+  cell: EnrichedCalendarCell;
+  isStrongMissing: boolean;
+}
+
+function BottomLabel({ cell, isStrongMissing }: BottomLabelProps): React.ReactElement | null {
+  // 누락 강조 라벨이 우선 — sale 없는 누락은 revenue도 없으므로 자연 mutual exclusion이지만
+  // 명시적으로 처리해 디자인 시스템 위계 (red 강조 > 매출 숫자) 보장.
+  if (isStrongMissing) {
+    return (
+      <span className="absolute bottom-1 left-1 text-[9px] font-semibold text-red-deep">누락</span>
+    );
+  }
+  if (cell.revenue !== null && cell.revenue > 0) {
+    return (
+      <span className="absolute bottom-1 left-1 text-[8.5px] tabular-nums text-ink-1">
+        {Math.round(cell.revenue / 10000)}
+      </span>
+    );
+  }
+  return null;
+}
+
+interface DotIndicatorsProps {
+  cell: EnrichedCalendarCell;
+}
+
+function DotIndicators({ cell }: DotIndicatorsProps): React.ReactElement | null {
+  const hasMissingDot = cell.isMissing && cell.consecutiveMissingDays < 2;
+  if (!cell.hasPurchase && !hasMissingDot) return null;
+  return (
+    <span className="absolute right-1 top-1 flex gap-0.5">
+      {cell.hasPurchase && <span className="h-1 w-1 rounded-full bg-amber" aria-hidden />}
+      {hasMissingDot && <span className="h-1 w-1 rounded-full bg-red" aria-hidden />}
+    </span>
+  );
+}
+
+function weekdayTone(weekday: number, isInactive: boolean): string {
+  if (isInactive) return "text-ink-4";
+  if (weekday === 0) return "text-red-deep";
+  if (weekday === 6) return "text-blue-deep";
+  return "text-ink-3";
+}
+
+function computeIntensityPercent(revenue: number, maxRevenue: number, isInactive: boolean): number {
+  if (isInactive || revenue <= 0 || maxRevenue <= 0) return 0;
+  // 5단계 인텐시티 (0% / 3.5% / 7% / 10.5% / 14%)
+  const ratio = revenue / maxRevenue;
+  const level = Math.min(4, Math.max(1, Math.ceil(ratio * 4)));
+  return level * 3.5;
+}
+
+function cellAriaSummary(cell: EnrichedCalendarCell): string {
+  const parts: string[] = [];
+  if (cell.isFuture) parts.push("미래일자");
+  else if (cell.isBeforeSignup) parts.push("가입 전");
+  else if (cell.isRegularDayOff) parts.push("정기휴무");
+  else if (cell.isMissing) parts.push("판매 미입력");
+  else if (cell.hasSale) parts.push("판매 입력 완료");
+  else parts.push("데이터 없음");
+  if (cell.hasPurchase) parts.push("매입 있음");
+  return parts.join(", ");
+}

--- a/src/features/calendar/components/CalendarLegend.tsx
+++ b/src/features/calendar/components/CalendarLegend.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * 캘린더 범례 (patterns.md "캘린더 위계 #3 그리드 하단").
+ * 인텐시티 5단계 + 매입/누락 도트 설명.
+ */
+export function CalendarLegend(): React.ReactElement {
+  return (
+    <section
+      aria-label="캘린더 범례"
+      className="flex flex-col gap-stack-tight rounded-lg border border-border bg-card p-tile text-caption text-ink-3"
+    >
+      <div className="flex items-center gap-stack-tight">
+        <span className="text-micro">매출</span>
+        <IntensityScale />
+      </div>
+      <div className="flex flex-wrap items-center gap-stack-tight">
+        <DotKey tone="amber" label="매입 있음" />
+        <DotKey tone="red" label="판매 미입력" />
+      </div>
+    </section>
+  );
+}
+
+function IntensityScale(): React.ReactElement {
+  return (
+    <div className="flex items-center gap-1">
+      {[0, 1, 2, 3, 4].map((level) => (
+        <div
+          key={level}
+          className="h-3 w-3 rounded-sm"
+          style={{
+            backgroundColor: `color-mix(in srgb, var(--ink-1) ${level * 3.5}%, var(--card))`,
+          }}
+        />
+      ))}
+      <span className="ml-1 text-micro">낮음 → 높음</span>
+    </div>
+  );
+}
+
+interface DotKeyProps {
+  tone: "amber" | "red";
+  label: string;
+}
+
+function DotKey({ tone, label }: DotKeyProps): React.ReactElement {
+  const cls = tone === "amber" ? "bg-amber" : "bg-red";
+  return (
+    <span className="flex items-center gap-1">
+      <span className={`h-1.5 w-1.5 rounded-full ${cls}`} aria-hidden />
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/features/calendar/components/CellDetailPanel.tsx
+++ b/src/features/calendar/components/CellDetailPanel.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Link from "next/link";
+import { differenceInCalendarDays } from "date-fns";
+import { cn } from "@/lib/utils";
+import { formatDateKoFromIso, formatWon, parseLocalDateFromIso } from "@/lib/utils/format";
+import type { EnrichedCalendarCell } from "../lib/consecutive-missing";
+
+interface CellDetailPanelProps {
+  cell: EnrichedCalendarCell;
+  todayIso: string;
+}
+
+/**
+ * 선택일 상세 패널 (patterns.md "캘린더" 위계 #4).
+ *
+ * 셀 상태에 따라 다른 카피 + 액션:
+ * - 미래: "입력 불가" 안내
+ * - 가입 전: "가입 전 데이터 없음"
+ * - 정기휴무: "정기휴무일" 안내
+ * - 누락 + 7일 이내: 큰 red 알림 + 입력 버튼 (/sale/[date]) — FR-022~024
+ * - 누락 + 7일 초과: "이미 만료" 안내 (FR-024)
+ * - 판매 있음: 매출/순익/마진율 메트릭 4-grid
+ *
+ * Toast 인프라 미존재 — T163 spec의 "토스트"는 인라인 패널로 대체.
+ */
+export function CellDetailPanel({ cell, todayIso }: CellDetailPanelProps): React.ReactElement {
+  // todayIso는 호출 측에서 mount 후 채워진 값을 보장 (null guard는 page에서).
+  const date = parseLocalDateFromIso(cell.date) ?? new Date();
+  const today = parseLocalDateFromIso(todayIso) ?? new Date();
+  const daysFromToday = differenceInCalendarDays(date, today);
+
+  return (
+    <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
+      <header className="text-title-md text-ink-1">{formatDateKoFromIso(cell.date)}</header>
+      <Body cell={cell} daysFromToday={daysFromToday} />
+    </article>
+  );
+}
+
+interface BodyProps {
+  cell: EnrichedCalendarCell;
+  daysFromToday: number;
+}
+
+function Body({ cell, daysFromToday }: BodyProps): React.ReactElement {
+  if (cell.isFuture) {
+    return <Notice tone="neutral">아직 오지 않은 날이에요. 미래 데이터는 입력할 수 없어요.</Notice>;
+  }
+  if (cell.isBeforeSignup) {
+    return <Notice tone="neutral">가입 전 데이터예요.</Notice>;
+  }
+  if (cell.isRegularDayOff) {
+    return <Notice tone="neutral">정기휴무일이에요.</Notice>;
+  }
+  if (cell.hasSale) {
+    return <SaleSummary cell={cell} />;
+  }
+  if (cell.isMissing) {
+    return <MissingActions cell={cell} daysFromToday={daysFromToday} />;
+  }
+  return <Notice tone="neutral">데이터가 없어요.</Notice>;
+}
+
+interface SaleSummaryProps {
+  cell: EnrichedCalendarCell;
+}
+
+function SaleSummary({ cell }: SaleSummaryProps): React.ReactElement {
+  const revenue = cell.revenue ?? 0;
+  const netProfit = cell.netProfit ?? 0;
+  const marginPercent = revenue > 0 ? (netProfit / revenue) * 100 : 0;
+  return (
+    <div className="grid grid-cols-2 gap-stack">
+      <Metric label="매출" value={`${formatWon(revenue)}원`} />
+      <Metric label="순수익" value={`${formatWon(netProfit)}원`} />
+      <Metric label="마진율" value={`${marginPercent.toFixed(1)}%`} />
+      <Metric label="매입" value={cell.hasPurchase ? "있음" : "—"} />
+    </div>
+  );
+}
+
+interface MissingActionsProps {
+  cell: EnrichedCalendarCell;
+  daysFromToday: number;
+}
+
+function MissingActions({ cell, daysFromToday }: MissingActionsProps): React.ReactElement {
+  // FR-024: 7일 초과 누락은 소급 입력 불가 (save_sale RPC도 거부)
+  const isExpired = daysFromToday < -7;
+  if (isExpired) {
+    return (
+      <Notice tone="neutral">
+        7일이 지나 더 이상 입력할 수 없어요. 캘린더 통계에는 누락으로 남아요.
+      </Notice>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-stack-tight">
+      <Notice tone="red">판매 입력이 비어있어요. 1분이면 끝나요.</Notice>
+      <Link
+        href={`/sale/${cell.date}`}
+        data-calendar-action="missing-day-go"
+        className="flex items-center justify-center rounded-xl bg-ink-1 py-3 text-body text-bg"
+      >
+        지금 입력하기
+      </Link>
+    </div>
+  );
+}
+
+interface NoticeProps {
+  tone: "red" | "neutral";
+  children: React.ReactNode;
+}
+
+function Notice({ tone, children }: NoticeProps): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        "rounded-lg p-tile text-body-regular",
+        tone === "red" ? "bg-red-soft text-red-deep" : "bg-bg text-ink-3",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface MetricProps {
+  label: string;
+  value: string;
+}
+
+function Metric({ label, value }: MetricProps): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-micro text-ink-3">{label}</span>
+      <span className="text-metric-md tabular-nums text-ink-1">{value}</span>
+    </div>
+  );
+}

--- a/src/features/calendar/components/MonthCumulativeCard.tsx
+++ b/src/features/calendar/components/MonthCumulativeCard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { formatWon, formatNumber } from "@/lib/utils/format";
+import type { CalendarCumulative } from "@/lib/supabase/rpc";
+
+interface MonthCumulativeCardProps {
+  cumulative: CalendarCumulative;
+  marginLabel: string;
+}
+
+/**
+ * 월간 누적 KPI 카드 (patterns.md "캘린더" 위계 #2).
+ * 매출 / 순수익 / 일평균 / 영업일수 — "재료 원가 기준 (이동평균법)" 라벨 (FR-019).
+ */
+export function MonthCumulativeCard({
+  cumulative,
+  marginLabel,
+}: MonthCumulativeCardProps): React.ReactElement {
+  return (
+    <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
+      <div className="grid grid-cols-2 gap-stack">
+        <KpiSlot label="총 매출" value={`${formatWon(cumulative.totalRevenue)}원`} />
+        <KpiSlot label="순수익" value={`${formatWon(cumulative.totalNetProfit)}원`} />
+        <KpiSlot
+          label="일평균 매출"
+          value={cumulative.operatingDays > 0 ? `${formatWon(cumulative.avgDailyRevenue)}원` : "—"}
+        />
+        <KpiSlot label="영업일수" value={`${formatNumber(cumulative.operatingDays)}일`} />
+      </div>
+      <p className="text-micro text-ink-3">{marginLabel}</p>
+    </article>
+  );
+}
+
+interface KpiSlotProps {
+  label: string;
+  value: string;
+}
+
+function KpiSlot({ label, value }: KpiSlotProps): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-micro text-ink-3">{label}</span>
+      <span className="text-metric-md tabular-nums text-ink-1">{value}</span>
+    </div>
+  );
+}

--- a/src/features/calendar/components/MonthHeader.tsx
+++ b/src/features/calendar/components/MonthHeader.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+interface MonthHeaderProps {
+  year: number;
+  month: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onToday: () => void;
+}
+
+/**
+ * 월간 캘린더 헤더 (patterns.md "캘린더" 위계 #1).
+ * "2026년 4월" + 이전/다음 달 네비 + 오늘로 돌아가기.
+ */
+export function MonthHeader({
+  year,
+  month,
+  onPrev,
+  onNext,
+  onToday,
+}: MonthHeaderProps): React.ReactElement {
+  return (
+    <header className="flex items-center justify-between">
+      <div className="flex items-center gap-stack">
+        <NavButton ariaLabel="이전 달" onClick={onPrev}>
+          ‹
+        </NavButton>
+        <h1 className="text-title-lg text-ink-1 tabular-nums">
+          {year}년 {month}월
+        </h1>
+        <NavButton ariaLabel="다음 달" onClick={onNext}>
+          ›
+        </NavButton>
+      </div>
+      <button
+        type="button"
+        onClick={onToday}
+        className="rounded-md border border-border px-2 py-1 text-caption text-ink-3"
+      >
+        오늘
+      </button>
+    </header>
+  );
+}
+
+interface NavButtonProps {
+  ariaLabel: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function NavButton({ ariaLabel, onClick, children }: NavButtonProps): React.ReactElement {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className="flex h-8 w-8 items-center justify-center rounded-md border border-border text-ink-1"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/features/calendar/hooks/useCalendarMonth.ts
+++ b/src/features/calendar/hooks/useCalendarMonth.ts
@@ -20,11 +20,16 @@ async function fetchCalendarMonth(year: number, month: number): Promise<Calendar
   return { ...data, cells: withConsecutiveMissingDays(data.cells) };
 }
 
-export function useCalendarMonth(year: number, month: number): UseQueryResult<CalendarMonthView> {
+export function useCalendarMonth(
+  year: number | null,
+  month: number | null,
+): UseQueryResult<CalendarMonthView> {
   return useQuery({
-    queryKey: calendarMonthQueryKey(year, month),
-    queryFn: () => fetchCalendarMonth(year, month),
+    queryKey: calendarMonthQueryKey(year ?? 0, month ?? 0),
+    queryFn: () => fetchCalendarMonth(year as number, month as number),
     // 월간 데이터는 변동이 적고 sale/purchase 변경 시 명시적 invalidate가 더 정확.
     staleTime: 5 * 60 * 1000,
+    // year/month가 mount 전에는 null이라 placeholder 쿼리(0,0)가 발사되지 않도록 차단.
+    enabled: year !== null && month !== null,
   });
 }

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -20,11 +20,30 @@ const WEEKDAY_KO = ["일", "월", "화", "수", "목", "금", "토"] as const;
  * timezone 해석 회피 위해 date 부품을 직접 분해 (Date 생성자에 ISO 문자열 + Z 패스
  * 사용 시 호스트 tz에 따라 ±1일 오차 가능).
  */
-export function weekdayKoFromIso(iso: string): string {
+/**
+ * "YYYY-MM-DD" 문자열을 로컬 시간 0시 Date로 변환. 호스트 tz 무관하게 캘린더 일자
+ * 단위 비교에 사용. ISO 부분 분해 → Date 생성자 (UTC 해석 회피).
+ */
+export function parseLocalDateFromIso(iso: string): Date | null {
   const parts = iso.split("-").map(Number);
   const [y, m, d] = parts;
-  if (y === undefined || m === undefined || d === undefined) return "";
-  return WEEKDAY_KO[new Date(y, m - 1, d).getDay()] ?? "";
+  if (y === undefined || m === undefined || d === undefined) return null;
+  return new Date(y, m - 1, d);
+}
+
+export function weekdayKoFromIso(iso: string): string {
+  const date = parseLocalDateFromIso(iso);
+  if (!date) return "";
+  return WEEKDAY_KO[date.getDay()] ?? "";
+}
+
+/**
+ * "YYYY-MM-DD" → "M월 D일 (요일)" 한국어 라벨. CellDetailPanel·캘린더 헤더 등 공유.
+ */
+export function formatDateKoFromIso(iso: string): string {
+  const date = parseLocalDateFromIso(iso);
+  if (!date) return iso;
+  return formatTodayKo(date);
 }
 
 /**

--- a/src/lib/utils/use-today-iso.ts
+++ b/src/lib/utils/use-today-iso.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 오늘 날짜 (YYYY-MM-DD)를 클라이언트 mount 후 한 번만 채움.
+ * SSR과 CSR이 자정 경계를 사이에 두면 서로 다른 날짜를 렌더해 hydration mismatch.
+ * 마운트 전에는 null — 호출 측이 null을 가드해야 함.
+ */
+export function useTodayIso(): string | null {
+  const [iso, setIso] = useState<string | null>(null);
+  useEffect(() => {
+    setIso(new Date().toISOString().slice(0, 10));
+  }, []);
+  return iso;
+}


### PR DESCRIPTION
## Summary

Phase 8 PR 37 — 캘린더 탭 UI 통합. T156~T161 + T163~T165. 누락일 셀 클릭 → `/sale/[date]` 소급 입력 (D7 funnel 핵심 동선).

### 변경 내역

**컴포넌트 5개 (`src/features/calendar/components/`)**
- **MonthHeader** — 이전/다음/오늘 네비 + "YYYY년 M월"
- **MonthCumulativeCard** — 매출/순익/일평균/영업일수 4-grid + 재료원가 라벨 (FR-019)
- **CalendarGrid** — 7×6 그리드, 매출 인텐시티 5단계 (`color-mix`), 우상 도트 (매입 amber / 누락 red), 좌하 매출 만원 라벨 (단 누락 강조 시 "누락"), 미래/가입전/정기휴무 회색, 오늘은 `c-blue` ring
- **CellDetailPanel** — 셀 상태별 카피 6종 (미래/가입전/정기휴무/누락-7d-이내+입력 버튼/누락-7d-초과/판매-완료 메트릭). FR-022~024.
- **CalendarLegend** — 인텐시티 + 매입/누락 도트 설명

**페이지 (`src/app/(main)/calendar/page.tsx`)**
- 월 navigate state + 셀 select state
- `calendar_viewed` (T164) / `calendar_missing_day_clicked` (T165) GA4 발화

**유틸**
- `parseLocalDateFromIso` — ISO 문자열 → 로컬 0시 Date (tz 무관 캘린더 비교)
- `formatDateKoFromIso` — "M월 D일 (요일)" 라벨
- `useTodayIso` — 클라이언트 mount 후 1회 채움 (SSR/CSR drift 차단)

### simplify 적용 사항 (3-agent 리뷰 → 10건 모두 적용)

| # | 카테고리 | 내용 |
|---|---------|------|
| 1 | **critical 정확성** | `useTodayIso` mount 전 `""` 반환 → `parseDateIso("")` 1970 fallback → daysFromToday 거대 음수로 7일 만료 오판정 → page에서 `todayIso && <CellDetailPanel>` null guard |
| 2 | **critical 효율** | `useCalendarMonth(0, 0)` placeholder 쿼리 mount 전 발사 → `enabled: year !== null && month !== null` |
| 3 | **critical 정확성** | `calendar_viewed`가 `query.data` 참조 변경 시마다 중복 발화 → `monthKey` + `operating_days` primitive dep로 안정화 |
| 4 | UX 정확성 | 누락 + revenue 동시 좌하 라벨 충돌 → `BottomLabel`로 mutual exclusion (누락 강조 우선) |
| 5 | a11y | 매입 도트 color-only meaning → `cellAriaSummary`에 "매입 있음" 추가 |
| 6 | 코드 재사용 | `parseLocalDateFromIso` 유틸 추출 (Cell+Grid 중복 + `weekdayKoFromIso` 내부 통합) + `formatDateKoFromIso` |
| 7 | 코드 재사용 | `useTodayIso` 훅 → `src/lib/utils/use-today-iso.ts`로 추출 (today/page.tsx와 공유 가능) |
| 8 | 효율 | `Dot` / `DotKey` wrapper 제거 → 2-tone 매핑은 inline 1줄 |
| 9 | 효율 | `selectedCell` `useMemo` 제거 (~31 cell find는 자명한 무의미 최적화) |
| 10 | 효율 | `navigateMonth` 외부 함수 → 내부 closure (3개 setter 인자 제거) |

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 135/135 ✅ (UI 컴포넌트 단위 테스트는 헌법 v1.3.0 의무 제외)
- build ✅

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [ ] **수동 UX 검증**: 모바일 폭(375px) `npm run dev`로 (1) 셀 클릭 시 상세 패널 노출, (2) 누락일 클릭 → `/sale/[date]` 이동, (3) 7일 초과 누락 → "이미 만료" 안내, (4) 정기휴무일 클릭 → "정기휴무일" 안내, (5) 월 네비 / "오늘" 버튼

Refs T156 T157 T158 T159 T160 T161 T163 T164 T165

🤖 Generated with [Claude Code](https://claude.com/claude-code)