### PR TITLE
fix(domain): NaN 가드 + 음수 입력 short-circuit 우회 차단

### DIFF
--- a/src/lib/domain/_assert.ts
+++ b/src/lib/domain/_assert.ts
@@ -6,6 +6,11 @@
  */
 
 export function assertNonNegative(value: number, label: string): void {
+  // `NaN < 0` is false → without an explicit guard, NaN slips through and
+  // contaminates Decimal arithmetic downstream.
+  if (Number.isNaN(value)) {
+    throw new Error(`${label} must be a number (got NaN)`);
+  }
   if (value < 0) {
     throw new Error(`${label} must be non-negative (got ${value})`);
   }

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -8,7 +8,8 @@ import { isRegularDayOff, weekdayOf, type Weekday } from "./regular-days-off";
  * 출력: 예상 소진일 + status + trend + 콜드스타트 여부.
  *
  * 핵심 로직:
- *  1. 콜드스타트 (가입 ≤ 7일) → 모든 항목 isColdStart=true, 예측 안 함
+ *  1. 콜드스타트 (가입 < 7일) → 모든 항목 isColdStart=true, 예측 안 함
+ *     (정확히 7일 경계는 cold가 아님 — `tests/unit/forecast.test.ts` 참고)
  *  2. 요일별 가중 평균 산정 (정기휴무 제외)
  *  3. 오늘부터 일별 시뮬레이션 (정기휴무는 소비 0)
  *  4. 리드타임 + 안전여유 1일 차감해 status 분류

--- a/src/lib/domain/margin.ts
+++ b/src/lib/domain/margin.ts
@@ -43,6 +43,7 @@ export function calculateMargin({ price, cost }: MarginInput): MarginResult {
   const priceDecimal = price instanceof Decimal ? price : new Decimal(price);
   const costDecimal = cost instanceof Decimal ? cost : new Decimal(cost);
   assertNonNegative(priceDecimal.toNumber(), "menu price");
+  assertNonNegative(costDecimal.toNumber(), "menu cost");
 
   if (priceDecimal.isZero()) {
     return { amount: costDecimal.negated(), rate: new Decimal(0), label: MARGIN_LABEL };

--- a/src/lib/domain/pricing.ts
+++ b/src/lib/domain/pricing.ts
@@ -26,6 +26,8 @@ export function computeNewWeightedAverage({
   newQuantity,
   newUnitPrice,
 }: WeightedAverageInput): Decimal {
+  assertNonNegative(currentStock, "currentStock");
+  assertNonNegative(currentAvg, "currentAvg");
   assertNonNegative(newQuantity, "newQuantity");
   assertNonNegative(newUnitPrice, "newUnitPrice");
 

--- a/tests/unit/margin.test.ts
+++ b/tests/unit/margin.test.ts
@@ -104,4 +104,14 @@ describe("calculateMargin", () => {
   it("음수 가격은 거부", () => {
     expect(() => calculateMargin({ price: -100, cost: new Decimal(50) })).toThrow();
   });
+
+  it("음수 원가는 거부 (price=0이어도 short-circuit으로 우회되지 않음)", () => {
+    expect(() => calculateMargin({ price: 0, cost: new Decimal(-1) })).toThrow();
+    expect(() => calculateMargin({ price: 5000, cost: new Decimal(-1) })).toThrow();
+  });
+
+  it("NaN 입력은 거부", () => {
+    expect(() => calculateMargin({ price: Number.NaN, cost: new Decimal(0) })).toThrow(/NaN/);
+    expect(() => calculateMargin({ price: 5000, cost: Number.NaN })).toThrow(/NaN/);
+  });
 });

--- a/tests/unit/pricing.test.ts
+++ b/tests/unit/pricing.test.ts
@@ -142,5 +142,38 @@ describe("computeNewWeightedAverage", () => {
         }),
       ).toThrow();
     });
+
+    it("음수 currentStock 거부 (newQuantity=0 short-circuit으로 우회되지 않음)", () => {
+      expect(() =>
+        computeNewWeightedAverage({
+          currentStock: -1,
+          currentAvg: 50,
+          newQuantity: 0,
+          newUnitPrice: 0,
+        }),
+      ).toThrow();
+    });
+
+    it("음수 currentAvg 거부", () => {
+      expect(() =>
+        computeNewWeightedAverage({
+          currentStock: 1000,
+          currentAvg: -50,
+          newQuantity: 100,
+          newUnitPrice: 70,
+        }),
+      ).toThrow();
+    });
+
+    it("NaN은 거부 (Number(undefined) 등 silent 오염 방지)", () => {
+      expect(() =>
+        computeNewWeightedAverage({
+          currentStock: 1000,
+          currentAvg: 50,
+          newQuantity: Number.NaN,
+          newUnitPrice: 70,
+        }),
+      ).toThrow(/NaN/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

도메인 입력 검증의 silent fail 3건 수정.

- **`assertNonNegative` NaN 가드** — `NaN < 0`이 `false`라 NaN이 통과 → Decimal 곱셈에서 결과 전체 오염. 명시적 NaN 거부.
- **`calculateMargin` price=0 cost 미검증** — price=0 early return이 cost 검증 전에 발동 → 음수 cost가 `negated()`로 양수 마진처럼 표시. price 검증 직후 cost도 검증.
- **`computeNewWeightedAverage` newQuantity=0 비대칭** — newQuantity=0 short-circuit이 currentStock·currentAvg 검증을 우회 → 음수 currentAvg가 그대로 새 평균으로 둔갑. 4개 입력 모두 검증.

부수: `forecast.ts` 헤더 주석의 콜드스타트 경계 표기를 코드/테스트와 일치 (`≤` → `<`).

## Test plan

- [x] `tests/unit/margin.test.ts` — 음수 cost / NaN 입력 거부 케이스 추가
- [x] `tests/unit/pricing.test.ts` — 음수 stock·avg / NaN 거부 케이스 추가 (newQuantity=0 short-circuit 우회 차단 검증)
- [x] `npm run test:unit` 102 passed
- [x] typecheck / lint / format:check / build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)