### PR TITLE
refactor(app+ui+stores): slice 7 — useActiveIngredients + LoadingText/ErrorAlert atom + dead code

### DIFF
--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -36,19 +36,12 @@ export default function CalendarPage(): React.ReactElement {
 
   const query = useCalendarMonth(year, month);
 
-  // monthKey + operating_days만 dep으로 두면 같은 월의 refetch (참조만 다른 동일 데이터)에는
-  // 중복 발화하지 않음. 값이 실제로 변하는 경우에만 트래킹.
-  const monthKey = year !== null && month !== null ? `${year}-${month}` : null;
+  // primitive deps로 month 변경 + operating_days 변경에만 발화. 동일 데이터 refetch엔 skip.
   const operatingDays = query.data?.cumulative.operatingDays ?? null;
   useEffect(() => {
-    if (operatingDays === null || !monthKey) return;
-    const [y, m] = monthKey.split("-").map(Number);
-    trackEvent("calendar_viewed", {
-      year: y as number,
-      month: m as number,
-      operating_days: operatingDays,
-    });
-  }, [monthKey, operatingDays]);
+    if (year === null || month === null || operatingDays === null) return;
+    trackEvent("calendar_viewed", { year, month, operating_days: operatingDays });
+  }, [year, month, operatingDays]);
 
   function handleSelect(cell: EnrichedCalendarCell): void {
     setSelectedDate(cell.date);
@@ -93,8 +86,9 @@ export default function CalendarPage(): React.ReactElement {
     );
   }
 
