### PR TITLE
refactor(purchase): slice 4 — 캐시 무효화 fix + UNIT_LABELS 호이스트 + try/catch 제거

### DIFF
--- a/src/features/inventory/components/AddIngredientForm.tsx
+++ b/src/features/inventory/components/AddIngredientForm.tsx
@@ -1,29 +1,25 @@
 "use client";
 
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Field } from "@/components/ui/field";
 import { PrimaryButton } from "@/components/ui/primary-button";
-import { ingredientInputSchema, type IngredientInput } from "@/features/purchase/schemas";
+import {
+  INGREDIENT_UNIT_LABELS,
+  ingredientInputSchema,
+  type IngredientInput,
+} from "@/features/purchase/schemas";
 import { useCreateIngredient } from "@/features/purchase/hooks/useIngredients";
 
 interface AddIngredientFormProps {
   onClose: () => void;
 }
 
-const UNIT_LABELS: Record<IngredientInput["unit"], string> = {
-  g: "g (그램)",
-  ml: "ml (밀리리터)",
-  piece: "개",
-};
-
 /**
  * 재료 등록 폼. 토글은 부모(InventoryPage)가 관리 — 헤더 버튼으로 열고 onClose로 닫음.
  * unit은 등록 후 변경 불가 (data-model.md §2 reject_unit_change 트리거) — 라벨에 명시.
  */
 export function AddIngredientForm({ onClose }: AddIngredientFormProps): React.ReactElement {
-  const [submitError, setSubmitError] = useState<string | null>(null);
   const createMutation = useCreateIngredient();
 
   const {
@@ -37,13 +33,7 @@ export function AddIngredientForm({ onClose }: AddIngredientFormProps): React.Re
   });
 
   async function onSubmit(values: IngredientInput): Promise<void> {
-    setSubmitError(null);
-    try {
-      await createMutation.mutateAsync(values);
-    } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : "등록 실패");
-      return;
-    }
+    await createMutation.mutateAsync(values);
     reset();
     onClose();
   }
@@ -62,7 +52,6 @@ export function AddIngredientForm({ onClose }: AddIngredientFormProps): React.Re
           type="button"
           onClick={() => {
             reset();
-            setSubmitError(null);
             onClose();
           }}
           className="text-caption text-ink-3 hover:text-ink-2"
@@ -85,17 +74,17 @@ export function AddIngredientForm({ onClose }: AddIngredientFormProps): React.Re
           {...register("unit")}
           className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
         >
