### PR TITLE
refactor(edge-fn): slice 8 — push-scheduler KST 요일 fix + 운영 가시성

### DIFF
--- a/supabase/functions/d7-tracker/index.ts
+++ b/supabase/functions/d7-tracker/index.ts
@@ -2,21 +2,11 @@
  * Edge Function — D7 retention tracker (Phase 8 / T166).
  * 트리거: pg_cron이 pg_net으로 HTTP POST (027_d7_tracker_cron.sql, 매일 KST 11:00).
  *
- * 로직:
- *  1) "가입 7일째" 코호트 — KST 기준 today - 7일에 가입한 사용자 (탈퇴 신청자 제외).
- *     UTC 단순 비교는 KST 저녁 가입자가 다음 UTC 날짜로 넘어가 누락되므로
- *     +09:00 offset 윈도우 사용.
- *  2) 그 중 sales.created_at >= now() - 24h 인 사용자 = "활성"
- *     (sale 입력은 핵심 가치 행위이므로 단순 로그인보다 신뢰성 높은 retention 신호).
- *     candidate 전원에 대해 단일 .in() 쿼리로 한 번에 조회 — N+1 회피.
- *  3) GA4 Measurement Protocol로 d7_active 이벤트 발화.
+ * 로직: "가입 7일째 + 24h 내 sale 입력" 코호트 → GA4 Measurement Protocol로 d7_active 발화.
+ * KST cohort window — UTC 단순 비교는 KST 저녁 가입자가 다음 UTC 날짜로 넘어가 누락.
+ * push-scheduler와 동일 GA4 secrets (GA4_MEASUREMENT_ID + GA4_API_SECRET) 공유 — 미설정 시 no-op.
  *
- * Secrets:
- *   GA4_MEASUREMENT_ID + GA4_API_SECRET (둘 다 등록되어야 발화)
- *   미설정 시 silent no-op (return success: true, sent_count: 0).
- *
- * 헌법 IV: service_role 사용 (RLS 우회). user.id는 GA4 client_id로 그대로 사용 —
- * UUIDv4는 외부 시스템에서 PII로 연결 불가능한 무작위 식별자.
+ * client_id로 user.id (UUIDv4) 그대로 사용 — 외부 시스템에서 PII로 연결 불가능한 무작위 식별자.
  */
 
 // @ts-expect-error: Deno runtime
@@ -51,7 +41,8 @@ async function reportD7Active(userId: string, signupDate: string): Promise<Ga4Re
       },
     );
     return { ok: res.ok };
-  } catch {
+  } catch (err) {
+    console.warn("ga4 dispatch failed", err);
     return { ok: false };
   }
 }

--- a/supabase/functions/permanent-delete/index.ts
+++ b/supabase/functions/permanent-delete/index.ts
@@ -1,18 +1,10 @@
 /**
  * Edge Function — 만료된 탈퇴 사용자 영구 삭제 (FR-036).
- *
- * 트리거: pg_cron daily (별도 마이그레이션에서 등록)
- * 권한: service role
- *
- * 동작:
- *   permanent_delete_at <= now() AND withdrawal_requested_at IS NOT NULL
- *   인 사용자에 대해 auth.users 삭제 → public.users CASCADE 삭제 →
- *   ingredients/sales/etc. CASCADE 삭제.
- *
- * 멱등성: 이미 삭제된 사용자는 영향 없음 (조건이 0 row 반환).
+ * 트리거: pg_cron daily. permanent_delete_at <= now() + withdrawal_requested_at NOT NULL인
+ * auth.users를 삭제 → DB cascade (스키마 정의 참조). 멱등 — 0 row 시 no-op.
  */
 
-// @ts-expect-error: Deno runtime, deno.serve is global in Supabase Edge Functions.
+// @ts-expect-error: Deno runtime
 import { createClient } from "jsr:@supabase/supabase-js@2";
 
 interface DeletionResult {
@@ -21,12 +13,12 @@ interface DeletionResult {
   errors: Array<{ userId: string; message: string }>;
 }
 
-// @ts-expect-error: Deno global available at runtime in Supabase Edge.
+// @ts-expect-error: Deno global
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
-// @ts-expect-error: Deno global available at runtime in Supabase Edge.
+// @ts-expect-error: Deno global
 const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
-// @ts-expect-error: Deno.serve is global in Supabase Edge Functions.
+// @ts-expect-error: Deno.serve global
 Deno.serve(async (): Promise<Response> => {
   if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
     return Response.json({ success: false, error: "missing env" }, { status: 500 });
@@ -61,5 +53,10 @@ Deno.serve(async (): Promise<Response> => {
     result.deletedCount += 1;
   }
 
+  // 부분 실패가 cron 모니터(pg_net._http_response)에서 보이도록 207 multi-status.
+  if (result.errors.length > 0) {
+    result.success = false;
+    return Response.json(result, { status: 207 });
+  }
   return Response.json(result);
 });

--- a/supabase/functions/push-scheduler/index.ts
+++ b/supabase/functions/push-scheduler/index.ts
@@ -28,6 +28,13 @@ interface PushPayload {
   type: AlertType;
 }
 
+interface PushSubscriptionRow {
+  id: string;
+  endpoint: string;
+  keys_p256dh: string;
+  keys_auth: string;
+}
+
 // @ts-expect-error: Deno global
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 // @ts-expect-error: Deno global
@@ -38,8 +45,8 @@ const VAPID_PUBLIC = Deno.env.get("VAPID_PUBLIC_KEY") ?? "";
 const VAPID_PRIVATE = Deno.env.get("VAPID_PRIVATE_KEY") ?? "";
 // @ts-expect-error: Deno global
 const VAPID_SUBJECT = Deno.env.get("VAPID_SUBJECT") ?? "mailto:hello@easystock.app";
-// GA4 Measurement Protocol — secrets에 NEXT_PUBLIC_GA_MEASUREMENT_ID + GA4_API_SECRET 등록 시
-// T140 order_alert_received 등 서버측 발화. 미설정 시 no-op.
+// GA4 Measurement Protocol — d7-tracker와 동일 secrets 공유 (GA4_MEASUREMENT_ID +
+// GA4_API_SECRET). 미설정 시 reportToGa4 no-op.
 // @ts-expect-error: Deno global
 const GA4_MEASUREMENT_ID = Deno.env.get("GA4_MEASUREMENT_ID") ?? "";
 // @ts-expect-error: Deno global
@@ -65,8 +72,9 @@ async function reportToGa4(type: AlertType, sentCount: number): Promise<void> {
         }),
       },
     );
