### PR TITLE
fix(inventory): 재료 캐시 무효화 + 재료 삭제 기능

### DIFF
--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { daysUntilDate, formatNumber } from "@/lib/utils/format";
 import type { DepletionStatus } from "@/lib/domain/forecast";
+import { useDeleteIngredient } from "@/features/purchase/hooks/useIngredients";
 import type { IngredientForecastView } from "../hooks/useDepletionForecast";
 
 interface IngredientStatusListProps {
@@ -61,21 +63,60 @@ export function IngredientStatusList({ items }: IngredientStatusListProps): Reac
 
 function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactElement {
   const depletionLabel = formatDepletion(item);
+  const deleteMutation = useDeleteIngredient();
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete(): Promise<void> {
+    const confirmed = window.confirm(
+      `"${item.name}" 재료를 삭제할까요?\n\n사용 중인 메뉴 + 단가 history는 보존되고 재료 목록에서만 사라져요.`,
+    );
+    if (!confirmed) return;
+    setError(null);
+    try {
+      const result = await deleteMutation.mutateAsync(item.ingredientId);
+      if (result.inUseMenuCount > 0) {
+        window.alert(
+          `삭제 완료. 이 재료를 쓰던 메뉴 ${result.inUseMenuCount}개는 그대로 남아있어요. 메뉴 페이지에서 다른 재료로 교체하거나 메뉴 자체를 삭제하세요.`,
+        );
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "삭제 실패");
+    }
+  }
+
   return (
-    <li className="flex items-center justify-between rounded-lg border border-border bg-card px-tile py-stack">
-      <div className="flex flex-col gap-1">
-        <span className="text-body text-ink-1">{item.name}</span>
-        <span className="text-caption text-ink-3 tabular-nums">
-          현재 {formatNumber(item.currentStock)}
-          {item.unit}
-          <span className="text-ink-4"> · </span>
-          리드타임 {item.leadTimeDays}일
-        </span>
+    <li className="flex flex-col gap-1 rounded-lg border border-border bg-card px-tile py-stack">
+      <div className="flex items-center justify-between gap-stack">
+        <div className="flex flex-col gap-1">
+          <span className="text-body text-ink-1">{item.name}</span>
+          <span className="text-caption text-ink-3 tabular-nums">
+            현재 {formatNumber(item.currentStock)}
+            {item.unit}
+            <span className="text-ink-4"> · </span>
+            리드타임 {item.leadTimeDays}일
+          </span>
+        </div>
+        <div className="flex items-center gap-stack-tight">
+          <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
+            <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
+            {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleDelete()}
+            disabled={deleteMutation.isPending}
+            aria-label={`${item.name} 삭제`}
+            className="flex h-7 w-7 items-center justify-center rounded-md border border-border text-caption text-ink-3 hover:border-red hover:text-red disabled:opacity-50"
+          >
+            ×
+          </button>
+        </div>
       </div>
-      <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
-        <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
-        {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
-      </div>
+      {error && (
+        <p role="alert" className="text-caption text-red">
+          {error}
+        </p>
+      )}
     </li>
   );
 }

--- a/src/features/purchase/hooks/useIngredients.ts
+++ b/src/features/purchase/hooks/useIngredients.ts
@@ -8,7 +8,8 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { saveIngredient } from "@/lib/supabase/rpc";
+import { deleteIngredient, saveIngredient } from "@/lib/supabase/rpc";
+import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import type { IngredientInput } from "../schemas";
 
 export interface IngredientRow {
@@ -64,12 +65,38 @@ async function createIngredient(input: IngredientInput): Promise<IngredientRow> 
   };
 }
 
+function invalidateIngredientCaches(queryClient: ReturnType<typeof useQueryClient>): void {
+  // 재료 목록 + 소진 예측 둘 다 무효화 — 두 쿼리는 모두 ingredients 테이블에 의존.
+  void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+  void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
+}
+
 export function useCreateIngredient(): UseMutationResult<IngredientRow, Error, IngredientInput> {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createIngredient,
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
-    },
+    onSuccess: () => invalidateIngredientCaches(queryClient),
+  });
+}
+
+export interface DeleteIngredientResult {
+  ingredientId: string;
+  inUseMenuCount: number;
+}
+
+async function deleteIngredientById(ingredientId: string): Promise<DeleteIngredientResult> {
+  const supabase = createClient();
+  const { data, error } = await deleteIngredient(supabase, ingredientId);
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("delete_ingredient: empty response");
+  return { ingredientId: row.ingredient_id, inUseMenuCount: row.in_use_menu_count };
+}
+
+export function useDeleteIngredient(): UseMutationResult<DeleteIngredientResult, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteIngredientById,
+    onSuccess: () => invalidateIngredientCaches(queryClient),
   });
 }

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -109,6 +109,19 @@ export function deleteMenu(
   return callRpc(client, "delete_menu", { p_menu_id: menuId });
 }
 
