### PR TITLE
refactor(sale): slice 3 — 캐시 무효화 fix + useMemo 정리 + Zustand selector

### DIFF
--- a/src/features/sale/components/MenuRow.tsx
+++ b/src/features/sale/components/MenuRow.tsx
@@ -11,17 +11,17 @@ interface MenuRowProps {
 }
 
 export function MenuRow({ menu, quantity, onChange }: MenuRowProps): React.ReactElement {
-  const active = quantity > 0;
+  const isActive = quantity > 0;
 
   return (
     <li
       className={cn(
         "flex items-center justify-between rounded-lg border px-tile py-stack",
-        active ? "border-border-strong bg-card" : "border-border bg-card",
+        isActive ? "border-border-strong bg-card" : "border-border bg-card",
       )}
     >
       <div className="flex flex-col gap-1">
-        <span className={cn("text-body", active ? "text-ink-1" : "text-ink-2")}>{menu.name}</span>
+        <span className={cn("text-body", isActive ? "text-ink-1" : "text-ink-2")}>{menu.name}</span>
         <span className="text-caption text-ink-3 tabular-nums">{formatNumber(menu.price)}원</span>
       </div>
 

--- a/src/features/sale/components/SaleEditDialog.tsx
+++ b/src/features/sale/components/SaleEditDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useMenus } from "@/features/menu/hooks/useMenus";
 import { computeSnapshotPreview, daysUntilLock, isSaleLocked } from "@/lib/domain/snapshot";
@@ -26,30 +26,26 @@ export function SaleEditDialog({ sale }: SaleEditDialogProps): React.ReactElemen
   const editMutation = useSaleEdit();
   const deleteMutation = useSaleDelete();
 
-  const createdAt = useMemo(() => new Date(sale.created_at), [sale.created_at]);
-  const locked = isSaleLocked(createdAt);
+  // useMemo는 trivial Date 생성/Map 구성에 비용 오버헤드만 더함 — 단순 계산은 inline.
+  const createdAt = new Date(sale.created_at);
+  const isLocked = isSaleLocked(createdAt);
   const daysLeft = daysUntilLock(createdAt);
 
-  const initialQuantities = useMemo(
+  // lazy 초기화 — initialQuantities 변경 시 setQuantities로 명시 재설정 (현재는 마운트 1회).
+  const [quantities, setQuantities] = useState<Map<string, number>>(
     () => new Map(sale.items.map((it) => [it.menu_id, it.quantity])),
-    [sale.items],
   );
-
-  const [quantities, setQuantities] = useState<Map<string, number>>(initialQuantities);
   const [reason, setReason] = useState("");
 
-  const items = useMemo(
-    () =>
-      Array.from(quantities.entries())
-        .filter(([, qty]) => qty > 0)
-        .map(([menuId, quantity]) => ({ menuId, quantity })),
-    [quantities],
-  );
+  // quantities Map identity가 매번 새로워서 useMemo가 skip 못 함 → inline derive.
+  const items = Array.from(quantities.entries())
+    .filter(([, qty]) => qty > 0)
+    .map(([menuId, quantity]) => ({ menuId, quantity }));
 
-  const preview = useMemo(() => {
-    if (!menus || menus.length === 0 || items.length === 0) return null;
-    return computeSnapshotPreview(items, menus.map(toSnapshotMenu));
-  }, [items, menus]);
+  const preview =
+    menus && menus.length > 0 && items.length > 0
+      ? computeSnapshotPreview(items, menus.map(toSnapshotMenu))
+      : null;
 
   function setQuantity(menuId: string, next: number): void {
     setQuantities((prev) => {
@@ -76,7 +72,7 @@ export function SaleEditDialog({ sale }: SaleEditDialogProps): React.ReactElemen
     deleteMutation.mutate(sale.id, { onSuccess: () => router.push("/today") });
   }
 
-  if (locked) {
+  if (isLocked) {
     return <LockedView sale={sale} />;
   }
 
@@ -102,7 +98,7 @@ export function SaleEditDialog({ sale }: SaleEditDialogProps): React.ReactElemen
         ))}
       </ul>
 
-      <Field label="수정 사유 (선택, 200자 이내)" error={undefined}>
+      <Field label="수정 사유 (선택, 200자 이내)">
         <textarea
           value={reason}
           onChange={(e) => setReason(e.target.value.slice(0, 200))}
@@ -149,19 +145,17 @@ export function SaleEditDialog({ sale }: SaleEditDialogProps): React.ReactElemen
 }
 
 function DaysLeftHint({ daysLeft }: { daysLeft: number }): React.ReactElement {
-  const tone = daysLeft <= 1 ? "red" : daysLeft <= 3 ? "amber" : "ink-3";
   return (
-    <p
-      className={cn(
-        "text-caption",
-        tone === "red" && "text-red-deep",
-        tone === "amber" && "text-amber-deep",
-        tone === "ink-3" && "text-ink-3",
-      )}
-    >
+    <p className={cn("text-caption", daysLeftTone(daysLeft))}>
       편집 가능 기간 {daysLeft}일 남음 (저장 후 7일까지 수정 가능)
     </p>
   );
+}
+
+function daysLeftTone(daysLeft: number): string {
+  if (daysLeft <= 1) return "text-red-deep";
+  if (daysLeft <= 3) return "text-amber-deep";
+  return "text-ink-3";
 }
 
 function LockedView({ sale }: { sale: SaleWithItems }): React.ReactElement {

--- a/src/features/sale/components/SaleInputForm.tsx
+++ b/src/features/sale/components/SaleInputForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useMenus, type MenuRowWithRecipe } from "@/features/menu/hooks/useMenus";
 import { useSaleDraft } from "@/stores/sale-draft";
@@ -22,44 +22,42 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
   const router = useRouter();
   const { data: menus } = useMenus();
   const { data: favorites } = useFavoriteMenus();
-  const draft = useSaleDraft();
+  // Zustand selector를 슬라이스별로 분리 — 전체 store 구독 시 모든 mutation이 매 렌더 트리거.
+  const items = useSaleDraft((s) => s.items);
+  const draftDate = useSaleDraft((s) => s.draftDate);
+  const setDraftDate = useSaleDraft((s) => s.setDraftDate);
+  const setQuantity = useSaleDraft((s) => s.setQuantity);
+  const clearDraft = useSaleDraft((s) => s.clear);
   const submit = useSaleSubmit();
 
-  // 페이지 진입 시 draft에 날짜 묶기 — soldAt 바뀌면 갱신.
   useEffect(() => {
-    if (draft.draftDate !== soldAt) {
-      draft.setDraftDate(soldAt);
+    if (draftDate !== soldAt) {
+      setDraftDate(soldAt);
     }
-  }, [soldAt, draft]);
+  }, [soldAt, draftDate, setDraftDate]);
 
