### PR TITLE
fix(forecast+today): weekday-missing fallback + 로컬 tz 기반 today

### DIFF
--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -77,6 +77,9 @@ export function computeWeekdayUsageAverage(
 /**
  * 오늘부터 하루씩 시뮬레이션. 정기휴무는 소비 0.
  * 1년 내 소진 안 하면 null (충분히 여유).
+ *
+ * 데이터 없는 요일은 영업일 평균으로 대체. 그렇지 않으면 가입 직후·드문 영업
+ * 요일에 over-forecast (실제보다 오래 버틴다고 잘못 안내) 위험.
  */
 export function predictDepletionDate({
   currentStock,
@@ -90,18 +93,26 @@ export function predictDepletionDate({
   daysOff: readonly Weekday[];
 }): Date | null {
   let stock = new Decimal(currentStock);
+  const fallback = overallWeekdayAverage(weekdayAvg);
 
   for (let offset = 1; offset <= MAX_FORECAST_DAYS; offset++) {
     const day = new Date(today.getTime() + offset * ONE_DAY_MS);
     if (isRegularDayOff(day, daysOff)) continue;
 
-    const usage = weekdayAvg.get(weekdayOf(day)) ?? new Decimal(0);
-    if (usage.isZero()) continue; // 데이터 없는 요일 → 소비 미정, 패스
+    const usage = weekdayAvg.get(weekdayOf(day)) ?? fallback;
+    if (usage.isZero()) continue; // 전체 데이터가 0 → 소비 미정, 패스
 
     stock = stock.minus(usage);
     if (stock.isNegative() || stock.isZero()) return day;
   }
   return null;
+}
+
+function overallWeekdayAverage(weekdayAvg: ReadonlyMap<Weekday, Decimal>): Decimal {
+  if (weekdayAvg.size === 0) return new Decimal(0);
+  let sum = new Decimal(0);
+  for (const v of weekdayAvg.values()) sum = sum.plus(v);
+  return sum.dividedBy(weekdayAvg.size);
 }
 
 /**

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -16,6 +16,18 @@ export function formatNumber(value: number): string {
 export const WEEKDAY_KO = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
 /**
+ * 로컬 타임존 기준 "YYYY-MM-DD". KST 자정~UTC 09:00 사이에는 `toISOString()`이
+ * 어제 날짜를 반환하므로 캘린더 today highlight·sale soldAt 비교가 어긋남 —
+ * `parseLocalDateFromIso`와 짝을 이루는 로컬 기반 포맷터로 통일.
+ */
+export function localIsoDate(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
  * "YYYY-MM-DD" 문자열을 로컬 시간 0시 Date로 변환. 호스트 tz 무관하게 캘린더 일자
  * 단위 비교에 사용 — Date 생성자에 ISO 문자열 + Z 패스를 그대로 넘기면 호스트 tz에
  * 따라 ±1일 오차가 생길 수 있음.

--- a/src/lib/utils/use-today-iso.ts
+++ b/src/lib/utils/use-today-iso.ts
@@ -1,16 +1,20 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { localIsoDate } from "./format";
 
 /**
  * 오늘 날짜 (YYYY-MM-DD)를 클라이언트 mount 후 한 번만 채움.
  * SSR과 CSR이 자정 경계를 사이에 두면 서로 다른 날짜를 렌더해 hydration mismatch.
  * 마운트 전에는 null — 호출 측이 null을 가드해야 함.
+ *
+ * 로컬 tz 기반 — 캘린더 cell key가 로컬 ISO 문자열이라 KST 자정~UTC 09:00 동안에는
+ * `toISOString()`(UTC)이 한 칸 앞 날짜를 보고해 today highlight가 빗나감.
  */
 export function useTodayIso(): string | null {
   const [iso, setIso] = useState<string | null>(null);
   useEffect(() => {
-    setIso(new Date().toISOString().slice(0, 10));
+    setIso(localIsoDate());
   }, []);
   return iso;
 }

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -121,6 +121,35 @@ describe("predictDepletionDate", () => {
     });
     expect(result).toBeNull();
   });
+
+  it("데이터 없는 요일은 영업일 평균으로 대체 — over-forecast 방지", () => {
+    // 월·화만 데이터 (둘 다 10g/일). 영업일 평균 = 10g.
+    // fallback 없이는: 월·화만 소진 → 100/(10×2/7일) ≈ 35일 (실제보다 오래 버틴다고 잘못 안내).
+    // fallback 적용: 매일 10g → 10일 뒤 소진.
+    const weekdayAvg = new Map([
+      ["MON", new Decimal(10)],
+      ["TUE", new Decimal(10)],
+    ] as const);
+    const withFallback = predictDepletionDate({
+      currentStock: 100,
+      weekdayAvg,
+      today,
+      daysOff: [],
+    });
+    expect(withFallback).not.toBeNull();
+    const daysUntilDepletion = Math.round((withFallback!.getTime() - today.getTime()) / ONE_DAY);
+    expect(daysUntilDepletion).toBeLessThanOrEqual(11);
+  });
+
+  it("weekdayAvg 비어있으면 소진 예측 불가 (null)", () => {
+    const result = predictDepletionDate({
+      currentStock: 100,
+      weekdayAvg: new Map(),
+      today,
+      daysOff: [],
+    });
+    expect(result).toBeNull();
+  });
 });
 
 describe("classifyStatus (FR-013)", () => {

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatNumber,
   formatTodayKo,
   formatWon,
+  localIsoDate,
   parseLocalDateFromIso,
   weekdayKoFromIso,
 } from "@/lib/utils/format";
@@ -21,6 +22,18 @@ describe("formatNumber", () => {
   it("천 단위 콤마, 소수점 보존", () => {
     expect(formatNumber(1234)).toBe("1,234");
     expect(formatNumber(12.5)).toBe("12.5");
+  });
+});
+
+describe("localIsoDate", () => {
+  it("로컬 tz 기준 YYYY-MM-DD (toISOString UTC와 다를 수 있음)", () => {
+    const date = new Date(2026, 4, 1, 23, 30); // 로컬 2026-05-01 23:30
+    expect(localIsoDate(date)).toBe("2026-05-01");
+  });
+
+  it("월/일 zero-pad", () => {
+    const date = new Date(2026, 0, 5);
+    expect(localIsoDate(date)).toBe("2026-01-05");
   });
 });
 


### PR DESCRIPTION
## Summary

캘린더/예측 자정 경계 + 가입 직후 over-forecast 2건 수정.

- **`predictDepletionDate` weekday-missing fallback** — 데이터 없는 요일을 silent skip 하면, 월·화만 영업한 가입 초반에 100g/(20g·주2회) ≈ 35일이라며 안전 안내. 영업일 평균(=10g/일)을 fallback으로 두어 10일 뒤 소진 경고가 정확히 뜨도록.
- **`useTodayIso` 로컬 tz 통일** — `toISOString().slice(0,10)`은 UTC 기준이라 KST 자정~UTC 09:00 사이엔 어제 날짜 반환 → 캘린더 today highlight가 어제 칸에 맞춰지고 cell.date 비교가 1칸 어긋남. `localIsoDate()` 헬퍼로 로컬 tz 기반 YYYY-MM-DD 통일.

## Test plan

- [x] `forecast.test.ts` — 월·화만 데이터 → 영업일 평균 적용 / 빈 weekdayAvg → null
- [x] `format.test.ts` — `localIsoDate` zero-pad / 로컬 tz 23:30 케이스
- [x] 기존 forecast/format 케이스 전부 회귀 없음
- [x] typecheck / lint / format:check / build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)