### PR TITLE
refactor(menu+inventory): slice 5 — invalidateMenuCaches + 캐시 누락 fix + row→cost mapper 통합

### DIFF
--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { daysUntilDate, formatNumber } from "@/lib/utils/format";
 import type { DepletionStatus } from "@/lib/domain/forecast";
@@ -64,23 +63,17 @@ export function IngredientStatusList({ items }: IngredientStatusListProps): Reac
 function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactElement {
   const depletionLabel = formatDepletion(item);
   const deleteMutation = useDeleteIngredient();
-  const [error, setError] = useState<string | null>(null);
 
   async function handleDelete(): Promise<void> {
     const confirmed = window.confirm(
       `"${item.name}" 재료를 삭제할까요?\n\n사용 중인 메뉴 + 단가 history는 보존되고 재료 목록에서만 사라져요.`,
     );
     if (!confirmed) return;
-    setError(null);
-    try {
-      const result = await deleteMutation.mutateAsync(item.ingredientId);
-      if (result.inUseMenuCount > 0) {
-        window.alert(
-          `삭제 완료. 이 재료를 쓰던 메뉴 ${result.inUseMenuCount}개는 그대로 남아있어요. 메뉴 페이지에서 다른 재료로 교체하거나 메뉴 자체를 삭제하세요.`,
-        );
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "삭제 실패");
+    const result = await deleteMutation.mutateAsync(item.ingredientId);
+    if (result.inUseMenuCount > 0) {
+      window.alert(
+        `삭제 완료. 이 재료를 쓰던 메뉴 ${result.inUseMenuCount}개는 그대로 남아있어요. 메뉴 페이지에서 다른 재료로 교체하거나 메뉴 자체를 삭제하세요.`,
+      );
     }
   }
 
@@ -112,20 +105,24 @@ function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactE
           </button>
         </div>
       </div>
-      {error && (
+      {deleteMutation.error && (
         <p role="alert" className="text-caption text-red">
-          {error}
+          {deleteMutation.error.message}
         </p>
       )}
     </li>
   );
 }
 
+const STATUS_TONE: Record<DepletionStatus, string> = {
+  critical: "text-red-deep",
+  order_needed: "text-amber-deep",
+  caution: "text-amber-deep",
+  safe: "text-ink-3",
+};
+
 function toneClass(status: DepletionStatus): string {
-  if (status === "critical") return "text-red-deep";
-  if (status === "order_needed") return "text-amber-deep";
-  if (status === "caution") return "text-amber-deep";
-  return "text-ink-3";
+  return STATUS_TONE[status];
 }
 
 function formatDepletion(item: IngredientForecastView): string {

--- a/src/features/inventory/components/StockCountForm.tsx
+++ b/src/features/inventory/components/StockCountForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { PrimaryButton } from "@/components/ui/primary-button";
 import { Field } from "@/components/ui/field";
@@ -9,24 +9,21 @@ import { useApplyStockCount } from "../hooks/useApplyStockCount";
 import { StockCountResultCard } from "./StockCountResultCard";
 import type { ApplyStockCountResult } from "@/lib/supabase/rpc";
 
-const todayString = (): string => new Date().toISOString().slice(0, 10);
+const TODAY_ISO = new Date().toISOString().slice(0, 10);
 
 export function StockCountForm(): React.ReactElement {
   const router = useRouter();
   const { data: ingredients, isLoading } = useIngredients();
   const submit = useApplyStockCount();
 
-  const [countedAt, setCountedAt] = useState(todayString);
+  const [countedAt, setCountedAt] = useState(TODAY_ISO);
   const [actuals, setActuals] = useState<Map<string, number>>(new Map());
   const [result, setResult] = useState<ApplyStockCountResult | null>(null);
 
-  const items = useMemo(
-    () =>
-      Array.from(actuals.entries())
-        .filter(([, v]) => Number.isFinite(v))
-        .map(([ingredientId, actualStock]) => ({ ingredientId, actualStock })),
-    [actuals],
-  );
+  // actuals Map identity가 매 입력마다 바뀌어 useMemo가 skip 못 함 → inline.
+  const items = Array.from(actuals.entries())
+    .filter(([, v]) => Number.isFinite(v))
+    .map(([ingredientId, actualStock]) => ({ ingredientId, actualStock }));
 
   function handleSubmit(): void {
     if (items.length === 0) return;
@@ -50,12 +47,12 @@ export function StockCountForm(): React.ReactElement {
 
   return (
     <div className="flex flex-col gap-section pb-44">
-      <Field label="실사 날짜" error={undefined}>
+      <Field label="실사 날짜">
         <input
           type="date"
           value={countedAt}
           onChange={(e) => setCountedAt(e.target.value)}
-          max={todayString()}
+          max={TODAY_ISO}
           className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
         />
       </Field>

--- a/src/features/inventory/hooks/useApplyStockCount.ts
+++ b/src/features/inventory/hooks/useApplyStockCount.ts
@@ -5,8 +5,7 @@ import { createClient } from "@/lib/supabase/client";
 import { applyStockCount, type ApplyStockCountResult } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
-import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
-import { depletionForecastQueryKey } from "./useDepletionForecast";
+import { invalidateMenuCaches } from "@/features/menu/hooks/useMenus";
 import type { ApplyStockCountInput } from "../schemas";
 
 async function submit(input: ApplyStockCountInput): Promise<ApplyStockCountResult> {
@@ -33,9 +32,9 @@ export function useApplyStockCount(): UseMutationResult<
         loss_amount: result.weeklyLossAmount,
         item_count: result.itemDifferences.length,
       });
+      // invalidateMenuCaches가 menu + forecast 둘 다 처리. 재료 목록만 추가.
       void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
-      void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
-      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+      invalidateMenuCaches(queryClient);
     },
   });
 }

--- a/src/features/menu/components/MenuActions.tsx
+++ b/src/features/menu/components/MenuActions.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useDeleteMenu } from "../hooks/useMenuMutations";
@@ -10,28 +9,16 @@ interface MenuActionsProps {
   menuName: string;
 }
 
-/**
- * 메뉴 상세 페이지의 수정/삭제 액션. 삭제는 soft delete + confirm.
- * sale_items 참조는 보존 (헌법 III 스냅샷) — 통계에는 남고 목록에서만 사라짐.
- */
 export function MenuActions({ menuId, menuName }: MenuActionsProps): React.ReactElement {
   const router = useRouter();
   const deleteMutation = useDeleteMenu();
-  const [error, setError] = useState<string | null>(null);
 
   async function handleDelete(): Promise<void> {
     const confirmed = window.confirm(
       `"${menuName}" 메뉴를 삭제할까요?\n\n과거 판매 기록은 그대로 보존되고 메뉴 목록에서만 사라져요.`,
     );
     if (!confirmed) return;
-
-    setError(null);
-    try {
-      await deleteMutation.mutateAsync(menuId);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "삭제 실패");
-      return;
-    }
+    await deleteMutation.mutateAsync(menuId);
     router.push("/menu");
   }
 
@@ -53,9 +40,9 @@ export function MenuActions({ menuId, menuName }: MenuActionsProps): React.React
           {deleteMutation.isPending ? "삭제 중…" : "삭제"}
         </button>
       </div>
-      {error && (
+      {deleteMutation.error && (
         <p role="alert" className="text-caption text-red">
-          {error}
+          {deleteMutation.error.message}
         </p>
       )}
     </div>

--- a/src/features/menu/components/MenuList.tsx
+++ b/src/features/menu/components/MenuList.tsx
@@ -56,17 +56,15 @@ function MenuListRow({ menu }: { menu: MenuRowWithRecipe }): React.ReactElement 
  * - green: 50%+, amber: 30~49%, red: <30%
  */
 function MarginChip({ rate }: { rate: number }): React.ReactElement {
-  const tone: "green" | "amber" | "red" = rate >= 50 ? "green" : rate >= 30 ? "amber" : "red";
   return (
-    <span
-      className={cn(
-        "rounded-full px-3 py-1 text-label tabular-nums",
-        tone === "green" && "bg-green-soft text-green-deep",
-        tone === "amber" && "bg-amber-soft text-amber-deep",
-        tone === "red" && "bg-red-soft text-red-deep",
-      )}
-    >
+    <span className={cn("rounded-full px-3 py-1 text-label tabular-nums", marginToneClass(rate))}>
       {rate.toFixed(0)}%
     </span>
   );
+}
+
+function marginToneClass(rate: number): string {
+  if (rate >= 50) return "bg-green-soft text-green-deep";
+  if (rate >= 30) return "bg-amber-soft text-amber-deep";
+  return "bg-red-soft text-red-deep";
 }

--- a/src/features/menu/hooks/useCloneTemplate.ts
+++ b/src/features/menu/hooks/useCloneTemplate.ts
@@ -4,7 +4,8 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import { cloneMenuTemplate } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
-import { menuListQueryKey } from "./useMenus";
+import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
+import { invalidateMenuCaches } from "./useMenus";
 import type { CloneTemplateInput } from "../schemas";
 
 interface CloneResult {
@@ -37,7 +38,9 @@ export function useCloneTemplate(): UseMutationResult<CloneResult, Error, CloneT
         store_type: input.storeType,
         new_menus: result.newMenuCount,
       });
-      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+      invalidateMenuCaches(queryClient);
+      // 템플릿은 메뉴 + 재료를 함께 생성 → 재료 목록도 무효화.
+      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
     },
   });
 }