-  const sortedMenus = useMemo(
-    () => sortByFavorites(menus ?? [], favorites ?? []),
-    [menus, favorites],
-  );
+  // ~20개 메뉴 sort + Map 구성은 trivial, useMemo 오버헤드만 더함 → inline.
+  const sortedMenus = sortByFavorites(menus ?? [], favorites ?? []);
+  const draftMap = new Map(items.map((it) => [it.menuId, it.quantity]));
 
-  const draftMap = useMemo(
-    () => new Map(draft.items.map((it) => [it.menuId, it.quantity])),
-    [draft.items],
-  );
-
-  const preview = useMemo(() => {
-    if (!menus || menus.length === 0) return null;
-    return computeSnapshotPreview(
-      draft.items.filter((it) => it.quantity > 0),
-      menus.map(toSnapshotMenu),
-    );
-  }, [draft.items, menus]);
+  const preview =
+    menus && menus.length > 0
+      ? computeSnapshotPreview(
+          items.filter((it) => it.quantity > 0),
+          menus.map(toSnapshotMenu),
+        )
+      : null;
 
   function handleSubmit(): void {
     submit.mutate(
       {
         soldAt,
-        items: draft.items.filter((it) => it.quantity > 0),
+        items: items.filter((it) => it.quantity > 0),
         isFirstSale,
       },
       {
         onSuccess: () => {
-          draft.clear();
+          clearDraft();
           router.push("/today");
         },
       },
@@ -77,7 +75,7 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
     );
   }
 
-  const totalQuantity = draft.items.reduce((sum, it) => sum + it.quantity, 0);
+  const totalQuantity = items.reduce((sum, it) => sum + it.quantity, 0);
 
   return (
     <div className="flex flex-col gap-stack pb-44">
@@ -87,7 +85,7 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
             key={menu.id}
             menu={menu}
             quantity={draftMap.get(menu.id) ?? 0}
-            onChange={(next) => draft.setQuantity(menu.id, next)}
+            onChange={(next) => setQuantity(menu.id, next)}
           />
         ))}
       </ul>

--- a/src/features/sale/hooks/_keys.ts
+++ b/src/features/sale/hooks/_keys.ts
@@ -1,0 +1,1 @@
+export const salesQueryKey = ["sales"] as const;

--- a/src/features/sale/hooks/useSaleEdit.ts
+++ b/src/features/sale/hooks/useSaleEdit.ts
@@ -4,6 +4,9 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import { editSale, deleteSale } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
+import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
+import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
+import { salesQueryKey } from "./_keys";
 import type { EditSaleInput } from "../schemas";
 
 interface EditResult {
@@ -33,13 +36,21 @@ async function remove(saleId: string): Promise<void> {
   if (error) throw new Error(error.message);
 }
 
+// sale 편집/삭제도 재료 재고 보정 + price_history insert를 RPC가 수행하므로 sale 키
+// 단독 무효화는 inventory 페이지 stale을 만든다 (useSaleSubmit과 동일 패턴).
+function invalidateSaleAndIngredientCaches(queryClient: ReturnType<typeof useQueryClient>): void {
+  void queryClient.invalidateQueries({ queryKey: salesQueryKey });
+  void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+  void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
+}
+
 export function useSaleEdit(): UseMutationResult<EditResult, Error, EditSaleInput> {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: edit,
     onSuccess: () => {
       trackEvent("sale_edited", {});
-      void queryClient.invalidateQueries({ queryKey: ["sales"] });
+      invalidateSaleAndIngredientCaches(queryClient);
     },
   });
 }
