### PR TITLE
refactor(domain): slice 1 — type narrowing + 재사용 + dead export 정리

### DIFF
--- a/src/lib/domain/_decimal.ts
+++ b/src/lib/domain/_decimal.ts
@@ -11,7 +11,7 @@ import DecimalBase from "decimal.js";
  * 내부 곱셈/나눗셈 라운딩 헤드룸) 일반 거래 단위(numeric(12,4)) 변환에 불필요
  * 하게 큰 메모리를 안 씀. 28은 decimal.js 기본값.
  */
-export const DOMAIN_DECIMAL_PRECISION = 28;
+const DOMAIN_DECIMAL_PRECISION = 28;
 
 export const Decimal = DecimalBase.clone({
   precision: DOMAIN_DECIMAL_PRECISION,

--- a/src/lib/domain/margin.ts
+++ b/src/lib/domain/margin.ts
@@ -28,7 +28,8 @@ export function calculateMenuCost(recipe: readonly RecipeItemForCost[]): Decimal
 }
 
 export interface MarginInput {
-  price: number;
+  // Decimal 직접 전달 가능 — Sale 합계처럼 누적 Decimal을 number로 round-trip하지 않도록.
+  price: number | Decimal;
   cost: number | Decimal;
 }
 
@@ -39,15 +40,14 @@ export interface MarginResult {
 }
 
 export function calculateMargin({ price, cost }: MarginInput): MarginResult {
-  assertNonNegative(price, "menu price");
-
+  const priceDecimal = price instanceof Decimal ? price : new Decimal(price);
   const costDecimal = cost instanceof Decimal ? cost : new Decimal(cost);
+  assertNonNegative(priceDecimal.toNumber(), "menu price");
 
-  if (price === 0) {
+  if (priceDecimal.isZero()) {
     return { amount: costDecimal.negated(), rate: new Decimal(0), label: MARGIN_LABEL };
   }
 
-  const priceDecimal = new Decimal(price);
   const amount = priceDecimal.minus(costDecimal);
   const rate = amount.dividedBy(priceDecimal).times(100);
 

--- a/src/lib/domain/regular-days-off.ts
+++ b/src/lib/domain/regular-days-off.ts
@@ -12,14 +12,20 @@ import type { Database } from "@/lib/supabase/types";
 
 export type Weekday = Database["public"]["Enums"]["weekday"];
 
-const WEEKDAY_BY_INDEX: readonly Weekday[] = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+// 7-tuple로 명시 → date.getDay()의 0-6 인덱스가 type-level에서 narrow됨.
+// 이전엔 `if (!w) throw` 가드가 있었으나 getDay()가 항상 0-6을 반환해 불가능 분기였음.
+const WEEKDAY_BY_INDEX = [
+  "SUN",
+  "MON",
+  "TUE",
+  "WED",
+  "THU",
+  "FRI",
+  "SAT",
+] as const satisfies readonly [Weekday, Weekday, Weekday, Weekday, Weekday, Weekday, Weekday];
 
 export function weekdayOf(date: Date): Weekday {
-  const w = WEEKDAY_BY_INDEX[date.getDay()];
-  if (!w) {
-    throw new Error(`invalid weekday index: ${date.getDay()}`);
-  }
-  return w;
+  return WEEKDAY_BY_INDEX[date.getDay() as 0 | 1 | 2 | 3 | 4 | 5 | 6];
 }
 
 export function isRegularDayOff(date: Date, daysOff: readonly Weekday[]): boolean {

--- a/src/lib/domain/snapshot.ts
+++ b/src/lib/domain/snapshot.ts
@@ -1,5 +1,11 @@
 import { Decimal } from "./_decimal";
-import { calculateMargin, calculateMenuCost, MARGIN_LABEL, type MarginLabel } from "./margin";
+import {
+  calculateMargin,
+  calculateMenuCost,
+  MARGIN_LABEL,
+  type MarginLabel,
+  type RecipeItemForCost,
+} from "./margin";
 
 /**
  * 헌법 III: Sale 저장 시 메뉴 원가/판매가 스냅샷 영구 보존.
@@ -19,7 +25,7 @@ export interface MenuForSnapshot {
   id: string;
   name: string;
   price: number;
-  recipeItems: ReadonlyArray<{ quantity: number; avgPrice: number }>;
+  recipeItems: readonly RecipeItemForCost[];
 }
 
 export interface SaleItemInput {
@@ -55,7 +61,8 @@ export function computeSnapshotPreview(
   const totalRevenue = breakdown.reduce((sum, line) => sum.plus(line.lineRevenue), new Decimal(0));
   const totalCost = breakdown.reduce((sum, line) => sum.plus(line.lineCost), new Decimal(0));
 
-  const margin = calculateMargin({ price: totalRevenue.toNumber(), cost: totalCost });
+  // Decimal 그대로 전달 — number round-trip 시 큰 카트에서 소수 손실.
+  const margin = calculateMargin({ price: totalRevenue, cost: totalCost });
 
   return {
     totalRevenue,


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor 중 슬라이스 1 — `src/lib/domain/` (509 LOC, 7 파일). simplify 3-agent (reuse / quality / efficiency) 리뷰 결과 중 **동작 변경 없는 4건**만 적용. 동작 변경되는 5건(NaN 가드 / coldstart 경계 / forecast 결측 요일 / lock 초정밀도 / margin 0-price assert)은 별도 bugfix PR로 분리.

### 변경 (no-functional-change)

| # | 파일 | 변경 |
|---|---|---|
| 1 | `regular-days-off.ts` | `WEEKDAY_BY_INDEX`를 `as const satisfies` 7-tuple로 좁혀 `date.getDay()` 0-6 인덱스가 type-level에서 narrow됨. `if (!w) throw` defensive guard 제거 — `getDay()` 도메인 0-6 보장으로 도달 불가 분기였음 |
| 2 | `snapshot.ts` | `MenuForSnapshot.recipeItems` 타입을 `RecipeItemForCost`로 통합 — inline shape `{ quantity; avgPrice }`와 구조 동일, 도메인 타입 재사용 |
| 3 | `snapshot.ts` | `computeSnapshotPreview`가 `calculateMargin`에 `totalRevenue.toNumber()` 대신 Decimal 그대로 전달 — number round-trip으로 큰 카트에서 발생할 수 있는 소수 손실 차단 (SC-009 30일 누적 ≤0.01원 방어선) |
| 4 | `margin.ts` | `MarginInput.price`를 `number → number\|Decimal`로 widen. cost와 대칭. `isZero()` 분기 + `assertNonNegative`는 Decimal 변환 후 `toNumber`로 위임 |
| 5 | `_decimal.ts` | `DOMAIN_DECIMAL_PRECISION` export 제거 (외부 사용처 없음, 모듈 내부 상수만) |

### 별도 PR 예정 (bugfix, 동작 변경 있음)

| 이슈 | 영향 |
|---|---|
| `assertNonNegative`가 NaN을 통과시킴 | `Number.isFinite` 추가 |
| `isColdStart` 경계 `<` (정확히 7일이 cold start 아님) | 스펙 확인 후 결정 |
| `forecast`가 weekdayAvg 결측 시 silent skip | 활성 요일이 모두 결측이면 `null` 반환 = 항상 안전으로 분류되는 버그 |
| `Math.max(0, daysUntilDepletion)` clamp | "이미 소진" 상태가 critical에 묻힘 |
| `isSaleLocked`가 초/시 단위 비교 | 자정 직전 저장 시 7일 보장 위반 |
| `calculateMargin price === 0` 분기가 `assertNonNegative(cost)` 건너뜀 | 음수 cost 통과 |
| `pricing newQuantity === 0` 분기가 `assertNonNegative(currentAvg)` 건너뜀 | 일관성 누락 |

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅ (도메인 단위 테스트 전부 통과 — 시그니처 호환 보장)
- build ✅
- 시그니처 호환 — 호출부 (`compute-menu-margin`, `save_sale` RPC 미러) 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)