### PR TITLE
refactor(tests): slice 9 (final) — describeIfSupabase + isoDate helper

### DIFF
--- a/tests/helpers/integration-describe.ts
+++ b/tests/helpers/integration-describe.ts
@@ -1,0 +1,8 @@
+// Vitest 전용 헬퍼 — Playwright (e2e)가 import하면 vitest 의존이 e2e 런타임에 흘러들어가
+// 별도 파일로 분리. tests/helpers/test-supabase.ts는 vitest와 playwright가 공용.
+
+import { describe } from "vitest";
+import { hasSupabaseTestEnv } from "./test-supabase";
+
+/** Supabase env가 있을 때만 통합 테스트 suite 실행 — 9개 파일에서 반복되던 패턴 단일 출처. */
+export const describeIfSupabase = hasSupabaseTestEnv ? describe : describe.skip;

--- a/tests/helpers/test-supabase.ts
+++ b/tests/helpers/test-supabase.ts
@@ -1,3 +1,4 @@
+import { describe } from "vitest";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";
 
@@ -78,6 +79,25 @@ export async function cleanupTestUser(userId: string): Promise<void> {
   if (error && !error.message.includes("not found")) {
     throw new Error(`cleanupTestUser failed: ${error.message}`);
   }
+}
+
+/** Supabase env이 있는 환경에서만 통합 테스트 suite 실행 — 9개 파일에서 반복되던 패턴. */
+export const describeIfSupabase = hasSupabaseTestEnv ? describe : describe.skip;
+
+/**
+ * UTC 기준 N일 오프셋 ISO date (YYYY-MM-DD).
+ * 로컬 setDate 변형은 DST 경계에서 ±1일 — 서버 current_date (UTC)와 일치시키려면 UTC.
+ */
+export function isoDate(offsetDays: number = 0): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+/** 가입일 backdate — calendar/sale 테스트에서 과거 데이터 검증용. */
+export async function backdateSignup(userId: string, isoDateStr: string): Promise<void> {
+  const admin = getServiceRoleClient();
+  await admin.from("users").update({ signed_up_at: isoDateStr }).eq("id", userId);
 }
 
 export async function signInAs(user: TestUser): Promise<SupabaseClient<Database>> {

--- a/tests/helpers/test-supabase.ts
+++ b/tests/helpers/test-supabase.ts
@@ -1,4 +1,3 @@
-import { describe } from "vitest";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";
 
@@ -80,9 +79,6 @@ export async function cleanupTestUser(userId: string): Promise<void> {
     throw new Error(`cleanupTestUser failed: ${error.message}`);
   }
 }
-
-/** Supabase env이 있는 환경에서만 통합 테스트 suite 실행 — 9개 파일에서 반복되던 패턴. */
-export const describeIfSupabase = hasSupabaseTestEnv ? describe : describe.skip;
 
 /**
  * UTC 기준 N일 오프셋 ISO date (YYYY-MM-DD).

--- a/tests/integration/calendar-month.test.ts
+++ b/tests/integration/calendar-month.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
+  backdateSignup,
   cleanupTestUser,
   createTestUser,
+  describeIfSupabase,
   getServiceRoleClient,
-  hasSupabaseTestEnv,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -20,9 +21,7 @@ import type { Database } from "@/lib/supabase/types";
  * - RLS: 다른 사용자 데이터 leak 차단
  */
 
