### PR TITLE
refactor(menu+inventory): useCreateMenu hook + IngredientFormFields 공통화

### DIFF
--- a/src/features/inventory/components/AddIngredientForm.tsx
+++ b/src/features/inventory/components/AddIngredientForm.tsx
@@ -2,14 +2,10 @@
 
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Field } from "@/components/ui/field";
 import { PrimaryButton } from "@/components/ui/primary-button";
-import {
-  INGREDIENT_UNIT_LABELS,
-  ingredientInputSchema,
-  type IngredientInput,
-} from "@/features/purchase/schemas";
+import { ingredientInputSchema, type IngredientInput } from "@/features/purchase/schemas";
 import { useCreateIngredient } from "@/features/purchase/hooks/useIngredients";
+import { IngredientFormFields } from "./IngredientFormFields";
 
 interface AddIngredientFormProps {
   onClose: () => void;
@@ -60,33 +56,13 @@ export function AddIngredientForm({ onClose }: AddIngredientFormProps): React.Re
         </button>
       </header>
 
-      <Field label="재료 이름" error={errors.name?.message}>
-        <input
-          {...register("name")}
-          type="text"
-          placeholder="예: 우유, 시럽, 컵"
-          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
-        />
-      </Field>
-
-      <Field label="단위 (등록 후 변경 불가)" error={errors.unit?.message}>
-        <select
-          {...register("unit")}
-          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
-        >
-          {Object.entries(INGREDIENT_UNIT_LABELS).map(([unit, label]) => (
-            <option key={unit} value={unit}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </Field>
-
-      {createMutation.error && (
-        <p role="alert" className="text-body-regular text-red">
-          {createMutation.error.message}
-        </p>
-      )}
+      <IngredientFormFields
+        register={register}
+        errors={errors}
+        unitLabel="단위 (등록 후 변경 불가)"
+        namePlaceholder="예: 우유, 시럽, 컵"
+        errorMessage={createMutation.error?.message}
+      />
 
       <PrimaryButton type="submit" disabled={submitting}>
         {submitting ? "등록 중…" : "등록"}

--- a/src/features/inventory/components/IngredientFormFields.tsx
+++ b/src/features/inventory/components/IngredientFormFields.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { FieldErrors, UseFormRegister } from "react-hook-form";
+import { Field } from "@/components/ui/field";
+import { INGREDIENT_UNIT_LABELS, type IngredientInput } from "@/features/purchase/schemas";
+
+interface IngredientFormFieldsProps {
+  register: UseFormRegister<IngredientInput>;
+  errors: FieldErrors<IngredientInput>;
+  unitLabel?: string;
+  namePlaceholder?: string;
+  autoFocusName?: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * 재료 등록 폼의 본문 필드 — AddIngredientForm(<form>)과
+ * IngredientQuickCreate(<div>, 중첩 form 회피) 두 컨테이너에서 공유.
+ */
+export function IngredientFormFields({
+  register,
+  errors,
+  unitLabel = "단위",
+  namePlaceholder,
+  autoFocusName = false,
+  errorMessage,
+}: IngredientFormFieldsProps): React.ReactElement {
+  return (
+    <>
+      <Field label="재료 이름" error={errors.name?.message}>
+        <input
+          {...register("name")}
+          type="text"
+          placeholder={namePlaceholder}
+          autoFocus={autoFocusName}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        />
+      </Field>
+
+      <Field label={unitLabel} error={errors.unit?.message}>
+        <select
+          {...register("unit")}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        >
+          {Object.entries(INGREDIENT_UNIT_LABELS).map(([unit, label]) => (
+            <option key={unit} value={unit}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      {errorMessage && (
+        <p role="alert" className="text-body-regular text-red">
+          {errorMessage}
+        </p>
+      )}
+    </>
+  );
+}

--- a/src/features/menu/components/MenuForm.tsx
+++ b/src/features/menu/components/MenuForm.tsx
@@ -4,15 +4,11 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQueryClient } from "@tanstack/react-query";
-import { createClient } from "@/lib/supabase/client";
-import { saveMenu } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { Field } from "@/components/ui/field";
 import { PrimaryButton } from "@/components/ui/primary-button";
 import { menuSchema, type MenuInput } from "../schemas";
-import { menuListQueryKey } from "../hooks/useMenus";
-import { useEditMenu } from "../hooks/useMenuMutations";
+import { useCreateMenu, useEditMenu } from "../hooks/useMenuMutations";
 
 interface IngredientOption {
   id: string;
@@ -31,8 +27,8 @@ interface MenuFormProps {
 
 export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactElement {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const createMutation = useCreateMenu();
   const editMutation = useEditMenu();
 
   const {
@@ -61,22 +57,17 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
       return;
     }
 
-    const supabase = createClient();
-    const { error } = await saveMenu(supabase, {
-      name: values.name,
-      price: values.price,
-      recipe: values.recipe,
-    });
-    if (error) {
-      setSubmitError(error.message);
+    try {
+      await createMutation.mutateAsync(values);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "저장 실패");
       return;
     }
     if (mode.isFirstMenu) trackEvent("first_menu_registered", {});
-    void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
     router.push("/menu");
   }
 
-  const submitting = isSubmitting || editMutation.isPending;
+  const submitting = isSubmitting || editMutation.isPending || createMutation.isPending;
   const submitLabel = mode.kind === "edit" ? "수정 저장" : "저장";
 
   return (

--- a/src/features/menu/hooks/useMenuMutations.ts
+++ b/src/features/menu/hooks/useMenuMutations.ts
@@ -2,13 +2,30 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { deleteMenu, editMenu } from "@/lib/supabase/rpc";
+import { deleteMenu, editMenu, saveMenu } from "@/lib/supabase/rpc";
 import type { MenuInput } from "../schemas";
-import { invalidateMenuCaches } from "./useMenus";
+import { invalidateMenuCaches, menuListQueryKey } from "./useMenus";
 
 interface EditMenuVariables {
   menuId: string;
   values: MenuInput;
+}
+
+// 신규 메뉴는 sale·consumption이 없으므로 forecast 캐시는 그대로 — menuList만 invalidate.
+// 편집/삭제는 recipe 구성이 바뀌어 forecast 영향 → invalidateMenuCaches로 함께 처리.
+export function useCreateMenu(): UseMutationResult<string, Error, MenuInput> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (values) => {
+      const supabase = createClient();
+      const { data, error } = await saveMenu(supabase, values);
+      if (error) throw new Error(error.message);
+      const row = data?.[0];
+      if (!row) throw new Error("save_menu returned empty");
+      return row.menu_id;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: menuListQueryKey }),
+  });
 }
 
 export function useEditMenu(): UseMutationResult<string, Error, EditMenuVariables> {

--- a/src/features/purchase/components/IngredientQuickCreate.tsx
+++ b/src/features/purchase/components/IngredientQuickCreate.tsx
@@ -2,9 +2,9 @@
 
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Field } from "@/components/ui/field";
 import { PrimaryButton } from "@/components/ui/primary-button";
-import { INGREDIENT_UNIT_LABELS, ingredientInputSchema, type IngredientInput } from "../schemas";
+import { IngredientFormFields } from "@/features/inventory/components/IngredientFormFields";
+import { ingredientInputSchema, type IngredientInput } from "../schemas";
 import { useCreateIngredient, type IngredientRow } from "../hooks/useIngredients";
 
 interface IngredientQuickCreateProps {
@@ -37,33 +37,12 @@ export function IngredientQuickCreate({
     <div className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
       <h3 className="text-title-md text-ink-1">새 재료 추가</h3>
 
-      <Field label="재료 이름" error={errors.name?.message}>
-        <input
-          {...register("name")}
-          type="text"
-          autoFocus
-          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
-        />
-      </Field>
-
-      <Field label="단위" error={errors.unit?.message}>
-        <select
-          {...register("unit")}
-          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
-        >
-          {Object.entries(INGREDIENT_UNIT_LABELS).map(([unit, label]) => (
-            <option key={unit} value={unit}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </Field>
-
-      {mutation.error && (
-        <p role="alert" className="text-caption text-red">
-          {mutation.error.message}
-        </p>
-      )}
+      <IngredientFormFields
+        register={register}
+        errors={errors}
+        autoFocusName
+        errorMessage={mutation.error?.message}
+      />
 
       <div className="flex gap-stack">
         <button


### PR DESCRIPTION
## Summary

폼 두 곳의 동일 본문/뮤테이션을 단일 출처로.

- **\`useCreateMenu\` hook 추가** — MenuForm onSubmit이 createClient/saveMenu/queryClient를 직접 다루던 부분을 useEditMenu와 대칭으로 hook 추출. **invalidation 정책 차이 명시**: 신규 메뉴는 sale·consumption이 없으므로 forecast 캐시 그대로 — menuList만 invalidate.
- **\`IngredientFormFields\` 공통 컴포넌트** — AddIngredientForm(\`<form>\`)과 IngredientQuickCreate(\`<div>\`, 중첩 form 회피) 두 곳에서 25줄씩 반복되던 name+unit Field 마크업을 단일 컴포넌트로. unitLabel / namePlaceholder / autoFocusName / errorMessage prop으로 컨테이너별 차이 흡수.

동작 변경 없음 — 외부 caller signature 동일.

## Test plan

- [x] typecheck / lint / format:check / build green
- [x] \`npm run test:unit\` 106 passed
- [x] MenuForm: 신규/수정 양쪽 흐름 동일하게 hook 경유
- [x] IngredientForm 두 컨테이너의 prop 차이 모두 보존 (unit 라벨, autoFocus, namePlaceholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)