--- a/src/features/menu/hooks/useMenuMutations.ts
+++ b/src/features/menu/hooks/useMenuMutations.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import { deleteMenu, editMenu } from "@/lib/supabase/rpc";
 import type { MenuInput } from "../schemas";
-import { menuListQueryKey } from "./useMenus";
+import { invalidateMenuCaches } from "./useMenus";
 
 interface EditMenuVariables {
   menuId: string;
@@ -27,9 +27,7 @@ export function useEditMenu(): UseMutationResult<string, Error, EditMenuVariable
       if (!row) throw new Error("edit_menu returned empty");
       return row.menu_id;
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
-    },
+    onSuccess: () => invalidateMenuCaches(queryClient),
   });
 }
 
@@ -41,8 +39,6 @@ export function useDeleteMenu(): UseMutationResult<void, Error, string> {
       const { error } = await deleteMenu(supabase, menuId);
       if (error) throw new Error(error.message);
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
-    },
+    onSuccess: () => invalidateMenuCaches(queryClient),
   });
 }

--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
+import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 
 /**
  * 사용자 메뉴 + 레시피 + 재료 단가를 한 번에 fetch.
@@ -86,4 +87,14 @@ export function useMenus(): UseQueryResult<MenuRowWithRecipe[]> {
     queryKey: menuListQueryKey,
     queryFn: fetchMenus,
   });
+}
+
+/**
+ * 메뉴 mutation 후 호출 — 메뉴 자체 + 메뉴 마진을 표시하는 dashboard top3 / forecast 화면이
+ * 모두 ingredient 단가에 의존하므로 forecast 키도 함께 무효화. menu/sale/purchase mutation
+ * 어디서든 같은 패턴 일관 사용.
+ */
+export function invalidateMenuCaches(queryClient: ReturnType<typeof useQueryClient>): void {
+  void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
+  void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
 }

