### PR TITLE
feat(analytics): d7-tracker Edge Function + cron (Phase 8 PR 38)

### DIFF
--- a/docs/setup-push.md
+++ b/docs/setup-push.md
@@ -34,20 +34,21 @@ Vault에 없으면 cron이 매 실행 시 `raise warning` 후 no-op (푸시 발�
 
 ## 4) Edge Function 배포
 
-`supabase/functions/push-scheduler/`는 `.github/workflows/deploy-edge-functions.yml`이 master 머지 시 자동 배포. 수동 배포가 필요하면:
+`supabase/functions/push-scheduler/`와 `supabase/functions/d7-tracker/`는 `.github/workflows/deploy-edge-functions.yml`이 master 머지 시 자동 배포. 수동 배포:
 
 ```bash
 npx supabase functions deploy push-scheduler --project-ref <ref>
+npx supabase functions deploy d7-tracker --project-ref <ref>
 ```
 
 ## 5) (선택) GA4 측정 활성화
 
-T140 `order_alert_received` 등 서버측 발화 — Edge Function Secrets에:
+T140 `order_alert_received` (push-scheduler) + T166 `d7_active` (d7-tracker) 서버측 발화 — Edge Function Secrets에:
 
 - `GA4_MEASUREMENT_ID`
 - `GA4_API_SECRET`
 
-미설정 시 푸시는 정상 발송, GA4 측정만 skip.
+미설정 시 푸시/D7 추적은 정상 동작, GA4 측정만 skip.
 
 ## 검증
 
@@ -67,3 +68,4 @@ select private.invoke_push_scheduler('order_alert');
 | order_alert      | 매일 09:00 | 매일 00:00 | `0 0 * * *`  |
 | closing_reminder | 매일 22:00 | 매일 13:00 | `0 13 * * *` |
 | stock_count      | 일 07:00   | 토 22:00   | `0 22 * * 6` |
+| d7_tracker       | 매일 11:00 | 매일 02:00 | `0 2 * * *`  |

--- a/supabase/functions/d7-tracker/index.ts
+++ b/supabase/functions/d7-tracker/index.ts
@@ -1,0 +1,130 @@
+/**
+ * Edge Function — D7 retention tracker (Phase 8 / T166).
+ * 트리거: pg_cron이 pg_net으로 HTTP POST (027_d7_tracker_cron.sql, 매일 KST 11:00).
+ *
+ * 로직:
+ *  1) "가입 7일째" 코호트 — KST 기준 today - 7일에 가입한 사용자 (탈퇴 신청자 제외).
+ *     UTC 단순 비교는 KST 저녁 가입자가 다음 UTC 날짜로 넘어가 누락되므로
+ *     +09:00 offset 윈도우 사용.
+ *  2) 그 중 sales.created_at >= now() - 24h 인 사용자 = "활성"
+ *     (sale 입력은 핵심 가치 행위이므로 단순 로그인보다 신뢰성 높은 retention 신호).
+ *     candidate 전원에 대해 단일 .in() 쿼리로 한 번에 조회 — N+1 회피.
+ *  3) GA4 Measurement Protocol로 d7_active 이벤트 발화.
+ *
+ * Secrets:
+ *   GA4_MEASUREMENT_ID + GA4_API_SECRET (둘 다 등록되어야 발화)
+ *   미설정 시 silent no-op (return success: true, sent_count: 0).
+ *
+ * 헌법 IV: service_role 사용 (RLS 우회). user.id는 GA4 client_id로 그대로 사용 —
+ * UUIDv4는 외부 시스템에서 PII로 연결 불가능한 무작위 식별자.
+ */
+
+// @ts-expect-error: Deno runtime
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+// @ts-expect-error: Deno global
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+// @ts-expect-error: Deno global
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+// @ts-expect-error: Deno global
+const GA4_MEASUREMENT_ID = Deno.env.get("GA4_MEASUREMENT_ID") ?? "";
+// @ts-expect-error: Deno global
+const GA4_API_SECRET = Deno.env.get("GA4_API_SECRET") ?? "";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface Ga4Result {
+  ok: boolean;
+}
+
+async function reportD7Active(userId: string, signupDate: string): Promise<Ga4Result> {
+  if (!GA4_MEASUREMENT_ID || !GA4_API_SECRET) return { ok: false };
+  try {
+    const res = await fetch(
+      `https://www.google-analytics.com/mp/collect?measurement_id=${GA4_MEASUREMENT_ID}&api_secret=${GA4_API_SECRET}`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          client_id: userId,
+          events: [{ name: "d7_active", params: { signup_date: signupDate } }],
+        }),
+      },
+    );
+    return { ok: res.ok };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** "가입 7일째" 코호트의 KST 기준 날짜 → UTC 윈도우 [start, end). */
+function kstCohortWindow(now: Date): { date: string; startIso: string; endIso: string } {
+  // KST = UTC+9. now를 +9h 시프트해 그 시각의 KST 날짜를 계산 → 7일 빼기.
+  const shifted = new Date(now.getTime() + 9 * 60 * 60 * 1000 - 7 * DAY_MS);
+  const date = shifted.toISOString().slice(0, 10);
+  const startIso = `${date}T00:00:00+09:00`;
+  // 다음날 0시 KST = startIso + 24h
+  const endIso = new Date(new Date(startIso).getTime() + DAY_MS).toISOString();
+  return { date, startIso, endIso };
+}
+
+// @ts-expect-error: Deno.serve global
+Deno.serve(async (): Promise<Response> => {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    return Response.json({ success: false, error: "missing env" }, { status: 500 });
+  }
+
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const cohort = kstCohortWindow(new Date());
+
+  const { data: candidates, error: queryError } = await admin
+    .from("users")
+    .select("id, signed_up_at")
+    .gte("signed_up_at", cohort.startIso)
+    .lt("signed_up_at", cohort.endIso)
+    .is("withdrawal_requested_at", null);
+
+  if (queryError) {
+    return Response.json({ success: false, error: queryError.message }, { status: 500 });
+  }
+
+  const users = candidates ?? [];
+  if (users.length === 0) {
+    return Response.json({ success: true, candidates_count: 0, sent_count: 0 });
+  }
+
+  // N+1 회피: 24h 활성 사용자 ID set을 단일 쿼리로 조회.
+  const since24h = new Date(Date.now() - DAY_MS).toISOString();
+  const userIds = users.map((u) => u.id);
+  const { data: activeRows, error: activityError } = await admin
+    .from("sales")
+    .select("user_id")
+    .in("user_id", userIds)
+    .gte("created_at", since24h);
+
+  if (activityError) {
+    return Response.json({ success: false, error: activityError.message }, { status: 500 });
+  }
+
+  const activeSet = new Set((activeRows ?? []).map((r) => r.user_id));
+
+  let sentCount = 0;
+  let failedCount = 0;
+  for (const user of users) {
+    if (!activeSet.has(user.id)) continue;
+    const result = await reportD7Active(user.id, user.signed_up_at.slice(0, 10));
+    if (result.ok) sentCount += 1;
+    else failedCount += 1;
+  }
+
+  return Response.json({
+    success: true,
+    cohort_date_kst: cohort.date,
+    candidates_count: users.length,
+    active_count: activeSet.size,
+    sent_count: sentCount,
+    failed_count: failedCount,
+  });
+});