-          {(Object.keys(UNIT_LABELS) as Array<IngredientInput["unit"]>).map((unit) => (
+          {Object.entries(INGREDIENT_UNIT_LABELS).map(([unit, label]) => (
             <option key={unit} value={unit}>
-              {UNIT_LABELS[unit]}
+              {label}
             </option>
           ))}
         </select>
       </Field>
 
-      {submitError && (
+      {createMutation.error && (
         <p role="alert" className="text-body-regular text-red">
-          {submitError}
+          {createMutation.error.message}
         </p>
       )}
 

--- a/src/features/purchase/components/IngredientQuickCreate.tsx
+++ b/src/features/purchase/components/IngredientQuickCreate.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Field } from "@/components/ui/field";
 import { PrimaryButton } from "@/components/ui/primary-button";
-import { ingredientInputSchema, type IngredientInput } from "../schemas";
+import { INGREDIENT_UNIT_LABELS, ingredientInputSchema, type IngredientInput } from "../schemas";
 import { useCreateIngredient, type IngredientRow } from "../hooks/useIngredients";
 
 interface IngredientQuickCreateProps {
@@ -13,17 +12,10 @@ interface IngredientQuickCreateProps {
   onCancel: () => void;
 }
 
-const UNIT_LABELS: Record<IngredientInput["unit"], string> = {
-  g: "g (그램)",
-  ml: "ml (밀리리터)",
-  piece: "개",
-};
-
 export function IngredientQuickCreate({
   onCreated,
   onCancel,
 }: IngredientQuickCreateProps): React.ReactElement {
-  const [error, setError] = useState<string | null>(null);
   const mutation = useCreateIngredient();
   const {
     register,
@@ -35,17 +27,12 @@ export function IngredientQuickCreate({
   });
 
   async function onSubmit(values: IngredientInput): Promise<void> {
-    setError(null);
-    try {
-      const created = await mutation.mutateAsync(values);
-      onCreated(created);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "재료 생성 실패");
-    }
+    const created = await mutation.mutateAsync(values);
+    onCreated(created);
   }
 
-  // 중첩 <form>은 invalid HTML — 외부 PurchaseForm 안에 들어가므로 <div>로 렌더하고
-  // 추가 버튼은 type="button" + handleSubmit() 직접 호출.
+  // 부모 PurchaseForm이 이미 <form>이라 중첩 <form> 회피 — <div>로 렌더하고 추가 버튼은
+  // type="button" + handleSubmit() 직접 호출.
   return (
     <div className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
       <h3 className="text-title-md text-ink-1">새 재료 추가</h3>
@@ -64,17 +51,17 @@ export function IngredientQuickCreate({
           {...register("unit")}
           className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
         >
-          {(Object.keys(UNIT_LABELS) as IngredientInput["unit"][]).map((u) => (
-            <option key={u} value={u}>
-              {UNIT_LABELS[u]}
+          {Object.entries(INGREDIENT_UNIT_LABELS).map(([unit, label]) => (
+            <option key={unit} value={unit}>
+              {label}
             </option>
           ))}
         </select>
       </Field>
 
-      {error && (
+      {mutation.error && (
         <p role="alert" className="text-caption text-red">
-          {error}
+          {mutation.error.message}
         </p>
       )}
 

--- a/src/features/purchase/components/VendorQuickCreate.tsx
+++ b/src/features/purchase/components/VendorQuickCreate.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Field } from "@/components/ui/field";
@@ -17,7 +16,6 @@ export function VendorQuickCreate({
   onCreated,
   onCancel,
 }: VendorQuickCreateProps): React.ReactElement {
-  const [error, setError] = useState<string | null>(null);
   const mutation = useCreateVendor();
   const {
     register,
@@ -29,17 +27,12 @@ export function VendorQuickCreate({
   });
 
   async function onSubmit(values: VendorInput): Promise<void> {
-    setError(null);
-    try {
-      const created = await mutation.mutateAsync(values);
-      onCreated(created);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "거래처 생성 실패");
-    }
+    const created = await mutation.mutateAsync(values);
+    onCreated(created);
   }
 
-  // 중첩 <form>은 invalid HTML — 외부 PurchaseForm 안에 들어가므로 <div>로 렌더하고
-  // 추가 버튼은 type="button" + handleSubmit() 직접 호출.
+  // 부모 PurchaseForm이 이미 <form>이라 중첩 <form> 회피 — <div>로 렌더하고 추가
+  // 버튼은 type="button" + handleSubmit() 직접 호출.
   return (
     <div className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
       <h3 className="text-title-md text-ink-1">새 거래처 추가</h3>
@@ -62,9 +55,9 @@ export function VendorQuickCreate({
         />
       </Field>
 
-      {error && (
+      {mutation.error && (
         <p role="alert" className="text-caption text-red">
-          {error}
+          {mutation.error.message}
         </p>
       )}
 

--- a/src/features/purchase/hooks/useIngredients.ts
+++ b/src/features/purchase/hooks/useIngredients.ts
@@ -19,13 +19,6 @@ export interface IngredientRow {
   current_avg_price: number;
 }
 
-interface RawIngredientRow {
-  id: string;
-  name: string;
-  unit: "g" | "ml" | "piece";
-  current_avg_price: number;
-}
-
 export const ingredientListQueryKey = ["ingredients", "list"] as const;
 
 async function fetchIngredients(): Promise<IngredientRow[]> {
@@ -36,10 +29,13 @@ async function fetchIngredients(): Promise<IngredientRow[]> {
     .eq("is_active", true)
     .order("name");
   if (error) throw new Error(error.message);
-  return ((data ?? []) as unknown as RawIngredientRow[]).map((row) => ({
-    id: row.id,
-    name: row.name,
-    unit: row.unit,
+  // supabase-js v2의 select 결과 타입 추론이 nested join + numeric 조합에서 흔들려
+  // 명시 캐스팅. numeric 컬럼은 PostgREST가 string으로 직렬화 → Number로 좁힘.
+  const rows = (data ?? []) as Array<
+    Omit<IngredientRow, "current_avg_price"> & { current_avg_price: string | number }
+  >;
+  return rows.map((row) => ({
+    ...row,
     current_avg_price: Number(row.current_avg_price),
   }));
 }

--- a/src/features/purchase/hooks/usePurchaseSubmit.ts
+++ b/src/features/purchase/hooks/usePurchaseSubmit.ts
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/client";
 import { savePurchase, type SavePurchaseResult } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
+import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import { ingredientListQueryKey } from "./useIngredients";
 import type { SavePurchaseInput } from "../schemas";
 
@@ -38,8 +39,10 @@ export function usePurchaseSubmit(): UseMutationResult<SavePurchaseResult, Error
           alert_count: result.priceChangeAlerts.length,
         });
       }
-      // 매입은 ingredient 단가/재고 갱신 + 메뉴 마진 영향
+      // 매입은 가중 이동 평균법으로 ingredient 단가 + 재고 갱신 → 소진 예측 / 메뉴
+      // 마진 / 재료 목록 모두 stale. 일관 무효화.
       void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+      void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
       void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
     },
   });

--- a/src/features/purchase/hooks/useVendors.ts
+++ b/src/features/purchase/hooks/useVendors.ts
@@ -43,7 +43,7 @@ async function createVendor(input: VendorInput): Promise<VendorRow> {
   if (error) throw new Error(error.message);
   const row = data?.[0];
   if (!row) throw new Error("save_vendor: empty response");
-  return { id: row.id, name: row.name, lead_time_days: row.lead_time_days };
+  return row;
 }
 
 export function useCreateVendor(): UseMutationResult<VendorRow, Error, VendorInput> {

--- a/src/features/purchase/schemas.ts
+++ b/src/features/purchase/schemas.ts
@@ -34,3 +34,10 @@ export const ingredientInputSchema = z.object({
 });
 
 export type IngredientInput = z.infer<typeof ingredientInputSchema>;
+
+// IngredientQuickCreate (매입 inline) + AddIngredientForm (재료 페이지) 두 곳에서 공유.
+export const INGREDIENT_UNIT_LABELS: Record<IngredientInput["unit"], string> = {
+  g: "g (그램)",
+  ml: "ml (밀리리터)",
+  piece: "개",
+};


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor 슬라이스 4 — `src/features/purchase/` (819 LOC, 9 파일). simplify 3-agent 리뷰 결과 중 안전한 정리 + 명백한 캐시 누수 버그 1건 fix. + `AddIngredientForm` (slice 5 영역이지만 같은 폼 중복) 같이 정리.

### 변경

**🐛 BUG FIX**
- `usePurchaseSubmit`이 `ingredient` + `menu`만 무효화 → 매입은 가중 이동 평균법으로 단가/재고 갱신 → 소진 예측이 stale. `depletionForecastQueryKey` 추가. **이전 PR (#65, #69)에서 menu/ingredient/sale에 잡았던 동일 클래스 버그**

**🧹 정리 (no-functional-change)**

| # | 파일 | 변경 |
|---|---|---|
| 1 | `schemas.ts` | `INGREDIENT_UNIT_LABELS` 상수 호이스트 — `IngredientQuickCreate` (매입 inline) + `AddIngredientForm` (재료 페이지) 두 곳 동일 매핑 중복 제거 |
| 2 | 3 폼 컴포넌트 | `setError` + `try/catch` 로컬 에러 상태 제거 → `mutation.error` 직접 사용. 5줄 × 3 파일 (TanStack Query mutation 객체가 이미 error 추적) |
| 3 | 2 폼 컴포넌트 | `Object.keys(UNIT_LABELS) as IngredientInput["unit"][]` 캐스팅 → `Object.entries(INGREDIENT_UNIT_LABELS)` typed iteration |
| 4 | `useIngredients` | `RawIngredientRow` 별도 interface + `as unknown as` 이중 캐스팅 제거. select 컬럼이 `IngredientRow`와 1:1이라 단일 명시 캐스트로 충분 |
| 5 | `useVendors` | `createVendor`의 `{ id, name, lead_time_days }` no-op rebuild → `return row` |
| 6 | 2 QuickCreate | 정당화성 "왜" 주석 ("중첩 form은 invalid HTML") → 의도 설명형으로 다듬음 |

### 별도 PR 예정

- `IngredientQuickCreate` / `VendorQuickCreate` 동형 → `<QuickCreatePanel<TInput, TRow>>` 제네릭 통합 (~80 LOC 감소)
- `PurchaseForm`의 `VendorPicker` / `ItemRow` 단일 사용 sub-component 인라인 (~110 LOC 감소)
- `_keys.ts` 추출로 query key 일관 (slice 3 sale 패턴)
- 빈 카트 차단 강화 (defaultValues row 1개 + remove 시 last row 보호)

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅
- build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)