-  const selectedCell =
-    selectedDate !== null ? (query.data.cells.find((c) => c.date === selectedDate) ?? null) : null;
+  const selectedCell = selectedDate
+    ? (query.data.cells.find((c) => c.date === selectedDate) ?? null)
+    : null;
 
   return (
     <section className="flex flex-col gap-section">
@@ -118,8 +112,6 @@ export default function CalendarPage(): React.ReactElement {
         onSelect={handleSelect}
       />
       <CalendarLegend />
-      {/* todayIso는 mount 후 채워짐 — null이면 CellDetailPanel의 daysFromToday 계산이
-          1970 fallback에 의존하게 되므로 명시적으로 null guard. */}
       {selectedCell && todayIso && <CellDetailPanel cell={selectedCell} todayIso={todayIso} />}
     </section>
   );

--- a/src/app/(main)/menu/[id]/edit/page.tsx
+++ b/src/app/(main)/menu/[id]/edit/page.tsx
@@ -1,39 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
 import { MenuForm } from "@/features/menu/components/MenuForm";
 import { useMenus } from "@/features/menu/hooks/useMenus";
+import { useActiveIngredients } from "@/features/menu/hooks/useActiveIngredients";
 import type { MenuInput } from "@/features/menu/schemas";
-
-interface IngredientOption {
-  id: string;
-  name: string;
-  unit: string;
-}
 
 export default function MenuEditPage(): React.ReactElement {
   const { id } = useParams<{ id: string }>();
   const { data: menus, isLoading: menusLoading, error: menusError } = useMenus();
-  const [ingredients, setIngredients] = useState<IngredientOption[]>([]);
-  const [ingredientsLoading, setIngredientsLoading] = useState(true);
-  const [ingredientsError, setIngredientsError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const supabase = createClient();
-    void supabase
-      .from("ingredients")
-      .select("id, name, unit")
-      .eq("is_active", true)
-      .order("name")
-      .then(({ data, error }) => {
-        if (error) setIngredientsError(error.message);
-        else setIngredients(data ?? []);
-        setIngredientsLoading(false);
-      });
-  }, []);
+  const {
+    data: ingredients,
+    isLoading: ingredientsLoading,
+    error: ingredientsError,
+  } = useActiveIngredients();
 
   const menu = menus?.find((m) => m.id === id);
   const isLoading = menusLoading || ingredientsLoading;
@@ -51,7 +32,7 @@ export default function MenuEditPage(): React.ReactElement {
 
       {ingredientsError && (
         <p role="alert" className="text-body-regular text-red">
-          재료 목록을 불러오지 못했어요: {ingredientsError}
+          재료 목록을 불러오지 못했어요: {ingredientsError.message}
         </p>
       )}
 
@@ -67,7 +48,7 @@ export default function MenuEditPage(): React.ReactElement {
 
       {menu && !ingredientsError && (
         <MenuForm
-          ingredients={ingredients}
+          ingredients={ingredients ?? []}
           mode={{
             kind: "edit",
             menuId: menu.id,

--- a/src/app/(main)/menu/[id]/page.tsx
+++ b/src/app/(main)/menu/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { useMenus } from "@/features/menu/hooks/useMenus";
 import { MenuDetailCard } from "@/features/menu/components/MenuDetailCard";
 import { MenuActions } from "@/features/menu/components/MenuActions";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 
 export default function MenuDetailPage(): React.ReactElement {
   const { id } = useParams<{ id: string }>();
@@ -20,15 +21,9 @@ export default function MenuDetailPage(): React.ReactElement {
         </Link>
       </header>
 
-      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
-
-      {error && (
-        <p role="alert" className="text-body-regular text-red">
-          {error.message}
-        </p>
-      )}
-
-      {data && !menu && <p className="text-body-regular text-ink-3">메뉴를 찾을 수 없습니다.</p>}
+      {isLoading && <LoadingText />}
+      {error && <ErrorAlert message={error.message} />}
+      {data && !menu && <LoadingText>메뉴를 찾을 수 없습니다.</LoadingText>}
 
       {menu && (
         <>

--- a/src/app/(main)/menu/new/page.tsx
+++ b/src/app/(main)/menu/new/page.tsx
@@ -1,39 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabase/client";
 import { MenuForm } from "@/features/menu/components/MenuForm";
 import { useMenus } from "@/features/menu/hooks/useMenus";
-
-interface IngredientOption {
-  id: string;
-  name: string;
-  unit: string;
-}
+import { useActiveIngredients } from "@/features/menu/hooks/useActiveIngredients";
 
 export default function MenuNewPage(): React.ReactElement {
   const { data: menus, isLoading: menusLoading } = useMenus();
-  const [ingredients, setIngredients] = useState<IngredientOption[]>([]);
-  const [ingredientsLoading, setIngredientsLoading] = useState(true);
-  const [ingredientsError, setIngredientsError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const supabase = createClient();
-    void supabase
-      .from("ingredients")
-      .select("id, name, unit")
-      .eq("is_active", true)
-      .order("name")
-      .then(({ data, error }) => {
-        if (error) {
-          setIngredientsError(error.message);
-        } else {
-          setIngredients(data ?? []);
-        }
-        setIngredientsLoading(false);
-      });
-  }, []);
+  const { data: ingredients, isLoading: ingredientsLoading, error } = useActiveIngredients();
 
   const isLoading = menusLoading || ingredientsLoading;
   const isFirstMenu = (menus?.length ?? 0) === 0;
@@ -49,14 +23,14 @@ export default function MenuNewPage(): React.ReactElement {
 
       {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
 
-      {ingredientsError && (
+      {error && (
         <p role="alert" className="text-body-regular text-red">
-          재료 목록을 불러오지 못했어요: {ingredientsError}
+          재료 목록을 불러오지 못했어요: {error.message}
         </p>
       )}
 
-      {!isLoading && !ingredientsError && (
-        <MenuForm ingredients={ingredients} mode={{ kind: "create", isFirstMenu }} />
+      {!isLoading && !error && (
+        <MenuForm ingredients={ingredients ?? []} mode={{ kind: "create", isFirstMenu }} />
       )}
     </section>
   );

--- a/src/app/(main)/menu/page.tsx
+++ b/src/app/(main)/menu/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useMenus } from "@/features/menu/hooks/useMenus";
 import { MenuList } from "@/features/menu/components/MenuList";
 import { TemplateLoadDialog } from "@/features/menu/components/TemplateLoadDialog";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 
 export default function MenuPage(): React.ReactElement {
   const { data, isLoading, error } = useMenus();
@@ -20,13 +21,8 @@ export default function MenuPage(): React.ReactElement {
         </Link>
       </header>
 
-      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
-
-      {error && (
-        <p role="alert" className="text-body-regular text-red">
-          메뉴를 불러오지 못했어요: {error.message}
-        </p>
-      )}
+      {isLoading && <LoadingText />}
+      {error && <ErrorAlert prefix="메뉴를 불러오지 못했어요:" message={error.message} />}
 
       {data && data.length === 0 && <TemplateLoadDialog />}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 
-/**
- * 루트 라우트 — 인증 상태에 따라 즉시 분기.
- *  - 로그인 → /today (홈 대시보드)
- *  - 비로그인 → /login
- *
- * RSC 단계에서 redirect()로 처리 — 사용자에게 placeholder가 잠시도 안 보이도록.
- */
+// 루트 라우트 — 로그인 상태면 /today, 아니면 /login. RSC redirect로 placeholder 노출 차단.
 export default async function RootPage(): Promise<never> {
   const supabase = await createClient();
   const {

--- a/src/components/providers/ServiceWorkerRegister.tsx
+++ b/src/components/providers/ServiceWorkerRegister.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 
 export function ServiceWorkerRegister(): null {
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    // useEffect는 클라이언트에서만 실행되므로 typeof window 가드 불필요.
     if (!("serviceWorker" in navigator)) return;
     if (process.env.NODE_ENV !== "production") return;
 

--- a/src/components/ui/query-state.tsx
+++ b/src/components/ui/query-state.tsx
@@ -1,0 +1,22 @@
+// 라우트 페이지의 fetch loading/error 표시 — 9곳에서 inline JSX 중복이라 단일 atom.
+
+export function LoadingText({
+  children = "불러오는 중…",
+}: {
+  children?: string;
+}): React.ReactElement {
+  return <p className="text-body-regular text-ink-3">{children}</p>;
+}
+
+interface ErrorAlertProps {
+  message: string;
+  prefix?: string;
+}
+
+export function ErrorAlert({ message, prefix }: ErrorAlertProps): React.ReactElement {
+  return (
+    <p role="alert" className="text-body-regular text-red-deep">
+      {prefix ? `${prefix} ${message}` : message}
+    </p>
+  );
+}

--- a/src/features/menu/hooks/useActiveIngredients.ts
+++ b/src/features/menu/hooks/useActiveIngredients.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * MenuForm용 활성 재료 옵션 fetch.
+ * `useIngredients` (purchase 슬라이스)는 current_avg_price도 가져오는 무거운 쿼리라
+ * 메뉴 작성 폼에선 id/name/unit만 필요한 가벼운 파생 hook을 별도로 둠.
+ */
+
+export interface IngredientOption {
+  id: string;
+  name: string;
+  unit: string;
+}
+
+export const activeIngredientsQueryKey = ["ingredients", "active-options"] as const;
+
+async function fetchActiveIngredients(): Promise<IngredientOption[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("ingredients")
+    .select("id, name, unit")
+    .eq("is_active", true)
+    .order("name");
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export function useActiveIngredients(): UseQueryResult<IngredientOption[]> {
+  return useQuery({
+    queryKey: activeIngredientsQueryKey,
+    queryFn: fetchActiveIngredients,
+    staleTime: 60 * 1000,
+  });
+}

--- a/src/stores/sale-draft.ts
+++ b/src/stores/sale-draft.ts
@@ -1,14 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-/**
- * 판매 입력 폼 임시저장 (Zustand).
- *
- * 페르소나 마감 후 5분 입력 흐름 보호 — 입력 중 페이지 이탈/실수로
- * 작성한 내용 사라지지 않도록 localStorage에 자동 저장.
- *
- * 실제 sale row는 PR 14 (Phase 4 US1 sale)에서 saveSale RPC로 저장.
- */
+// 판매 입력 폼 임시저장 — 입력 중 페이지 이탈/실수로 작성 내용이 사라지지 않도록
+// localStorage 자동 저장 (페르소나 마감 후 5분 입력 흐름 보호).
 
 export interface SaleDraftItem {
   menuId: string;
@@ -20,7 +14,6 @@ interface SaleDraftState {
   items: SaleDraftItem[];
   setDraftDate: (date: string | null) => void;
   setQuantity: (menuId: string, quantity: number) => void;
-  removeItem: (menuId: string) => void;
   clear: () => void;
 }
 
@@ -45,9 +38,6 @@ export const useSaleDraft = create<SaleDraftState>()(
           }
           return { items: [...state.items, { menuId, quantity }] };
         }),
-
-      removeItem: (menuId) =>
-        set((state) => ({ items: state.items.filter((it) => it.menuId !== menuId) })),
 
       clear: () => set({ draftDate: null, items: [] }),
     }),


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor 슬라이스 7 — app routes + middleware + components/ui + stores (1201 LOC, 28 파일). simplify 3-agent 리뷰 결과 중 동작 변경 없는 8건.

### 변경

| # | 파일 | 변경 |
|---|---|---|
| 1 | 신규 `useActiveIngredients` hook | `menu/new/page` + `menu/[id]/edit/page` 동일 `useState + useEffect + supabase.from(...)` fetch 로직을 TanStack Query로 통합. unmount 후 setState 위험 + 직접 imperative fetch 둘 다 해결 |
| 2 | 신규 `components/ui/query-state.tsx` | `LoadingText` / `ErrorAlert` atom — 라우트 9곳 중복 JSX 단일 출처. `text-red` vs `text-red-deep` 톤 차이도 통일 |
| 3 | `menu/page` + `menu/[id]/page` | atoms 적용. 나머지 라우트는 다음 슬라이스 |
| 4 | `stores/sale-draft.ts` | `removeItem` 액션 dead code 제거 (호출처 0건). 파일 상단 5줄 JSDoc → 1줄 |
| 5 | `calendar/page.tsx` | `monthKey` split → `Number` `as number` 단언 제거 → `year`/`month` primitive deps 직접. `selectedDate` 이중 ternary 단순화. 정당화 주석 2개 제거 |
| 6 | `ServiceWorkerRegister` | `useEffect` 안의 `typeof window === "undefined"` 가드 (dead) 제거 |
| 7 | `app/page.tsx` | `RootPage` 5줄 JSDoc → 1줄 인라인 |
| 8 | `useActiveIngredients` 채택 | menu/new + menu/[id]/edit 둘 다 적용 |

### 별도 PR 예정

- `<QueryStateBoundary query={...}>` wrapper 도입 — 나머지 라우트 7곳에 적용
- `PageHeader` atom (title + back link 패턴 6개 중복)
- `SecondaryButton` variant (outline 버튼 4곳 중복)
- `middleware.ts` users 쿼리 핫패스 최적화 (모든 protected 요청마다 DB 왕복)
- `app/page.tsx` redirect를 middleware로 이전 (RTT 1회 절감)
- `sale/[date]/page.tsx` 4단계 중첩 삼항 → early return
- 정당화 주석들 (cookie-consent-banner, today/page useEffect 등) 정리
- middleware `as` 단언 제거 (Database row 타입 사용)

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅
- build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)