### PR TITLE
feat(menu+inventory): 메뉴 수정/삭제 + 재료 등록 UI

### DIFF
--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
 import { IngredientStatusList } from "@/features/inventory/components/IngredientStatusList";
 import { ColdStartNotice } from "@/features/inventory/components/ColdStartNotice";
+import { AddIngredientForm } from "@/features/inventory/components/AddIngredientForm";
 
 export default function InventoryPage(): React.ReactElement {
   const { data, isLoading, error } = useDepletionForecast();
@@ -41,6 +42,8 @@ export default function InventoryPage(): React.ReactElement {
       {isAllColdStart && <ColdStartNotice />}
 
       {data && <IngredientStatusList items={data} />}
+
+      <AddIngredientForm />
     </section>
   );
 }

--- a/src/app/(main)/menu/[id]/edit/page.tsx
+++ b/src/app/(main)/menu/[id]/edit/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { MenuForm } from "@/features/menu/components/MenuForm";
+import { useMenus } from "@/features/menu/hooks/useMenus";
+import type { MenuInput } from "@/features/menu/schemas";
+
+interface IngredientOption {
+  id: string;
+  name: string;
+  unit: string;
+}
+
+export default function MenuEditPage(): React.ReactElement {
+  const { id } = useParams<{ id: string }>();
+  const { data: menus, isLoading: menusLoading, error: menusError } = useMenus();
+  const [ingredients, setIngredients] = useState<IngredientOption[]>([]);
+  const [ingredientsLoading, setIngredientsLoading] = useState(true);
+  const [ingredientsError, setIngredientsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+    void supabase
+      .from("ingredients")
+      .select("id, name, unit")
+      .eq("is_active", true)
+      .order("name")
+      .then(({ data, error }) => {
+        if (error) setIngredientsError(error.message);
+        else setIngredients(data ?? []);
+        setIngredientsLoading(false);
+      });
+  }, []);
+
+  const menu = menus?.find((m) => m.id === id);
+  const isLoading = menusLoading || ingredientsLoading;
+
+  return (
+    <section className="flex flex-col gap-section">
+      <header className="flex items-center justify-between">
+        <h1 className="text-title-lg text-ink-1">메뉴 수정</h1>
+        <Link href={`/menu/${id}`} className="text-body-regular text-ink-3 hover:text-ink-2">
+          취소
+        </Link>
+      </header>
+
+      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
+
+      {ingredientsError && (
+        <p role="alert" className="text-body-regular text-red">
+          재료 목록을 불러오지 못했어요: {ingredientsError}
+        </p>
+      )}
+
+      {menusError && (
+        <p role="alert" className="text-body-regular text-red">
+          {menusError.message}
+        </p>
+      )}
+
+      {!isLoading && !ingredientsError && menus && !menu && (
+        <p className="text-body-regular text-ink-3">메뉴를 찾을 수 없습니다.</p>
+      )}
+
+      {menu && !ingredientsError && (
+        <MenuForm
+          ingredients={ingredients}
+          mode={{
+            kind: "edit",
+            menuId: menu.id,
+            initialValues: toInitialValues(menu),
+          }}
+        />
+      )}
+    </section>
+  );
+}
+
+function toInitialValues(
+  menu: NonNullable<ReturnType<typeof useMenus>["data"]>[number],
+): MenuInput {
+  return {
+    name: menu.name,
+    price: menu.price,
+    recipe: menu.recipe_items.map((item) => ({
+      ingredientId: item.ingredient.id,
+      quantityPerServing: item.quantity_per_serving,
+    })),
+  };
+}

--- a/src/app/(main)/menu/[id]/page.tsx
+++ b/src/app/(main)/menu/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useMenus } from "@/features/menu/hooks/useMenus";
 import { MenuDetailCard } from "@/features/menu/components/MenuDetailCard";
+import { MenuActions } from "@/features/menu/components/MenuActions";
 
 export default function MenuDetailPage(): React.ReactElement {
   const { id } = useParams<{ id: string }>();
@@ -29,7 +30,12 @@ export default function MenuDetailPage(): React.ReactElement {
 
       {data && !menu && <p className="text-body-regular text-ink-3">메뉴를 찾을 수 없습니다.</p>}
 
-      {menu && <MenuDetailCard menu={menu} />}
+      {menu && (
+        <>
+          <MenuDetailCard menu={menu} />
+          <MenuActions menuId={menu.id} menuName={menu.name} />
+        </>
+      )}
     </section>
   );
 }

