### PR TITLE
chore(polish): Phase 9 perf checks — E2E 5분 + Lighthouse 절차 (T169/T171)

### DIFF
--- a/docs/lighthouse.md
+++ b/docs/lighthouse.md
@@ -1,0 +1,47 @@
+# Lighthouse 검증 (T171)
+
+`/sale` 라우트에서 PWA / Accessibility / Performance / Best Practices ≥ 90 검증. CI 게이트 아닌 출시 직전 일회성 베이스라인 + 회귀 발생 시 재실행.
+
+## 한 번 실행
+
+### 1. 프로덕션 빌드 + 프리뷰 서버
+
+```bash
+npm run build
+npm run start
+```
+
+`http://localhost:3000` 에 프로덕션 번들 띄우기 (dev server는 hot-reload 영향으로 점수 부정확).
+
+### 2. 별도 터미널에서 Lighthouse
+
+```bash
+npx --yes lighthouse@latest http://localhost:3000/sale \
+  --preset=desktop \
+  --form-factor=mobile \
+  --screenEmulation.mobile=true \
+  --screenEmulation.width=375 \
+  --screenEmulation.height=667 \
+  --screenEmulation.deviceScaleFactor=2 \
+  --only-categories=performance,accessibility,best-practices,pwa \
+  --output=html \
+  --output-path=./lighthouse-sale.html \
+  --chrome-flags="--headless"
+```
+
+브라우저로 `lighthouse-sale.html` 열어 4 카테고리 모두 ≥ 90 확인.
+
+> **로그인 게이트**: `/sale`은 인증 필요 → Lighthouse가 로그인 화면을 측정하게 됨. 실제 페르소나 흐름 측정이 필요하면 사전에 브라우저로 로그인하고 `--extra-headers='{"Cookie":"..."}'` 또는 storage state json을 전달.
+
+## 임계 미달 시
+
+| 카테고리       | 흔한 원인                                                                      |
+| -------------- | ------------------------------------------------------------------------------ |
+| Performance    | 큰 이미지 / 폰트 FOUT / 큰 JS 번들 (next-bundle-analyzer로 재료 식별)          |
+| Accessibility  | 색 대비 (디자인 토큰 ink-3 on bg 확인) / 미스매치 라벨 / aria 누락             |
+| PWA            | manifest.ts theme_color / icon 사이즈 / start_url / serviceWorker registration |
+| Best Practices | 콘솔 에러 / `<img>` aspect ratio / mixed content                               |
+
+## CI 통합 (선택, 베타 후 결정)
+
+`@lhci/cli` + `lighthouserc.cjs` 으로 자동화 가능. 단, dev/preview server를 CI에서 띄우는 비용 + 점수 변동성으로 게이트 부적합 → **회귀 알림용 PR 코멘트** 정도가 적절. 베타 트래픽으로 Web Vitals 실측 시작 후 도입 권장.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:integration": "vitest run tests/integration",
     "test:e2e": "playwright test",
     "test:coverage": "vitest run --coverage",
+    "lighthouse:sale": "npx --yes lighthouse@latest http://localhost:3000/sale --form-factor=mobile --screenEmulation.mobile=true --screenEmulation.width=375 --screenEmulation.height=667 --screenEmulation.deviceScaleFactor=2 --only-categories=performance,accessibility,best-practices,pwa --output=html --output-path=./lighthouse-sale.html --chrome-flags=--headless",
     "db:reset": "supabase db reset --linked",
     "db:gen-types": "supabase gen types typescript --linked"
   },

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -31,7 +31,14 @@ test.describe("골든패스: 가입 → 메뉴 → 매입 → 판매 → 마진"
     if (user?.id) await cleanupTestUser(user.id);
   });
 
-  test("템플릿 → 매입(얼음 1000g @ 5000원) → 팥빙수 1개 판매 → 마진 ~83%", async ({ page }) => {
+  test("템플릿 → 매입(얼음 1000g @ 5000원) → 팥빙수 1개 판매 → 마진 ~83% (5분 이내)", async ({
+    page,
+  }) => {
+    // T169: 페르소나 골든패스 wall-clock 시간을 5분 이내로 제한 (SC-001/SC-007).
+    // E2E는 사람보다 훨씬 빠르므로 경고 임계로 충분 — 회귀 시 disconnect/retry 누적이
+    // 5분에 가까워지면 조기 알림.
+    const startedAt = Date.now();
+
     // 1) 로그인
     await page.goto("/login");
     await dismissConsentBanner(page);
@@ -103,5 +110,12 @@ test.describe("골든패스: 가입 → 메뉴 → 매입 → 판매 → 마진"
     await saveButton.scrollIntoViewIfNeeded();
     await saveButton.click();
     await expect(page).toHaveURL(/\/today/, { timeout: 10_000 });
+
+    // 7) 페르소나 시간 게이트 (T169, SC-001/SC-007)
+    const elapsedMs = Date.now() - startedAt;
+    expect(
+      elapsedMs,
+      `골든패스 5분 초과: ${(elapsedMs / 1000).toFixed(1)}s — 회귀로 사용자 마찰 누적 가능`,
+    ).toBeLessThan(5 * 60 * 1000);
   });
 });


### PR DESCRIPTION
## Summary

Phase 9 두 번째 PR — 페르소나 시간 게이트 + Lighthouse 절차. 자동화 게이트로 적합한 것만 CI 통합, 나머지는 셀프서비스 docs로 위임.

### 변경 내역

**T169 — 페르소나 골든패스 ≤ 5분 (SC-001/SC-007)**
- `tests/e2e/golden-path.spec.ts` 시작/종료 timestamp + 단일 assertion 추가
- E2E는 사람보다 훨씬 빠르므로 5분 게이트는 회귀 경고 임계로 작동 — 재시도 / disconnect 누적이 5분 근접 시 조기 알림

**T171 — Lighthouse `/sale` 모바일 (375x667)**
- [docs/lighthouse.md](docs/lighthouse.md) 절차 문서 — 빌드 → 프리뷰 → `npx lighthouse` 명령
- `package.json`에 `npm run lighthouse:sale` 스크립트 (npx 임시 실행, 새 의존성 없음)
- CI 게이트 부적합 — dev server 의존 + 점수 변동성. 출시 직전 1회 베이스라인 + 회귀 시 재실행 패턴. 베타 트래픽 후 Web Vitals 실측으로 자동화 도입 권장

### 자동화 vs 수동 분류

| Task | 분류 | 이유 |
|---|---|---|
| T169 페르소나 5분 | **자동 (CI 게이트)** | wall-clock 시간은 회귀에 민감, 측정 비용 낮음 |
| T171 Lighthouse | **셀프서비스 docs + 스크립트** | dev server 띄우기 + 점수 변동성으로 CI 게이트 부적합 |

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 152/152 ✅
- build ✅

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [x] E2E 골든패스 시간 게이트 (CI E2E job에서 자동)
- [ ] **수동 (출시 직전)**: `npm run build && npm start` → 별도 터미널 `npm run lighthouse:sale` → 4 카테고리 ≥ 90 확인

Refs T169 T171

🤖 Generated with [Claude Code](https://claude.com/claude-code)