### PR TITLE
fix(routing): 루트 페이지 placeholder 제거 → 인증 상태 redirect

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,17 @@
-export default function HomePage(): React.ReactElement {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-8 text-center">
-      <h1 className="text-2xl font-bold">이지스톡</h1>
-      <p className="mt-2 text-sm text-gray-600">카페·빙수집 사장님을 위한 재고·원가 관리 서비스</p>
-      <p className="mt-6 text-xs text-gray-400">데이터 수집 중 — 곧 만나요</p>
-    </main>
-  );
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * 루트 라우트 — 인증 상태에 따라 즉시 분기.
+ *  - 로그인 → /today (홈 대시보드)
+ *  - 비로그인 → /login
+ *
+ * RSC 단계에서 redirect()로 처리 — 사용자에게 placeholder가 잠시도 안 보이도록.
+ */
+export default async function RootPage(): Promise<never> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  redirect(user ? "/today" : "/login");
 }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("home page renders 이지스톡 heading", async ({ page }) => {
+test("/ 비로그인 진입 시 /login으로 redirect", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByRole("heading", { name: "이지스톡" })).toBeVisible();
+  await expect(page).toHaveURL(/\/login/);
 });


### PR DESCRIPTION
## Summary

기존 [src/app/page.tsx](src/app/page.tsx)는 "데이터 수집 중 — 곧 만나요" 문구만 띄우는 placeholder. 사용자가 `/` 진입 시 항상 placeholder가 잠시 보이고, 로그인 됐어도 그 자리에서 멈춰 있어 사용자 흐름과 어긋남.

### 변경 내역

루트 라우트를 server component로 바꿔 RSC 단계에서 즉시 redirect:
- 로그인 → `/today` (홈 대시보드)
- 비로그인 → `/login`

middleware는 `/`를 `PUBLIC_PATHS`에 그대로 두고, 인증 분기는 page.tsx가 담당. RSC `redirect()`라 사용자에게 placeholder가 한 순간도 안 보임.

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 152/152 ✅
- build ✅ (`/`는 `ƒ` server-rendered on demand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)