--- a/src/app/(main)/menu/new/page.tsx
+++ b/src/app/(main)/menu/new/page.tsx
@@ -56,7 +56,7 @@ export default function MenuNewPage(): React.ReactElement {
       )}
 
       {!isLoading && !ingredientsError && (
-        <MenuForm ingredients={ingredients} isFirstMenu={isFirstMenu} />
+        <MenuForm ingredients={ingredients} mode={{ kind: "create", isFirstMenu }} />
       )}
     </section>
   );

--- a/src/features/inventory/components/AddIngredientForm.tsx
+++ b/src/features/inventory/components/AddIngredientForm.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { ingredientInputSchema, type IngredientInput } from "@/features/purchase/schemas";
+import { useCreateIngredient } from "@/features/purchase/hooks/useIngredients";
+
+const UNIT_LABELS: Record<IngredientInput["unit"], string> = {
+  g: "g (그램)",
+  ml: "ml (밀리리터)",
+  piece: "개",
+};
+
+/**
+ * 재료 페이지 인라인 등록 폼.
+ * 토글 형태 — 평소엔 "+ 재료 추가" 버튼, 클릭 시 펼쳐짐.
+ *
+ * unit은 등록 후 변경 불가 (data-model.md §2 — `reject_unit_change` 트리거).
+ * 사용자가 명시적으로 인지하도록 라벨에 안내.
+ */
+export function AddIngredientForm(): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const createMutation = useCreateIngredient();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<IngredientInput>({
+    resolver: zodResolver(ingredientInputSchema),
+    defaultValues: { name: "", unit: "g" },
+  });
+
+  async function onSubmit(values: IngredientInput): Promise<void> {
+    setSubmitError(null);
+    try {
+      await createMutation.mutateAsync(values);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "등록 실패");
+      return;
+    }
+    reset();
+    setIsOpen(false);
+  }
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="rounded-md border border-dashed border-border-strong px-stack py-stack-tight text-body-regular text-ink-3 hover:bg-card-hover"
+      >
+        + 재료 추가
+      </button>
+    );
+  }
+
+  const submitting = isSubmitting || createMutation.isPending;
+
+  return (
+    <form
+      onSubmit={(event) => void handleSubmit(onSubmit)(event)}
+      className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile"
+      noValidate
+    >
+      <header className="flex items-center justify-between">
+        <h2 className="text-label text-ink-2">재료 등록</h2>
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            setIsOpen(false);
+            setSubmitError(null);
+          }}
+          className="text-caption text-ink-3 hover:text-ink-2"
+        >
+          취소
+        </button>
+      </header>
+
+      <Field label="재료 이름" error={errors.name?.message}>
+        <input
+          {...register("name")}
+          type="text"
+          placeholder="예: 우유, 시럽, 컵"
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        />
+      </Field>
+
+      <Field label="단위 (등록 후 변경 불가)" error={errors.unit?.message}>
+        <select
+          {...register("unit")}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        >
+          {(Object.keys(UNIT_LABELS) as Array<IngredientInput["unit"]>).map((unit) => (
+            <option key={unit} value={unit}>
+              {UNIT_LABELS[unit]}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      {submitError && (
+        <p role="alert" className="text-body-regular text-red">
+          {submitError}
+        </p>
+      )}
+
+      <PrimaryButton type="submit" disabled={submitting}>
+        {submitting ? "등록 중…" : "등록"}
+      </PrimaryButton>
+    </form>
+  );
+}

--- a/src/features/menu/components/MenuActions.tsx
+++ b/src/features/menu/components/MenuActions.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useDeleteMenu } from "../hooks/useMenuMutations";
+
+interface MenuActionsProps {
+  menuId: string;
+  menuName: string;
+}
+
+/**
+ * 메뉴 상세 페이지의 수정/삭제 액션. 삭제는 soft delete + confirm.
+ * sale_items 참조는 보존 (헌법 III 스냅샷) — 통계에는 남고 목록에서만 사라짐.
+ */
+export function MenuActions({ menuId, menuName }: MenuActionsProps): React.ReactElement {
+  const router = useRouter();
+  const deleteMutation = useDeleteMenu();
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete(): Promise<void> {
+    const confirmed = window.confirm(
+      `"${menuName}" 메뉴를 삭제할까요?\n\n과거 판매 기록은 그대로 보존되고 메뉴 목록에서만 사라져요.`,
+    );
+    if (!confirmed) return;
+
+    setError(null);
+    try {
+      await deleteMutation.mutateAsync(menuId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "삭제 실패");
+      return;
+    }
+    router.push("/menu");
+  }
+
+  return (
+    <div className="flex flex-col gap-stack-tight">
+      <div className="flex gap-stack-tight">
+        <Link
+          href={`/menu/${menuId}/edit`}
+          className="flex-1 rounded-md border border-border bg-card py-stack-tight text-center text-body-regular text-ink-1 hover:bg-card-hover"
+        >
+          수정
+        </Link>
+        <button
+          type="button"
+          onClick={() => void handleDelete()}
+          disabled={deleteMutation.isPending}
+          className="flex-1 rounded-md border border-red bg-card py-stack-tight text-body-regular text-red-deep hover:bg-red-soft disabled:opacity-60"
+        >
+          {deleteMutation.isPending ? "삭제 중…" : "삭제"}
+        </button>
+      </div>
+      {error && (
+        <p role="alert" className="text-caption text-red">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/menu/components/MenuForm.tsx
+++ b/src/features/menu/components/MenuForm.tsx
@@ -12,6 +12,7 @@ import { Field } from "@/components/ui/field";
 import { PrimaryButton } from "@/components/ui/primary-button";
 import { menuSchema, type MenuInput } from "../schemas";
 import { menuListQueryKey } from "../hooks/useMenus";
+import { useEditMenu } from "../hooks/useMenuMutations";
 
 interface IngredientOption {
   id: string;
@@ -19,15 +20,20 @@ interface IngredientOption {
   unit: string;
 }
 
+type MenuFormMode =
+  | { kind: "create"; isFirstMenu: boolean }
+  | { kind: "edit"; menuId: string; initialValues: MenuInput };
+
 interface MenuFormProps {
   ingredients: readonly IngredientOption[];
-  isFirstMenu: boolean;
+  mode: MenuFormMode;
 }
 
-export function MenuForm({ ingredients, isFirstMenu }: MenuFormProps): React.ReactElement {
+export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactElement {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const editMutation = useEditMenu();
 
   const {
     register,
@@ -36,7 +42,7 @@ export function MenuForm({ ingredients, isFirstMenu }: MenuFormProps): React.Rea
     formState: { errors, isSubmitting },
   } = useForm<MenuInput>({
     resolver: zodResolver(menuSchema),
-    defaultValues: { name: "", price: 0, recipe: [] },
+    defaultValues: mode.kind === "edit" ? mode.initialValues : { name: "", price: 0, recipe: [] },
   });
 
   const { fields, append, remove } = useFieldArray({ control, name: "recipe" });
@@ -44,25 +50,34 @@ export function MenuForm({ ingredients, isFirstMenu }: MenuFormProps): React.Rea
   async function onSubmit(values: MenuInput): Promise<void> {
     setSubmitError(null);
 
+    if (mode.kind === "edit") {
+      try {
+        await editMutation.mutateAsync({ menuId: mode.menuId, values });
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : "수정 실패");
+        return;
+      }
+      router.push(`/menu/${mode.menuId}`);
+      return;
+    }
+
     const supabase = createClient();
     const { error } = await saveMenu(supabase, {
       name: values.name,
       price: values.price,
       recipe: values.recipe,
     });
-
     if (error) {
       setSubmitError(error.message);
       return;
     }
-
-    if (isFirstMenu) {
-      trackEvent("first_menu_registered", {});
-    }
-
+    if (mode.isFirstMenu) trackEvent("first_menu_registered", {});
     void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
     router.push("/menu");
   }
+
+  const submitting = isSubmitting || editMutation.isPending;
+  const submitLabel = mode.kind === "edit" ? "수정 저장" : "저장";
 
   return (
     <form
@@ -126,8 +141,8 @@ export function MenuForm({ ingredients, isFirstMenu }: MenuFormProps): React.Rea
         </p>
       )}
 
-      <PrimaryButton type="submit" disabled={isSubmitting}>
-        {isSubmitting ? "저장 중…" : "저장"}
+      <PrimaryButton type="submit" disabled={submitting}>
+        {submitting ? "저장 중…" : submitLabel}
       </PrimaryButton>
     </form>
   );

--- a/src/features/menu/hooks/useMenuMutations.ts
+++ b/src/features/menu/hooks/useMenuMutations.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { deleteMenu, editMenu } from "@/lib/supabase/rpc";
+import type { MenuInput } from "../schemas";
+import { menuListQueryKey } from "./useMenus";
+
+interface EditMenuVariables {
+  menuId: string;
+  values: MenuInput;
+}
+
+export function useEditMenu(): UseMutationResult<string, Error, EditMenuVariables> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ menuId, values }) => {
+      const supabase = createClient();
+      const { data, error } = await editMenu(supabase, {
+        menuId,
+        name: values.name,
+        price: values.price,
+        recipe: values.recipe,
+      });
+      if (error) throw new Error(error.message);
+      const row = data?.[0];
+      if (!row) throw new Error("edit_menu returned empty");
+      return row.menu_id;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+    },
+  });
+}
+
+export function useDeleteMenu(): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (menuId) => {
+      const supabase = createClient();
+      const { error } = await deleteMenu(supabase, menuId);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+    },
+  });
+}

