### PR TITLE
ui(inventory): 재료 추가 버튼을 페이지 헤더로 이동

### DIFF
--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
 import { IngredientStatusList } from "@/features/inventory/components/IngredientStatusList";
@@ -8,12 +9,13 @@ import { AddIngredientForm } from "@/features/inventory/components/AddIngredient
 
 export default function InventoryPage(): React.ReactElement {
   const { data, isLoading, error } = useDepletionForecast();
+  const [isAddOpen, setIsAddOpen] = useState(false);
 
   const isAllColdStart = (data ?? []).length > 0 && (data ?? []).every((d) => d.isColdStart);
 
   return (
     <section className="flex flex-col gap-section">
-      <header className="flex items-center justify-between">
+      <header className="flex items-center justify-between gap-stack-tight">
         <h1 className="text-title-lg text-ink-1">재료</h1>
         <div className="flex gap-stack-tight">
           <Link
@@ -24,12 +26,22 @@ export default function InventoryPage(): React.ReactElement {
           </Link>
           <Link
             href="/purchase"
-            className="rounded-md bg-ink-1 px-stack py-stack-tight text-body-regular text-bg hover:opacity-90"
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
           >
             + 매입
           </Link>
+          <button
+            type="button"
+            onClick={() => setIsAddOpen((v) => !v)}
+            aria-expanded={isAddOpen}
+            className="rounded-md bg-ink-1 px-stack py-stack-tight text-body-regular text-bg hover:opacity-90"
+          >
+            + 재료
+          </button>
         </div>
       </header>
+
+      {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
 
       {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
 
@@ -42,8 +54,6 @@ export default function InventoryPage(): React.ReactElement {
       {isAllColdStart && <ColdStartNotice />}
 
       {data && <IngredientStatusList items={data} />}
-
-      <AddIngredientForm />
     </section>
   );
 }

--- a/src/features/inventory/components/AddIngredientForm.tsx
+++ b/src/features/inventory/components/AddIngredientForm.tsx
@@ -8,6 +8,10 @@ import { PrimaryButton } from "@/components/ui/primary-button";
 import { ingredientInputSchema, type IngredientInput } from "@/features/purchase/schemas";
 import { useCreateIngredient } from "@/features/purchase/hooks/useIngredients";
 
+interface AddIngredientFormProps {
+  onClose: () => void;
+}
+
 const UNIT_LABELS: Record<IngredientInput["unit"], string> = {
   g: "g (그램)",
   ml: "ml (밀리리터)",
@@ -15,14 +19,10 @@ const UNIT_LABELS: Record<IngredientInput["unit"], string> = {
 };
 
 /**
- * 재료 페이지 인라인 등록 폼.
- * 토글 형태 — 평소엔 "+ 재료 추가" 버튼, 클릭 시 펼쳐짐.
- *
- * unit은 등록 후 변경 불가 (data-model.md §2 — `reject_unit_change` 트리거).
- * 사용자가 명시적으로 인지하도록 라벨에 안내.
+ * 재료 등록 폼. 토글은 부모(InventoryPage)가 관리 — 헤더 버튼으로 열고 onClose로 닫음.
+ * unit은 등록 후 변경 불가 (data-model.md §2 reject_unit_change 트리거) — 라벨에 명시.
  */
-export function AddIngredientForm(): React.ReactElement {
-  const [isOpen, setIsOpen] = useState(false);
+export function AddIngredientForm({ onClose }: AddIngredientFormProps): React.ReactElement {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const createMutation = useCreateIngredient();
 
@@ -45,19 +45,7 @@ export function AddIngredientForm(): React.ReactElement {
       return;
     }
     reset();
-    setIsOpen(false);
-  }
-
-  if (!isOpen) {
-    return (
-      <button
-        type="button"
-        onClick={() => setIsOpen(true)}
-        className="rounded-md border border-dashed border-border-strong px-stack py-stack-tight text-body-regular text-ink-3 hover:bg-card-hover"
-      >
-        + 재료 추가
-      </button>
-    );
+    onClose();
   }
 
   const submitting = isSubmitting || createMutation.isPending;
@@ -74,8 +62,8 @@ export function AddIngredientForm(): React.ReactElement {
           type="button"
           onClick={() => {
             reset();
-            setIsOpen(false);
             setSubmitError(null);
+            onClose();
           }}
           className="text-caption text-ink-3 hover:text-ink-2"
         >


### PR DESCRIPTION
## Summary

기존 `+ 재료 추가` 폼은 페이지 하단에 self-contained 토글이라 사용자가 스크롤해야 발견. 헤더(실사/매입 옆)로 이동.

### 변경 내역

- 페이지가 `isAddOpen` state 보유, 헤더의 `+ 재료` 버튼이 토글
- `AddIngredientForm`은 `onClose` prop만 받는 내용 컴포넌트로 단순화 (자체 토글 책임 제거)
- 폼은 헤더 바로 아래 펼쳐짐 — status 리스트 위에 위치해 발견성 ↑
- 버튼 톤 조정: `+ 재료`가 primary (ink-1 채움) — 1차 액션. `+ 매입`은 secondary (테두리)로 톤다운 (매입은 빈도 낮은 컨텍스트 진입)

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest 158/158 ✅
- build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)