--- a/supabase/migrations/027_d7_tracker_cron.sql
+++ b/supabase/migrations/027_d7_tracker_cron.sql
@@ -1,0 +1,74 @@
+-- Migration: pg_cron 스케줄 — d7-tracker Edge Function 호출 (Phase 8 / T166)
+-- Spec: SC-008 funnel "d7_active" — D7 retention 측정.
+--
+-- 사전 요구 (push 인프라와 동일, docs/setup-push.md 참조):
+--   pg_cron / pg_net 확장 + Vault에 service_role_key + Edge Function `d7-tracker` 배포 +
+--   Edge Function secrets에 GA4_MEASUREMENT_ID / GA4_API_SECRET 등록
+--
+-- 시각: 매일 02:00 UTC = 11:00 KST. 아침 발주 알림(09:00 KST) 처리 직후 시점이라
+-- 사용자 활동 신호(첫 sale 입력)가 누적된 상태.
+
+-- 사전 검증
+do $$
+begin
+  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise exception 'pg_cron not enabled. Supabase 대시보드 → Database → Extensions';
+  end if;
+  if not exists (select 1 from pg_extension where extname = 'pg_net') then
+    raise exception 'pg_net not enabled. Supabase 대시보드 → Database → Extensions';
+  end if;
+end;
+$$;
+
+create schema if not exists private;
+grant usage on schema private to postgres;
+
+create or replace function private.invoke_d7_tracker()
+returns bigint
+language plpgsql
+security definer
+set search_path = public, vault
+as $$
+declare
+  v_project_url text := 'https://csekgdftbaomeqlcaohk.supabase.co';
+  v_service_key text;
+  v_request_id bigint;
+begin
+  select decrypted_secret into v_service_key
+  from vault.decrypted_secrets
+  where name = 'service_role_key';
+
+  if v_service_key is null then
+    raise warning 'service_role_key not in Supabase Vault — d7-tracker 호출 skip. docs/setup-push.md 참조';
+    return null;
+  end if;
+
+  select net.http_post(
+    url := v_project_url || '/functions/v1/d7-tracker',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || v_service_key
+    ),
+    body := '{}'::jsonb
+  ) into v_request_id;
+
+  return v_request_id;
+end;
+$$;
+
+comment on function private.invoke_d7_tracker() is
+  '⚠ pg_cron → d7-tracker Edge Function. Vault에 service_role_key + Edge Function secrets에 GA4_MEASUREMENT_ID/GA4_API_SECRET 미등록 시 silent no-op (return null 또는 sent_count=0).';
+
+-- 기존 스케줄 제거 후 재등록 (멱등성)
+do $$
+begin
+  perform cron.unschedule('d7_active_tracker');
+  exception when others then null;
+end;
+$$;
+
+select cron.schedule(
+  'd7_active_tracker',
+  '0 2 * * *',
+  $$select private.invoke_d7_tracker();$$
+);