@@ -48,8 +59,6 @@ export function useSaleDelete(): UseMutationResult<void, Error, string> {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: remove,
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["sales"] });
-    },
+    onSuccess: () => invalidateSaleAndIngredientCaches(queryClient),
   });
 }

--- a/src/features/sale/hooks/useSaleSubmit.ts
+++ b/src/features/sale/hooks/useSaleSubmit.ts
@@ -6,6 +6,9 @@ import { saveSale } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { requestPushPermissionAndSubscribe } from "@/lib/push/client";
 import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
+import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
+import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
+import { salesQueryKey } from "./_keys";
 import type { SaveSaleInput } from "../schemas";
 
 interface SubmitVariables extends SaveSaleInput {
@@ -58,8 +61,12 @@ export function useSaleSubmit(): UseMutationResult<SubmitResult, Error, SubmitVa
         trackEvent("retroactive_sale_complete", { sold_at: input.soldAt });
       }
 
+      // sale 저장은 재료 재고 차감 + 단가 history insert까지 트리거 → menu 캐시 외에
+      // ingredient/forecast도 함께 무효화해야 inventory 페이지가 즉시 반영.
       void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
-      void queryClient.invalidateQueries({ queryKey: ["sales"] });
+      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
+      void queryClient.invalidateQueries({ queryKey: salesQueryKey });
     },
   });
 }


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor 슬라이스 3 — `src/features/sale/` (782 LOC, 12 파일). simplify 3-agent 리뷰 결과 중 안전한 정리 + 명백한 캐시 누수 버그 1건 fix.

### 변경

**🐛 BUG FIX (1건)**
- `useSaleSubmit` / `useSaleEdit` / `useSaleDelete`가 `["sales"]` 키만 무효화 → sale 저장/편집/삭제는 RPC 안에서 재료 재고 차감 + `price_history` insert를 트리거하지만 ingredient/forecast 캐시가 stale → inventory 페이지가 즉시 반영 안 됨. **이전 PR (#65)에서 menu/ingredient에 잡았던 동일 클래스 버그**. `ingredientListQueryKey` + `depletionForecastQueryKey` 추가 무효화.

**🧹 정리 (no-functional-change)**

| # | 파일 | 변경 |
|---|---|---|
| 1 | `hooks/_keys.ts` | `salesQueryKey` 상수 추출 → 3곳 inline `["sales"]` 제거 |
| 2 | `SaleEditDialog` | 4개 `useMemo` 정리 — `createdAt`(trivial Date) inline / `initialQuantities` `useState` lazy init / `items` & `preview`는 dep map identity 매번 새로 만들어져 skip 못 하는 dead memo → inline |
| 3 | `SaleEditDialog` | `DaysLeftHint` 중첩 삼항 → `daysLeftTone(daysLeft)` helper 분리. 글로벌 룰 위반 해소 |
| 4 | `SaleEditDialog` | `<Field error={undefined}>` always-undefined prop 제거 |
| 5 | `SaleEditDialog` | `locked` → `isLocked` boolean prefix 일관 |
| 6 | `SaleInputForm` | `useSaleDraft()` 전체 store 구독 → slice selector 5개로 분리. 매 mutation 마다 재렌더되던 문제 제거 |
| 7 | `SaleInputForm` | `useEffect` deps의 `draft` 객체 → `draftDate` / `setDraftDate` 분리 |
| 8 | `SaleInputForm` | `sortedMenus` / `draftMap` / `preview`의 trivial `useMemo` 3개 → inline (~20 메뉴 sort + Map 구성은 useMemo 오버헤드만 더함) |
| 9 | `MenuRow` | `active` → `isActive` boolean prefix |

### 별도 PR 예정

- `SaleEditDialog` `LockedView` 와 `StickyTotalCard`의 매출/원가/순수익 표 통합 (`SaleSummaryMetrics`)
- `SaleEditDialog` 컴포넌트 분리 (locked/edit 본문)
- `SaleEditDialog` `confirm()` → 디자인 시스템 AlertDialog
- `useSaleByDate` / `useFavoriteMenus`의 `as` 단언 → Zod parse
- `to-snapshot-menu` ↔ `compute-menu-margin`의 row→domain mapping 통합 (slice 5 features/menu와 묶어서)

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅
- build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)