### PR TITLE
refactor(utils+rpc): slice 2 — null guard 통일 + mapper 추출 + JSDoc 정리

### DIFF
--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -78,6 +78,22 @@ interface SaveMenuRow {
   menu_id: string;
 }
 
+// 도메인 타입 → RPC payload 변환 어댑터 — saveMenu / editMenu / saveSale / editSale 4곳 공유.
+function mapRecipePayload(
+  recipe: SaveMenuArgs["recipe"],
+): Array<{ ingredient_id: string; quantity_per_serving: number }> {
+  return recipe.map((it) => ({
+    ingredient_id: it.ingredientId,
+    quantity_per_serving: it.quantityPerServing,
+  }));
+}
+
+function mapSaleItemsPayload(
+  items: ReadonlyArray<{ menuId: string; quantity: number }>,
+): Array<{ menu_id: string; quantity: number }> {
+  return items.map((it) => ({ menu_id: it.menuId, quantity: it.quantity }));
+}
+
 interface EditMenuArgs extends SaveMenuArgs {
   menuId: string;
 }
@@ -95,10 +111,7 @@ export function editMenu(
     p_menu_id: args.menuId,
     p_name: args.name,
     p_price: args.price,
-    p_recipe: args.recipe.map((it) => ({
-      ingredient_id: it.ingredientId,
-      quantity_per_serving: it.quantityPerServing,
-    })),
+    p_recipe: mapRecipePayload(args.recipe),
   });
 }
 
@@ -129,10 +142,7 @@ export function saveMenu(
   return callRpc(client, "save_menu", {
     p_name: args.name,
     p_price: args.price,
-    p_recipe: args.recipe.map((it) => ({
-      ingredient_id: it.ingredientId,
-      quantity_per_serving: it.quantityPerServing,
-    })),
+    p_recipe: mapRecipePayload(args.recipe),
   });
 }
 