--- a/src/features/menu/lib/compute-menu-margin.ts
+++ b/src/features/menu/lib/compute-menu-margin.ts
@@ -1,15 +1,18 @@
 import { calculateMargin, calculateMenuCost, type MarginResult } from "@/lib/domain/margin";
 import type { Decimal } from "@/lib/domain/_decimal";
+import type { RecipeItemForCost } from "@/lib/domain/margin";
 import type { MenuRowWithRecipe } from "../hooks/useMenus";
 
 /**
- * `useMenus`가 반환하는 row 형태에서 직접 원가 + 마진을 산출.
- * MenuList / MenuDetailCard / 후속 dashboard top-3 / sale 미리보기에서 공유.
- *
- * 레시피가 비어 있으면 `cost = 0`이므로 `rate = 100%`가 나오는데,
- * 그건 호출 측이 "레시피 미등록" placeholder로 처리하는 게 자연스럽다.
- * 여기서는 raw 계산만 하고 의미 부여는 UI에 위임.
+ * `useMenus` join row → 도메인 `RecipeItemForCost[]` 단일 어댑터.
+ * compute-menu-margin / sale 스냅샷 변환 두 곳에서 공유.
  */
+export function rowToRecipeForCost(row: MenuRowWithRecipe): RecipeItemForCost[] {
+  return row.recipe_items.map((item) => ({
+    quantity: item.quantity_per_serving,
+    avgPrice: item.ingredient.current_avg_price,
+  }));
+}
 
 export interface MenuMargin {
   cost: Decimal;
@@ -18,11 +21,9 @@ export interface MenuMargin {
 }
 
 export function computeMenuMarginFromRow(menu: MenuRowWithRecipe): MenuMargin {
-  const recipe = menu.recipe_items.map((item) => ({
-    quantity: item.quantity_per_serving,
-    avgPrice: item.ingredient.current_avg_price,
-  }));
+  const recipe = rowToRecipeForCost(menu);
   const cost = calculateMenuCost(recipe);
   const margin = calculateMargin({ price: menu.price, cost });
+  // 레시피 비어있으면 cost=0, rate=100% — 호출 측이 hasRecipe로 placeholder 처리.
   return { cost, margin, hasRecipe: recipe.length > 0 };
 }

--- a/src/features/sale/lib/to-snapshot-menu.ts
+++ b/src/features/sale/lib/to-snapshot-menu.ts
@@ -1,18 +1,16 @@
 import type { MenuRowWithRecipe } from "@/features/menu/hooks/useMenus";
+import { rowToRecipeForCost } from "@/features/menu/lib/compute-menu-margin";
 import type { MenuForSnapshot } from "@/lib/domain/snapshot";
 
 /**
- * `useMenus`의 join row를 도메인 함수가 받는 형태로 어댑트.
- * 같은 메뉴 데이터가 두 표현(DB column / 도메인 입력) 사이를 오갈 때 변환 단일 출처.
+ * `useMenus`의 join row를 sale 스냅샷 도메인 입력으로 어댑트.
+ * recipe 매핑은 compute-menu-margin과 공유 (rowToRecipeForCost).
  */
 export function toSnapshotMenu(row: MenuRowWithRecipe): MenuForSnapshot {
   return {
     id: row.id,
     name: row.name,
     price: row.price,
-    recipeItems: row.recipe_items.map((it) => ({
-      quantity: it.quantity_per_serving,
-      avgPrice: it.ingredient.current_avg_price,
-    })),
+    recipeItems: rowToRecipeForCost(row),
   };
 }


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor 슬라이스 5 — `src/features/menu/` + `src/features/inventory/` (1325 LOC, 18 파일). simplify 3-agent 리뷰 결과 중 안전 7건 적용. + 같은 패턴 적용한 sale/inventory 파일도 합류.

### 변경

**🐛 BUG FIX (1건)**
- `useEditMenu` / `useDeleteMenu`가 `menuListQueryKey`만 무효화 → recipe 변경 시 forecast / dashboard top3 stale. `invalidateMenuCaches(qc)` 헬퍼 도입해 menu + forecast 동시 무효화. 다른 mutation도 동일 패턴 일관 사용
  - `useCloneTemplate`: `invalidateMenuCaches` + `ingredientListQueryKey` (템플릿이 재료도 생성)
  - `useApplyStockCount`: `invalidateMenuCaches` + `ingredientListQueryKey` (이전엔 3줄 inline)

**🧹 정리 (no-functional-change)**

| # | 파일 | 변경 |
|---|---|---|
| 1 | `compute-menu-margin.ts` + `to-snapshot-menu.ts` | `rowToRecipeForCost(row)` 단일 어댑터 추출 → row → `{quantity, avgPrice}` 매핑 단일 출처화 |
| 2 | `MenuList.MarginChip` | 중첩 삼항 (`rate >= 50 ? "green" : rate >= 30 ? "amber" : "red"`) → `marginToneClass(rate)` 헬퍼 분리. 글로벌 룰 위반 해소 |
| 3 | `IngredientStatusList.toneClass` | if/else 체인 → `STATUS_TONE` Record 매핑 |
| 4 | `IngredientStatusList.IngredientRow` | `useState<string\|null>(error)` + try/catch 중복 → `mutation.error` 직접 사용 |
| 5 | `MenuActions` | 동일 — local error state + try/catch 제거 |
| 6 | `StockCountForm` | `actuals` Map identity 매 입력마다 새로 만들어져 skip 못 하는 `useMemo` 제거 → inline. `todayString()` 헬퍼 매번 재계산 → `TODAY_ISO` 상수. `<Field error={undefined}>` 제거 |

### 별도 PR 예정

- `useCreateMenu` mutation hook 분리 (현재 `MenuForm`의 create path가 직접 `saveMenu` + 인라인 `invalidateQueries` 호출 — useEditMenu와 비대칭)
- `AddIngredientForm` ↔ `IngredientQuickCreate` 폼 본체 통합 (slice 4에서 unit_labels/schema는 이미 호이스트, 폼 자체는 미통합)
- `useDepletionForecast.ts:34` `Number(s.amount)` 타입 hole 정정
- `useMenus.ts:72` `as unknown as` 정당화 주석 → 별도 typing 전략
- `TemplateLoadDialog` dessert_cafe dead config 처리

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅
- build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)