-  } catch {
-    // 측정 실패는 푸시 발송 결과에 영향 없음
+  } catch (err) {
+    // 측정 실패는 푸시 발송 결과에 영향 없음 — log로만 기록.
+    console.warn("ga4 dispatch failed", err);
   }
 }
 
@@ -90,10 +98,12 @@ Deno.serve(async (req: Request): Promise<Response> => {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const todayWeekday = KOREAN_WEEKDAYS[new Date().getUTCDay()] ?? "MON";
+  // KST 기준 오늘 요일 — UTC getUTCDay()는 KST 자정~UTC 09:00 구간에서 하루 밀린다.
+  // (FR-041 정기휴무 누락 방지). d7-tracker의 KST cohort window와 동일 +9h shift.
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  const todayWeekday = KOREAN_WEEKDAYS[new Date(Date.now() + KST_OFFSET_MS).getUTCDay()];
 
-  // 정기휴무 오늘인 사용자는 제외 (FR-041)
-  // 탈퇴 신청한 사용자는 제외 (FR-036). 정기휴무 요일 사용자는 아래 루프에서 별도 제외 (FR-041).
+  // FR-036 탈퇴 신청자 제외 + FR-041 정기휴무 사용자는 루프 안에서 todayWeekday 비교로 제외.
   const { data: targets, error: queryError } = await admin
     .from("users")
     .select("id, regular_days_off, push_subscriptions(id, endpoint, keys_p256dh, keys_auth)")
@@ -110,12 +120,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
 
   for (const user of targets ?? []) {
     if ((user.regular_days_off ?? []).includes(todayWeekday)) continue;
-    const subs = (user.push_subscriptions ?? []) as Array<{
-      id: string;
-      endpoint: string;
-      keys_p256dh: string;
-      keys_auth: string;
-    }>;
+    const subs = (user.push_subscriptions ?? []) as PushSubscriptionRow[];
 
     for (const sub of subs) {
       try {


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor 슬라이스 8 — Supabase Edge Functions (378 LOC, 3 파일). simplify 리뷰 결과 적용. 마이그레이션은 immutable diary라 스킵.

> ⚠️ **배포 영향**: master 머지 시 `.github/workflows/deploy-edge-functions.yml`가 3개 Edge Function 모두 자동 재배포.

### 변경

**🐛 BUG FIX (1건)**
- `push-scheduler/index.ts:93` — `KOREAN_WEEKDAYS[new Date().getUTCDay()]`가 **KST 자정~UTC 09:00 구간에서 하루 밀려** 정기휴무 사용자에게 알림 잘못 발송 (FR-041 위반). `d7-tracker`의 `+9h shift` 패턴 동일 적용 → KST 기준 요일. `?? "MON"` dead fallback도 제거 (`KOREAN_WEEKDAYS` 길이 7 + `getUTCDay` 0-6 보장)

**🔭 운영 가시성 (silent failure 차단)**

| # | 파일 | 변경 |
|---|---|---|
| 2 | `push-scheduler` + `d7-tracker` `reportToGa4` | 빈 catch → `console.warn(err)`. Edge log에서 GA4 발화 실패 가시화 |
| 3 | `permanent-delete` | 부분 실패 (`errors[]` 누적)가 응답 status 200으로 묻혀 cron 모니터에서 안 잡혔음 → status 207 multi-status + `success: false` |

**🧹 정리 (no-functional)**

- `push-scheduler` `PushSubscriptionRow` named interface 추출 → inline `as` 단언 제거
- `push-scheduler` 95-96 중복 "왜" 주석 → 한 줄
- `push-scheduler` GA4 secrets 주석에 "d7-tracker와 동일 공유" 명시 (contract)
- `d7-tracker` 19줄 docblock → 6줄 핵심만 (KST window + GA4 공유 + PII 무해성)
- `permanent-delete` 12줄 헤더 → 4줄 (cascade chain은 스키마 정의가 단일 진실)
- `// @ts-expect-error` 표현 3종 통일 (`Deno global` / `Deno runtime` / `Deno.serve global`)

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **158/158** ✅
- build ✅

### 배포 후 검증 (PR 머지 후)

- 다음 push cron 실행 (UTC 00:00 / 13:00 / 토 22:00 = KST 09:00 / 22:00 / 일 07:00) 시 KST 정기휴무 정확도 확인
- d7-tracker 다음 실행 (UTC 02:00 = KST 11:00) 시 GA4 secrets 미설정 환경의 console.warn 가시화 확인
- permanent-delete: 의도적 실패 시 207 응답 확인 (베타 단계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)