### PR DESCRIPTION
## Summary

Phase 8 PR 38 — D7 retention 메트릭 (T166). SC-008 funnel 마지막 단계 `d7_active`. 매일 KST 11:00 cron이 가입 7일째 사용자 중 24h 내 sale 입력(핵심 가치 행위)이 있으면 GA4 발화.

### 변경 내역

- **`supabase/functions/d7-tracker/index.ts`** — Deno Edge Function
  - **KST cohort window** 계산: UTC 단순 비교 시 KST 저녁 가입자 누락되므로 `+09:00` offset 윈도우
  - 단일 `.in('user_id', ...)` 쿼리로 24h 활성 set 조회 (N+1 회피)
  - GA4 Measurement Protocol 발화 — `client_id`는 user.id (UUIDv4, PII 연결 불가)
  - 응답 `{success, cohort_date_kst, candidates_count, active_count, sent_count, failed_count}`로 운영 가시성

- **`supabase/migrations/027_d7_tracker_cron.sql`** — 매일 02:00 UTC (KST 11:00) cron + `private.invoke_d7_tracker()` helper. push-scheduler와 동일한 Vault 패턴 (silent skip on missing key)

- **`docs/setup-push.md`** — d7-tracker 배포 + cron 시각 추가

### simplify 적용 사항 (3-agent 리뷰 → 9건 모두 적용)

| # | 카테고리 | 내용 |
|---|---------|------|
| 1 | **critical 정확성** | 타임존 버그 — `signed_up_at::date = current_date - 7` (UTC)는 KST 저녁 가입자(15:00+ KST)가 다음 UTC 날짜로 넘어가 누락. `kstCohortWindow` 헬퍼로 KST 기준 window |
| 2 | off-by-one | `.lte("T23:59:59Z")`는 `.999ms` 윈도우 제외 → `.lt(다음날 시작)` 반열림 |
| 3 | N+1 | candidate 별 `count head:true` → 단일 `.in('user_id', userIds)` 쿼리로 활성 set |
| 4 | privacy/충돌 | GA4 `client_id`를 8자 hex prefix → 전체 UUIDv4 (32-bit 충돌 위험 차단, PII 아님) |
| 5 | 운영 가시성 | `reportToGa4` 가 `res.ok` 미체크로 silent data loss → `{ok}` 반환 + `failed_count` 응답 |
| 6 | 효율 | 불필요한 `UserRow` interface + redundant cast 제거 |
| 7 | 효율 | Date math 일관성 — `Date.now() - N * DAY_MS` |
| 8 | 효율 | `count > 0` → `activeSet.has()` truthy 분기 |
| 9 | 효율 | `027.sql` 중복 grant 정당화 코멘트 제거 |

### 사전 작업 (운영 활성화)

[docs/setup-push.md](docs/setup-push.md):
1. Vault에 `service_role_key` (push 인프라와 공유)
2. Edge Function `d7-tracker` 배포 (CI 자동, master 머지 시)
3. (선택) `GA4_MEASUREMENT_ID` / `GA4_API_SECRET` Edge Function secrets

미등록 시 cron은 등록되지만 silent no-op.

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 135/135 ✅
- build ✅
- 마이그레이션 027 클라우드 적용 완료

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [ ] **수동 검증 (PR 머지 후)**: Edge Function 배포 자동 → curl로 강제 트리거 (`success:true`), 7일 전 가입한 테스트 사용자 + 24h 내 sale 있을 때 `sent_count >= 1` 확인
- [ ] GA4 DebugView에서 `d7_active` 이벤트 수신 확인 (Edge Function secrets 등록 후)

Refs T166

🤖 Generated with [Claude Code](https://claude.com/claude-code)