-const describeCalendar = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeCalendar("get_calendar_month RPC", () => {
+describeIfSupabase("get_calendar_month RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
   let menuId: string;
@@ -36,10 +35,9 @@ describeCalendar("get_calendar_month RPC", () => {
     const menu = await client.from("menus").select("id").eq("name", "아메리카노").single();
     menuId = menu.data!.id;
 
+    // 1월 셀의 is_before_signup=false를 보장하려면 가입일이 1월 이전이어야 함.
+    await backdateSignup(user.id, "2025-12-01");
     const admin = getServiceRoleClient();
-    // 1월 셀 검증을 위해 가입일을 1월 이전으로 backdate (그렇지 않으면 1월 셀은
-    // is_before_signup=true → is_missing=false가 되어 누락 판정 검증 불가)
-    await admin.from("users").update({ signed_up_at: "2025-12-01" }).eq("id", user.id);
     const ing = await admin
       .from("ingredients")
       .select("id")

--- a/tests/integration/calendar-month.test.ts
+++ b/tests/integration/calendar-month.test.ts
@@ -3,11 +3,11 @@ import {
   backdateSignup,
   cleanupTestUser,
   createTestUser,
-  describeIfSupabase,
   getServiceRoleClient,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { cloneMenuTemplate, getCalendarMonth } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/dashboard.test.ts
+++ b/tests/integration/dashboard.test.ts
@@ -2,8 +2,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
+  describeIfSupabase,
   getServiceRoleClient,
-  hasSupabaseTestEnv,
+  isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -20,17 +21,7 @@ import type { Database } from "@/lib/supabase/types";
  * - top3 메뉴 마진 정렬
  */
 
-const describeDashboard = hasSupabaseTestEnv ? describe : describe.skip;
-
-// RPC가 server-side `current_date` (UTC) 기준이므로 클라이언트도 UTC 기준 날짜 산술.
-// setDate는 로컬 타임존 기반이라 DST 전환일 등 ±1일 오차 가능.
-const isoDate = (offsetDays: number): string => {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() + offsetDays);
-  return d.toISOString().slice(0, 10);
-};
-
-describeDashboard("get_today_dashboard RPC", () => {
+describeIfSupabase("get_today_dashboard RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
   let menuId: string;

--- a/tests/integration/dashboard.test.ts
+++ b/tests/integration/dashboard.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  describeIfSupabase,
   getServiceRoleClient,
   isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { cloneMenuTemplate, getTodayDashboard } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/ingredient-delete.test.ts
+++ b/tests/integration/ingredient-delete.test.ts
@@ -1,11 +1,6 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
-import {
-  cleanupTestUser,
-  createTestUser,
-  describeIfSupabase,
-  signInAs,
-  type TestUser,
-} from "../helpers/test-supabase";
+import { cleanupTestUser, createTestUser, signInAs, type TestUser } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { cloneMenuTemplate, deleteIngredient, saveIngredient } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/ingredient-delete.test.ts
+++ b/tests/integration/ingredient-delete.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  hasSupabaseTestEnv,
+  describeIfSupabase,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -18,9 +18,7 @@ import type { Database } from "@/lib/supabase/types";
  * - 단가 history는 cascade 보존
  */
 
-const describeIngredientDelete = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeIngredientDelete("delete_ingredient RPC", () => {
+describeIfSupabase("delete_ingredient RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
 

--- a/tests/integration/menu-edit-delete.test.ts
+++ b/tests/integration/menu-edit-delete.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  hasSupabaseTestEnv,
+  describeIfSupabase,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -17,9 +17,7 @@ import type { Database } from "@/lib/supabase/types";
  * - 삭제는 soft (is_active=false), 과거 sale 참조 보존
  */
 
-const describeMenuMutations = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeMenuMutations("edit_menu / delete_menu RPC", () => {
+describeIfSupabase("edit_menu / delete_menu RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
   let ingredientId: string;

--- a/tests/integration/menu-edit-delete.test.ts
+++ b/tests/integration/menu-edit-delete.test.ts
@@ -1,11 +1,6 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
-import {
-  cleanupTestUser,
-  createTestUser,
-  describeIfSupabase,
-  signInAs,
-  type TestUser,
-} from "../helpers/test-supabase";
+import { cleanupTestUser, createTestUser, signInAs, type TestUser } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { cloneMenuTemplate, deleteMenu, editMenu, saveMenu } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/menu-template.test.ts
+++ b/tests/integration/menu-template.test.ts
@@ -1,11 +1,6 @@
 import { afterAll, beforeAll, expect, it } from "vitest";
-import {
-  cleanupTestUser,
-  createTestUser,
-  describeIfSupabase,
-  signInAs,
-  type TestUser,
-} from "../helpers/test-supabase";
+import { cleanupTestUser, createTestUser, signInAs, type TestUser } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { cloneMenuTemplate } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/menu-template.test.ts
+++ b/tests/integration/menu-template.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  hasSupabaseTestEnv,
+  describeIfSupabase,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -15,9 +15,7 @@ import type { Database } from "@/lib/supabase/types";
  * 사용자 가게에 복제. 같은 RPC를 두 번 호출해도 충돌 없이 idempotent.
  */
 
-const describeTpl = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeTpl("clone_menu_template RPC", () => {
+describeIfSupabase("clone_menu_template RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
 

--- a/tests/integration/placeholder.test.ts
+++ b/tests/integration/placeholder.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("integration suite placeholder", () => {
-  it("is mounted and discoverable", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/tests/integration/purchase-flow.test.ts
+++ b/tests/integration/purchase-flow.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
+  describeIfSupabase,
   getServiceRoleClient,
-  hasSupabaseTestEnv,
+  isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -20,9 +21,7 @@ import type { Database } from "@/lib/supabase/types";
  * - 메뉴 마진 자동 재계산 (재료 단가 변경 → 메뉴 원가 재계산은 클라이언트 측, 통합 검증 X)
  */
 
-const describePurchase = hasSupabaseTestEnv ? describe : describe.skip;
-
-describePurchase("save_purchase RPC + 가중 이동 평균법", () => {
+describeIfSupabase("save_purchase RPC + 가중 이동 평균법", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
   let vendorId: string;
@@ -53,7 +52,7 @@ describePurchase("save_purchase RPC + 가중 이동 평균법", () => {
     if (user?.id) await cleanupTestUser(user.id);
   }, 30_000);
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = isoDate();
 
   it("첫 매입 (stock=0): new_avg = amount/quantity, alerts 없음", async () => {
     // 1000g @ 50,000원 → unit_price = 50원/g
@@ -100,7 +99,7 @@ describePurchase("save_purchase RPC + 가중 이동 평균법", () => {
   });
 
   it("|change| < 5%이면 alerts에 안 들어감", async () => {
-    const dayBefore = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+    const dayBefore = isoDate(-2);
     // 2000g @ avg 60 → +100g @ unit_price 62 = (2000×60 + 100×62) / 2100 ≈ 60.0952
     // change = (60.0952 - 60) / 60 × 100 ≈ 0.16%
     const { data, error } = await savePurchase(client, {

--- a/tests/integration/purchase-flow.test.ts
+++ b/tests/integration/purchase-flow.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  describeIfSupabase,
   getServiceRoleClient,
   isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { savePurchase } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/rls.test.ts
+++ b/tests/integration/rls.test.ts
@@ -2,8 +2,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
+  describeIfSupabase,
   getServiceRoleClient,
-  hasSupabaseTestEnv,
+  isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -20,9 +21,7 @@ import type { Database } from "@/lib/supabase/types";
  * Supabase 환경 변수가 없으면 skip (CI에서는 secret이 설정된 환경에서만 실행).
  */
 
-const describeRls = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeRls("RLS user_id isolation", () => {
+describeIfSupabase("RLS user_id isolation", () => {
   let userA: TestUser;
   let userB: TestUser;
   let clientA: SupabaseClient<Database>;
@@ -81,7 +80,7 @@ describeRls("RLS user_id isolation", () => {
       .from("sales")
       .insert({
         user_id: userB.id,
-        sold_at: new Date().toISOString().slice(0, 10),
+        sold_at: isoDate(),
         total_revenue: 5000,
         total_cost_snapshot: 1000,
       })
@@ -107,7 +106,7 @@ describeRls("RLS user_id isolation", () => {
       .insert({
         user_id: userB.id,
         vendor_id: vendorByB.id,
-        purchased_at: new Date().toISOString().slice(0, 10),
+        purchased_at: isoDate(),
         total_amount: 50000,
       })
       .select("id")
@@ -119,7 +118,7 @@ describeRls("RLS user_id isolation", () => {
 
     const stockCount = await admin
       .from("daily_stock_counts")
-      .insert({ user_id: userB.id, counted_at: new Date().toISOString().slice(0, 10) })
+      .insert({ user_id: userB.id, counted_at: isoDate() })
       .select("id")
       .single();
     if (stockCount.error || !stockCount.data) {

--- a/tests/integration/rls.test.ts
+++ b/tests/integration/rls.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  describeIfSupabase,
   getServiceRoleClient,
   isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";
 

--- a/tests/integration/sale-edit.test.ts
+++ b/tests/integration/sale-edit.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
+  describeIfSupabase,
   getServiceRoleClient,
-  hasSupabaseTestEnv,
+  isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -18,15 +19,13 @@ import type { Database } from "@/lib/supabase/types";
  * - sale_edit_history 기록 (FR-031)
  */
 
-const describeSaleEdit = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeSaleEdit("edit_sale + delete_sale RPC", () => {
+describeIfSupabase("edit_sale + delete_sale RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
   let menuId: string;
   let ingredientId: string;
   let saleId: string;
-  const today = new Date().toISOString().slice(0, 10);
+  const today = isoDate();
 
   beforeAll(async () => {
     user = await createTestUser({ storeType: "cafe" });

--- a/tests/integration/sale-edit.test.ts
+++ b/tests/integration/sale-edit.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  describeIfSupabase,
   getServiceRoleClient,
   isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { cloneMenuTemplate, deleteSale, editSale, saveSale } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/sale-save.test.ts
+++ b/tests/integration/sale-save.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
+  describeIfSupabase,
   getServiceRoleClient,
-  hasSupabaseTestEnv,
+  isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -19,14 +20,12 @@ import type { Database } from "@/lib/supabase/types";
  * - 같은 날 두 번 저장은 duplicate_sale 거부
  */
 
-const describeSaleSave = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeSaleSave("save_sale RPC", () => {
+describeIfSupabase("save_sale RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
   let menuId: string;
   let ingredientId: string;
-  const today = new Date().toISOString().slice(0, 10);
+  const today = isoDate();
 
   beforeAll(async () => {
     user = await createTestUser({ storeType: "cafe" });

--- a/tests/integration/sale-save.test.ts
+++ b/tests/integration/sale-save.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  describeIfSupabase,
   getServiceRoleClient,
   isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { cloneMenuTemplate, saveSale } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/integration/stock-count.test.ts
+++ b/tests/integration/stock-count.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
+  describeIfSupabase,
   getServiceRoleClient,
-  hasSupabaseTestEnv,
+  isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
@@ -18,9 +19,7 @@ import type { Database } from "@/lib/supabase/types";
  * - ingredient_price_history reason='stock_count_correction', new_avg = previous_avg
  */
 
-const describeStock = hasSupabaseTestEnv ? describe : describe.skip;
-
-describeStock("apply_stock_count RPC", () => {
+describeIfSupabase("apply_stock_count RPC", () => {
   let user: TestUser;
   let client: SupabaseClient<Database>;
   let beanId: string;
@@ -48,7 +47,7 @@ describeStock("apply_stock_count RPC", () => {
     if (user?.id) await cleanupTestUser(user.id);
   }, 30_000);
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = isoDate();
 
   it("실재고 950g 보고 → current_stock=950, current_avg_price 50원 그대로 (FR-016)", async () => {
     const { data, error } = await applyStockCount(client, {
@@ -108,7 +107,7 @@ describeStock("apply_stock_count RPC", () => {
   });
 
   it("음수 actual_stock 거부", async () => {
-    const dayBefore = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+    const dayBefore = isoDate(-2);
     const { error } = await applyStockCount(client, {
       countedAt: dayBefore,
       items: [{ ingredientId: beanId, actualStock: -10 }],

--- a/tests/integration/stock-count.test.ts
+++ b/tests/integration/stock-count.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   cleanupTestUser,
   createTestUser,
-  describeIfSupabase,
   getServiceRoleClient,
   isoDate,
   signInAs,
   type TestUser,
 } from "../helpers/test-supabase";
+import { describeIfSupabase } from "../helpers/integration-describe";
 import { applyStockCount } from "@/lib/supabase/rpc";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/supabase/types";

--- a/tests/unit/smoke.test.ts
+++ b/tests/unit/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("smoke", () => {
-  it("runs vitest", () => {
-    expect(1 + 1).toBe(2);
-  });
-});


### PR DESCRIPTION
## Summary

전체 코드베이스 simplify refactor **마지막 슬라이스** 9 — tests (2765 LOC, 25 파일). simplify 리뷰 결과 중 동작 변경 없는 정리. 큰 변경 (`seedCafeWithBean` fixture / 모든 `Number()` 캐스트 일괄 정리 / `mustInsert` helper)은 별도 PR.

### 변경

**🧹 헬퍼 통합 (3건)**

| # | 헬퍼 | 용도 |
|---|---|---|
| 1 | `describeIfSupabase` | `hasSupabaseTestEnv ? describe : describe.skip` 패턴 — 9개 통합 테스트가 각자 다른 alias (`describeRls`/`describeCalendar`/...)로 정의 → 단일 출처 |
| 2 | `isoDate(offsetDays)` | UTC 기준 ISO date — 7곳 이상에서 inline `new Date().toISOString().slice(0,10)` + `Date.now() - N*86_400_000` 변형이 반복. local `setDate` 변형의 DST 경계 ±1일 위험 동시 차단 |
| 3 | `backdateSignup(userId, isoDate)` | `calendar-month.test`의 정당화 주석 + inline `admin.from("users").update(...)` → 단일 호출 |

**🗑️ Dead test 제거**
- `tests/integration/placeholder.test.ts` (`expect(true).toBe(true)` 1줄)
- `tests/unit/smoke.test.ts` (`expect(2).toBe(2)` 1줄)

둘 다 suite-discovery 잔재. 158개 → 156개 (실 테스트 변동 0).

### 별도 PR 예정

- `seedCafeWithBean(client, opts)` fixture — 5개 통합 테스트의 "cafe 템플릿 + 원두 ingredient + admin update stock/avg_price" boilerplate ~75 LOC 중복 제거
- `mustInsert<T>(qb, label)` helper — `rls.test.ts`의 8개 fixture insert + throw 블록 80+ LOC 정리
- `Number(row?.x)` 캐스트 패턴 (5개 파일에서 24+ 발생) — `numeric()` helper 또는 generated narrower types
- `tests/unit/biz-lib.test.ts:21`의 `as MenuRowWithRecipe[...]` 타입 단언

### 검증

- typecheck ✅ / lint ✅ / format:check ✅
- vitest **156/156** ✅ (placeholder + smoke -2)
- build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)