--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -63,6 +63,7 @@ async function fetchMenus(): Promise<MenuRowWithRecipe[]> {
       )
     `,
     )
+    .eq("is_active", true)
     .order("name");
 
   if (error) {

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -78,6 +78,37 @@ interface SaveMenuRow {
   menu_id: string;
 }
 
+interface EditMenuArgs extends SaveMenuArgs {
+  menuId: string;
+}
+
+interface DeleteMenuRow {
+  menu_id: string;
+  was_active: boolean;
+}
+
+export function editMenu(
+  client: ClientLike,
+  args: EditMenuArgs,
+): Promise<RpcResult<SaveMenuRow[]>> {
+  return callRpc(client, "edit_menu", {
+    p_menu_id: args.menuId,
+    p_name: args.name,
+    p_price: args.price,
+    p_recipe: args.recipe.map((it) => ({
+      ingredient_id: it.ingredientId,
+      quantity_per_serving: it.quantityPerServing,
+    })),
+  });
+}
+
+export function deleteMenu(
+  client: ClientLike,
+  menuId: string,
+): Promise<RpcResult<DeleteMenuRow[]>> {
+  return callRpc(client, "delete_menu", { p_menu_id: menuId });
+}
+
 export function saveMenu(
   client: ClientLike,
   args: SaveMenuArgs,

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -705,7 +705,25 @@ export type Database = {
           menu_ids: string[]
         }[]
       }
+      delete_menu: {
+        Args: { p_menu_id: string }
+        Returns: {
+          menu_id: string
+          was_active: boolean
+        }[]
+      }
       delete_sale: { Args: { p_sale_id: string }; Returns: undefined }
+      edit_menu: {
+        Args: {
+          p_menu_id: string
+          p_name: string
+          p_price: number
+          p_recipe?: Json
+        }
+        Returns: {
+          menu_id: string
+        }[]
+      }
       edit_sale: {
         Args: { p_new_items: Json; p_reason?: string; p_sale_id: string }
         Returns: {

--- a/supabase/migrations/028_edit_delete_menu_rpcs.sql
+++ b/supabase/migrations/028_edit_delete_menu_rpcs.sql
@@ -1,0 +1,113 @@
+-- Migration: edit_menu + delete_menu RPCs
+-- 호출자: 인증된 사용자가 본인 소유 메뉴를 수정/삭제.
+--
+-- 헌법 III 호환:
+--  - 메뉴 가격/원가 변경은 sale_items.unit_price / menu_cost_snapshot에 영향 X
+--    (이미 저장된 sale은 스냅샷 기반 — 과거 마진 영구 불변).
+--  - 따라서 단순 UPDATE로 충분.
+--
+-- 삭제는 soft delete (is_active=false). 이유: sale_items.menu_id → menus.id on delete restrict
+-- 이라 하드 delete 시 과거 sale이 있는 메뉴는 거부됨. soft delete는 UX 일관 + 통계 보존.
+
+create or replace function public.edit_menu(
+  p_menu_id uuid,
+  p_name text,
+  p_price numeric,
+  p_recipe jsonb default '[]'::jsonb
+)
+returns table (menu_id uuid)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+  v_owns boolean;
+  v_item jsonb;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+  if jsonb_typeof(p_recipe) <> 'array' then
+    raise exception 'recipe must be a JSONB array' using errcode = '22023';
+  end if;
+
+  -- 본인 소유 메뉴인지 검증 (RLS도 막지만 명시적 에러 메시지)
+  select exists (
+    select 1 from public.menus
+    where id = p_menu_id and user_id = v_user_id
+  ) into v_owns;
+
+  if not v_owns then
+    raise exception 'menu_not_found_or_forbidden' using errcode = '42501';
+  end if;
+
+  update public.menus
+  set name = p_name, price = p_price
+  where id = p_menu_id and user_id = v_user_id;
+
+  -- 레시피는 delete + insert (recipe_items 작아서 diff 비용 무의미)
+  delete from public.recipe_items where menu_id = p_menu_id;
+
+  for v_item in select * from jsonb_array_elements(p_recipe)
+  loop
+    insert into public.recipe_items (menu_id, user_id, ingredient_id, quantity_per_serving)
+    values (
+      p_menu_id,
+      v_user_id,
+      (v_item ->> 'ingredient_id')::uuid,
+      (v_item ->> 'quantity_per_serving')::numeric
+    );
+  end loop;
+
+  return query select p_menu_id;
+end;
+$$;
+
+comment on function public.edit_menu(uuid, text, numeric, jsonb) is
+  '메뉴 + 레시피 수정 (트랜잭셔널). 과거 sale의 unit_price/menu_cost_snapshot은 스냅샷이라 영향 없음 (헌법 III).';
+
+revoke all on function public.edit_menu(uuid, text, numeric, jsonb) from public;
+grant execute on function public.edit_menu(uuid, text, numeric, jsonb) to authenticated;
+
+-- ─── delete_menu (soft delete) ──────────────────────────────────
+create or replace function public.delete_menu(p_menu_id uuid)
+returns table (menu_id uuid, was_active boolean)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+  v_was_active boolean;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  -- 본인 소유 + 현재 active 상태 회수
+  select is_active into v_was_active
+  from public.menus
+  where id = p_menu_id and user_id = v_user_id;
+
+  if v_was_active is null then
+    raise exception 'menu_not_found_or_forbidden' using errcode = '42501';
+  end if;
+
+  -- soft delete: 이미 비활성이어도 idempotent
+  update public.menus
+  set is_active = false
+  where id = p_menu_id and user_id = v_user_id;
+
+  return query
+  select p_menu_id, v_was_active;
+end;
+$$;
+
+comment on function public.delete_menu(uuid) is
+  '메뉴 soft delete (is_active=false). 과거 sale_items.menu_id 참조 보존 — 통계/매출 history 영구 유지.';
+
+revoke all on function public.delete_menu(uuid) from public;
+grant execute on function public.delete_menu(uuid) to authenticated;

--- a/tests/integration/menu-edit-delete.test.ts
+++ b/tests/integration/menu-edit-delete.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  cleanupTestUser,
+  createTestUser,
+  hasSupabaseTestEnv,
+  signInAs,
+  type TestUser,
+} from "../helpers/test-supabase";
+import { cloneMenuTemplate, deleteMenu, editMenu, saveMenu } from "@/lib/supabase/rpc";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * `edit_menu` / `delete_menu` RPC 통합 테스트.
+ * - 본인 소유 메뉴 수정/삭제 정상
+ * - 다른 사용자 메뉴 수정/삭제는 차단 (헌법 IV)
+ * - 삭제는 soft (is_active=false), 과거 sale 참조 보존
+ */
+
+const describeMenuMutations = hasSupabaseTestEnv ? describe : describe.skip;
+
+describeMenuMutations("edit_menu / delete_menu RPC", () => {
+  let user: TestUser;
+  let client: SupabaseClient<Database>;
+  let ingredientId: string;
+
+  beforeAll(async () => {
+    user = await createTestUser({ storeType: "cafe" });
+    client = await signInAs(user);
+
+    await cloneMenuTemplate(client, { storeType: "cafe" });
+    const ing = await client.from("ingredients").select("id").eq("name", "원두").single();
+    ingredientId = ing.data!.id;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (user?.id) await cleanupTestUser(user.id);
+  }, 30_000);
+
+  it("edit_menu — 이름/가격/레시피 수정", async () => {
+    const created = await saveMenu(client, {
+      name: "테스트라떼",
+      price: 5000,
+      recipe: [{ ingredientId, quantityPerServing: 20 }],
+    });
+    expect(created.error).toBeNull();
+    const menuId = created.data![0]!.menu_id;
+
+    const edited = await editMenu(client, {
+      menuId,
+      name: "테스트라떼-수정",
+      price: 5500,
+      recipe: [{ ingredientId, quantityPerServing: 25 }],
+    });
+    expect(edited.error).toBeNull();
+
+    const after = await client
+      .from("menus")
+      .select("name, price, recipe_items(quantity_per_serving)")
+      .eq("id", menuId)
+      .single();
+    expect(after.data!.name).toBe("테스트라떼-수정");
+    expect(Number(after.data!.price)).toBe(5500);
+    expect(after.data!.recipe_items).toHaveLength(1);
+    expect(Number(after.data!.recipe_items[0]!.quantity_per_serving)).toBe(25);
+  });
+
+  it("delete_menu — soft delete (is_active=false)", async () => {
+    const created = await saveMenu(client, {
+      name: "삭제용메뉴",
+      price: 3000,
+      recipe: [],
+    });
+    const menuId = created.data![0]!.menu_id;
+
+    const deleted = await deleteMenu(client, menuId);
+    expect(deleted.error).toBeNull();
+    expect(deleted.data![0]!.was_active).toBe(true);
+
+    const row = await client.from("menus").select("is_active").eq("id", menuId).single();
+    expect(row.data!.is_active).toBe(false);
+  });
+
+  it("다른 사용자 메뉴는 수정/삭제 불가 (헌법 IV)", async () => {
+    const otherUser = await createTestUser({ storeType: "cafe" });
+    const otherClient = await signInAs(otherUser);
+    await cloneMenuTemplate(otherClient, { storeType: "cafe" });
+    const otherMenu = await otherClient
+      .from("menus")
+      .select("id")
+      .eq("name", "아메리카노")
+      .single();
+    const otherMenuId = otherMenu.data!.id;
+
+    const edit = await editMenu(client, {
+      menuId: otherMenuId,
+      name: "해킹시도",
+      price: 0,
+      recipe: [],
+    });
+    expect(edit.error?.message).toMatch(/not_found_or_forbidden|permission/);
+
+    const del = await deleteMenu(client, otherMenuId);
+    expect(del.error?.message).toMatch(/not_found_or_forbidden|permission/);
+
+    await cleanupTestUser(otherUser.id);
+  });
+});


### PR DESCRIPTION
## Summary

3개 기능 묶음 — 메뉴 수정 / 메뉴 삭제 / 재료 페이지 인라인 등록.

### 변경 내역

**메뉴 수정 (`/menu/[id]/edit`)**
- `MenuForm`을 discriminated union `mode: { kind: 'create' | 'edit', ... }`로 리팩토링 — 신규 + 편집 양쪽 지원, defaultValues prefill
- 편집 라우트 + `useEditMenu` mutation hook
- 헌법 III 호환: 메뉴 가격/레시피 변경은 `sale_items.unit_price`/`menu_cost_snapshot` 스냅샷에 영향 없음 → 단순 UPDATE + recipe_items delete-and-insert

**메뉴 삭제 (상세 페이지)**
- `MenuActions` 컴포넌트 — 수정 + 삭제 버튼, `window.confirm` 안내
- **Soft delete** (`is_active=false`): `sale_items.menu_id on delete restrict` 회피 + 통계/매출 history 영구 유지
- `useMenus`에 `.eq("is_active", true)` 필터 → 삭제된 메뉴는 목록에서 즉시 사라짐

**재료 등록 (재료 페이지 인라인 폼)**
- `AddIngredientForm` — 토글 형태 (`+ 재료 추가` 버튼 → 폼 펼침)
- 이름 + 단위 (g/ml/개)
- `unit`은 등록 후 변경 불가 (`reject_unit_change` 트리거) — 라벨에 명시

### DB

`supabase/migrations/028_edit_delete_menu_rpcs.sql`:
- `edit_menu(p_menu_id, p_name, p_price, p_recipe)` — 본인 소유 검증 + UPDATE + recipe_items 재구성
- `delete_menu(p_menu_id)` — soft delete, idempotent (이미 비활성이어도 OK)
- 둘 다 헌법 IV (security definer + auth.uid() + 본인 소유 검증)
- `#variable_conflict use_column`로 `menu_id` ambiguity 회피

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **155/155** ✅ (통합 +3: 메뉴 수정 / soft delete / 다른 사용자 차단)
- build ✅
- 마이그레이션 028 클라우드 적용 완료

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [ ] **수동 (PR 머지 후)**: `/menu/[id]` → 수정 / 삭제 동작 + `/inventory` 재료 추가 폼

🤖 Generated with [Claude Code](https://claude.com/claude-code)