+interface DeleteIngredientRow {
+  ingredient_id: string;
+  was_active: boolean;
+  in_use_menu_count: number;
+}
+
+export function deleteIngredient(
+  client: ClientLike,
+  ingredientId: string,
+): Promise<RpcResult<DeleteIngredientRow[]>> {
+  return callRpc(client, "delete_ingredient", { p_ingredient_id: ingredientId });
+}
+
 export function saveMenu(
   client: ClientLike,
   args: SaveMenuArgs,

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -705,6 +705,14 @@ export type Database = {
           menu_ids: string[]
         }[]
       }
+      delete_ingredient: {
+        Args: { p_ingredient_id: string }
+        Returns: {
+          in_use_menu_count: number
+          ingredient_id: string
+          was_active: boolean
+        }[]
+      }
       delete_menu: {
         Args: { p_menu_id: string }
         Returns: {

--- a/supabase/migrations/029_delete_ingredient_rpc.sql
+++ b/supabase/migrations/029_delete_ingredient_rpc.sql
@@ -1,0 +1,61 @@
+-- Migration: delete_ingredient RPC (soft delete)
+-- 호출자: 인증된 사용자가 본인 소유 재료를 비활성화.
+--
+-- Soft delete (is_active=false) 이유:
+--  - recipe_items.ingredient_id → ingredients.id on delete restrict
+--  - ingredient_price_history.ingredient_id → on delete cascade (이력은 cascade 무관)
+--  - 사용 중인 메뉴가 있으면 hard delete는 거부됨 + 통계/단가 history 보존이 안전
+--
+-- 사용 중인 메뉴가 있으면 응답에 menu_count 포함 → UI가 안내 후 비활성만 진행.
+
+create or replace function public.delete_ingredient(p_ingredient_id uuid)
+returns table (
+  ingredient_id uuid,
+  was_active boolean,
+  in_use_menu_count integer
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+  v_was_active boolean;
+  v_menu_count integer;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  select is_active into v_was_active
+  from public.ingredients
+  where id = p_ingredient_id and user_id = v_user_id;
+
+  if v_was_active is null then
+    raise exception 'ingredient_not_found_or_forbidden' using errcode = '42501';
+  end if;
+
+  -- 이 재료를 레시피에 쓰는 활성 메뉴 수 (UI 안내용)
+  select count(distinct ri.menu_id)::int
+  into v_menu_count
+  from public.recipe_items ri
+  join public.menus m on m.id = ri.menu_id
+  where ri.ingredient_id = p_ingredient_id
+    and ri.user_id = v_user_id
+    and m.is_active = true;
+
+  update public.ingredients
+  set is_active = false
+  where id = p_ingredient_id and user_id = v_user_id;
+
+  return query
+  select p_ingredient_id, v_was_active, v_menu_count;
+end;
+$$;
+
+comment on function public.delete_ingredient(uuid) is
+  '재료 soft delete (is_active=false). 사용 중인 메뉴 수 in_use_menu_count로 반환 → UI가 경고 후 비활성. 단가 history + 과거 sale 참조 보존.';
+
+revoke all on function public.delete_ingredient(uuid) from public;
+grant execute on function public.delete_ingredient(uuid) to authenticated;

--- a/tests/integration/ingredient-delete.test.ts
+++ b/tests/integration/ingredient-delete.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  cleanupTestUser,
+  createTestUser,
+  hasSupabaseTestEnv,
+  signInAs,
+  type TestUser,
+} from "../helpers/test-supabase";
+import { cloneMenuTemplate, deleteIngredient, saveIngredient } from "@/lib/supabase/rpc";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+/**
+ * `delete_ingredient` RPC 통합 테스트.
+ * - soft delete (is_active=false)
+ * - 사용 중인 메뉴 수 in_use_menu_count 정확
+ * - 다른 사용자 재료 삭제 차단 (헌법 IV)
+ * - 단가 history는 cascade 보존
+ */
+
+const describeIngredientDelete = hasSupabaseTestEnv ? describe : describe.skip;
+
+describeIngredientDelete("delete_ingredient RPC", () => {
+  let user: TestUser;
+  let client: SupabaseClient<Database>;
+
+  beforeAll(async () => {
+    user = await createTestUser({ storeType: "cafe" });
+    client = await signInAs(user);
+  }, 60_000);
+
+  afterAll(async () => {
+    if (user?.id) await cleanupTestUser(user.id);
+  }, 30_000);
+
+  it("사용 안 하는 재료 — soft delete + in_use_menu_count=0", async () => {
+    const created = await saveIngredient(client, { name: "테스트시럽", unit: "ml" });
+    const ingId = created.data![0]!.id;
+
+    const result = await deleteIngredient(client, ingId);
+    expect(result.error).toBeNull();
+    expect(result.data![0]!.was_active).toBe(true);
+    expect(result.data![0]!.in_use_menu_count).toBe(0);
+
+    const row = await client.from("ingredients").select("is_active").eq("id", ingId).single();
+    expect(row.data!.is_active).toBe(false);
+  });
+
+  it("템플릿 메뉴가 쓰는 재료 삭제 — in_use_menu_count > 0 + soft delete", async () => {
+    await cloneMenuTemplate(client, { storeType: "cafe" });
+    const ing = await client.from("ingredients").select("id").eq("name", "원두").single();
+    const ingId = ing.data!.id;
+
+    const result = await deleteIngredient(client, ingId);
+    expect(result.error).toBeNull();
+    expect(result.data![0]!.in_use_menu_count).toBeGreaterThan(0);
+
+    const row = await client.from("ingredients").select("is_active").eq("id", ingId).single();
+    expect(row.data!.is_active).toBe(false);
+  });
+
+  it("다른 사용자 재료 삭제 불가 (헌법 IV)", async () => {
+    const otherUser = await createTestUser({ storeType: "cafe" });
+    const otherClient = await signInAs(otherUser);
+    const created = await saveIngredient(otherClient, { name: "타인재료", unit: "g" });
+    const otherIngId = created.data![0]!.id;
+
+    const result = await deleteIngredient(client, otherIngId);
+    expect(result.error?.message).toMatch(/not_found_or_forbidden|permission/);
+
+    await cleanupTestUser(otherUser.id);
+  });
+});


### PR DESCRIPTION
## Summary

증상 2건 동시 수정.

### 1. 재료 추가 후 즉시 반영 안 되는 캐시 무효화 버그

**증상**: `AddIngredientForm`으로 재료 추가 → 재료 페이지 목록에 새 재료가 안 보임 (새로고침해야 등장).

**원인**: `useCreateIngredient`가 `ingredientListQueryKey`(`["ingredients", "list"]`)만 invalidate. 하지만 `/inventory` 페이지는 `depletionForecastQueryKey`(`["inventory", "forecast"]`)를 통해 `useDepletionForecast` 사용 → stale 캐시.

**Fix**: `invalidateIngredientCaches` helper로 두 키 동시 무효화. 신규 등록 + 삭제 모두 동일 패턴 (`useApplyStockCount` 기존 구조와 일치).

### 2. 재료 삭제 기능

- `supabase/migrations/029_delete_ingredient_rpc.sql` — `delete_ingredient(p_ingredient_id)` 
  - **Soft delete** (`is_active=false`): `recipe_items.ingredient_id on delete restrict` 회피 + 단가 history + 과거 sale 참조 보존
  - 응답에 `in_use_menu_count` — UI가 "이 재료 쓰는 메뉴 N개 남아있음" 안내
  - 헌법 IV (security definer + auth.uid() + 본인 소유 검증)
  - `#variable_conflict use_column`로 `ingredient_id` ambiguity 회피
- `deleteIngredient` RPC wrapper + `useDeleteIngredient` mutation hook
- `IngredientStatusList`: 각 재료 행에 `×` 버튼 + `window.confirm` 안내 + 사용 중 메뉴 수 `alert`

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅ (통합 +3: 미사용 재료 / 템플릿 메뉴가 쓰는 재료 / 헌법 IV RLS)
- build ✅
- 마이그레이션 029 클라우드 적용 완료

## Test plan

- [x] 단위/통합 테스트 통과 (CI)
- [ ] **수동 (PR 머지 후)**: `/inventory` → "+ 재료 추가" → 등록 → 즉시 목록에 등장 / 재료 행의 `×` 버튼 → 사용 중 메뉴 있을 때 안내 alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)