@@ -152,7 +162,7 @@ interface SaveSaleArgs {
 export function saveSale(client: ClientLike, args: SaveSaleArgs): Promise<RpcResult<SaleRpcRow[]>> {
   return callRpc(client, "save_sale", {
     p_sold_at: args.soldAt,
-    p_items: args.items.map((it) => ({ menu_id: it.menuId, quantity: it.quantity })),
+    p_items: mapSaleItemsPayload(args.items),
   });
 }
 
@@ -165,12 +175,12 @@ interface EditSaleArgs {
 export function editSale(client: ClientLike, args: EditSaleArgs): Promise<RpcResult<SaleRpcRow[]>> {
   return callRpc(client, "edit_sale", {
     p_sale_id: args.saleId,
-    p_new_items: args.newItems.map((it) => ({ menu_id: it.menuId, quantity: it.quantity })),
+    p_new_items: mapSaleItemsPayload(args.newItems),
     p_reason: args.reason ?? null,
   });
 }
 
-export function deleteSale(client: ClientLike, saleId: string): Promise<RpcResult<unknown>> {
+export function deleteSale(client: ClientLike, saleId: string): Promise<RpcResult<null>> {
   return callRpc(client, "delete_sale", { p_sale_id: saleId });
 }
 
@@ -345,7 +355,7 @@ export function subscribePush(
   });
 }
 
-export function unsubscribePush(client: ClientLike, endpoint: string): Promise<RpcResult<unknown>> {
+export function unsubscribePush(client: ClientLike, endpoint: string): Promise<RpcResult<null>> {
   return callRpc(client, "unsubscribe_push", { p_endpoint: endpoint });
 }
 
@@ -407,10 +417,10 @@ export async function getCalendarMonth(
     p_year: args.year,
     p_month: args.month,
   });
-  if (result.error) {
+  if (result.error || !result.data) {
     return { data: null, error: result.error };
   }
-  const raw = result.data!;
+  const raw = result.data;
   return {
     data: {
       year: raw.year,
@@ -525,10 +535,10 @@ export async function getTodayDashboard(
   client: ClientLike,
 ): Promise<RpcResult<TodayDashboardData>> {
   const result = await callRpc<TodayDashboardRaw>(client, "get_today_dashboard");
-  if (result.error) {
+  if (result.error || !result.data) {
     return { data: null, error: result.error };
   }
-  const raw = result.data!;
+  const raw = result.data;
   return {
     data: {
       storeName: raw.store_name,

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -16,13 +16,9 @@ export function formatNumber(value: number): string {
 const WEEKDAY_KO = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
 /**
- * "YYYY-MM-DD" 문자열을 한국어 한 글자 요일로 변환.
- * timezone 해석 회피 위해 date 부품을 직접 분해 (Date 생성자에 ISO 문자열 + Z 패스
- * 사용 시 호스트 tz에 따라 ±1일 오차 가능).
- */
-/**
  * "YYYY-MM-DD" 문자열을 로컬 시간 0시 Date로 변환. 호스트 tz 무관하게 캘린더 일자
- * 단위 비교에 사용. ISO 부분 분해 → Date 생성자 (UTC 해석 회피).
+ * 단위 비교에 사용 — Date 생성자에 ISO 문자열 + Z 패스를 그대로 넘기면 호스트 tz에
+ * 따라 ±1일 오차가 생길 수 있음.
  */
 export function parseLocalDateFromIso(iso: string): Date | null {
   const parts = iso.split("-").map(Number);


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor 중 슬라이스 2 — `src/lib/utils/` + `src/lib/supabase/rpc.ts` (721 LOC). simplify 3-agent 리뷰 결과 중 **동작 변경 없는 안전 4건**만 적용.

### 변경 (no-functional-change)

| # | 파일 | 변경 |
|---|---|---|
| 1 | `rpc.ts` | `mapRecipePayload` + `mapSaleItemsPayload` 헬퍼 추출 — `saveMenu`/`editMenu`/`saveSale`/`editSale` 4곳 inline map 중복 제거. 페이로드 어댑터 단일 출처화 |
| 2 | `rpc.ts` | `getCalendarMonth` + `getTodayDashboard`의 `result.data!` 단언 → `if (result.error \|\| !result.data) early return` 패턴으로 통일. RPC가 `{data: null, error: null}` 반환 시 crash 위험 차단. `applyStockCount`/`savePurchase`와 동일 형태 |
| 3 | `rpc.ts` | `deleteSale` + `unsubscribePush` 반환 타입 `RpcResult<unknown>` → `RpcResult<null>`. 호출자 캐스팅 불필요 |
| 4 | `format.ts` | `parseLocalDateFromIso` 위 orphan JSDoc 블록 제거 (이전 `weekdayKoFromIso`용 doc이 잘못된 위치에 남아있던 dead doc) |

### 별도 PR 예정

**큰 리팩토링 (slice 2 follow-up):**
- `callRpcRow<TRaw, TOut>(client, fn, args, map)` 헬퍼 — 5개 RPC wrapper의 callRpc + null guard + map 패턴 중복
- `SnakeToCamel<T>` 매핑 타입 제너릭 — Raw 인터페이스 5개와 출력 인터페이스 5개의 1:1 shadow 제거 (~80 LOC)
- `ClientLike { rpc: unknown }` + `Reflect.apply` 패턴을 `SupabaseClient<Database>` 직접 타입으로 좁히기
- 일부 wrapper가 raw snake_case 그대로 반환 (saveMenu/editMenu/deleteMenu/saveVendor/saveIngredient/updateRegularDaysOff 등) vs 일부는 camelCase 매핑 (savePurchase/applyStockCount/getDepletionForecast/getCalendarMonth/getTodayDashboard) — 일관성

**Bugfix PR (동작 변경):**
- `useTodayIso`가 `new Date().toISOString().slice(0,10)` (UTC 날짜) 반환 → KST 자정 근처 ±1일 오차. `parseLocalDateFromIso`가 이미 회피하는 동일 클래스 버그
- `applyStockCount` / `savePurchase` 일부 `Number()` 캐스트는 dead (jsonb 안 number는 PostgREST가 number로 직렬화) — 단, top-level numeric column은 string으로 직렬화되므로 부분만 dead. 정밀 분석 필요

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅
- build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)