### PR TITLE
refactor(ui): Metric / PageHeader / SECONDARY_BUTTON_CLASSES 원자 추출

### DIFF
--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -6,6 +6,9 @@ import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionFor
 import { IngredientStatusList } from "@/features/inventory/components/IngredientStatusList";
 import { ColdStartNotice } from "@/features/inventory/components/ColdStartNotice";
 import { AddIngredientForm } from "@/features/inventory/components/AddIngredientForm";
+import { PageHeader } from "@/components/ui/page-header";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
 export default function InventoryPage(): React.ReactElement {
   const { data, isLoading, error } = useDepletionForecast();
@@ -15,41 +18,32 @@ export default function InventoryPage(): React.ReactElement {
 
   return (
     <section className="flex flex-col gap-section">
-      <header className="flex items-center justify-between gap-stack-tight">
-        <h1 className="text-title-lg text-ink-1">재료</h1>
-        <div className="flex gap-stack-tight">
-          <Link
-            href="/inventory/stock-count"
-            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
-          >
-            실사
-          </Link>
-          <Link
-            href="/purchase"
-            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
-          >
-            + 매입
-          </Link>
-          <button
-            type="button"
-            onClick={() => setIsAddOpen((v) => !v)}
-            aria-expanded={isAddOpen}
-            className="rounded-md bg-ink-1 px-stack py-stack-tight text-body-regular text-bg hover:opacity-90"
-          >
-            + 재료
-          </button>
-        </div>
-      </header>
+      <PageHeader
+        title="재료"
+        action={
+          <div className="flex gap-stack-tight">
+            <Link href="/inventory/stock-count" className={SECONDARY_BUTTON_CLASSES}>
+              실사
+            </Link>
+            <Link href="/purchase" className={SECONDARY_BUTTON_CLASSES}>
+              + 매입
+            </Link>
+            <button
+              type="button"
+              onClick={() => setIsAddOpen((v) => !v)}
+              aria-expanded={isAddOpen}
+              className="rounded-md bg-ink-1 px-stack py-stack-tight text-body-regular text-bg hover:opacity-90"
+            >
+              + 재료
+            </button>
+          </div>
+        }
+      />
 
       {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
 
-      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
-
-      {error && (
-        <p role="alert" className="text-body-regular text-red">
-          {error.message}
-        </p>
-      )}
+      {isLoading && <LoadingText />}
+      {error && <ErrorAlert message={error.message} />}
 
       {isAllColdStart && <ColdStartNotice />}
 

--- a/src/app/(main)/inventory/stock-count/page.tsx
+++ b/src/app/(main)/inventory/stock-count/page.tsx
@@ -2,16 +2,19 @@
 
 import Link from "next/link";
 import { StockCountForm } from "@/features/inventory/components/StockCountForm";
+import { PageHeader } from "@/components/ui/page-header";
 
 export default function StockCountPage(): React.ReactElement {
   return (
     <section className="flex flex-col gap-section">
-      <header className="flex items-center justify-between">
-        <h1 className="text-title-lg text-ink-1">재고 실사</h1>
-        <Link href="/inventory" className="text-body-regular text-ink-3 hover:text-ink-2">
-          취소
-        </Link>
-      </header>
+      <PageHeader
+        title="재고 실사"
+        action={
+          <Link href="/inventory" className="text-body-regular text-ink-3 hover:text-ink-2">
+            취소
+          </Link>
+        }
+      />
       <StockCountForm />
     </section>
   );

--- a/src/app/(main)/menu/[id]/edit/page.tsx
+++ b/src/app/(main)/menu/[id]/edit/page.tsx
@@ -5,6 +5,8 @@ import { useParams } from "next/navigation";
 import { MenuForm } from "@/features/menu/components/MenuForm";
 import { useMenus } from "@/features/menu/hooks/useMenus";
 import { useActiveIngredients } from "@/features/menu/hooks/useActiveIngredients";
+import { PageHeader } from "@/components/ui/page-header";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 import type { MenuInput } from "@/features/menu/schemas";
 
 export default function MenuEditPage(): React.ReactElement {
@@ -21,26 +23,20 @@ export default function MenuEditPage(): React.ReactElement {
 
   return (
     <section className="flex flex-col gap-section">
-      <header className="flex items-center justify-between">
-        <h1 className="text-title-lg text-ink-1">메뉴 수정</h1>
-        <Link href={`/menu/${id}`} className="text-body-regular text-ink-3 hover:text-ink-2">
-          취소
-        </Link>
-      </header>
+      <PageHeader
+        title="메뉴 수정"
+        action={
+          <Link href={`/menu/${id}`} className="text-body-regular text-ink-3 hover:text-ink-2">
+            취소
+          </Link>
+        }
+      />
 
-      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
-
+      {isLoading && <LoadingText />}
       {ingredientsError && (
-        <p role="alert" className="text-body-regular text-red">
-          재료 목록을 불러오지 못했어요: {ingredientsError.message}
-        </p>
+        <ErrorAlert prefix="재료 목록을 불러오지 못했어요:" message={ingredientsError.message} />
       )}
-
-      {menusError && (
-        <p role="alert" className="text-body-regular text-red">
-          {menusError.message}
-        </p>
-      )}
+      {menusError && <ErrorAlert message={menusError.message} />}
 
       {!isLoading && !ingredientsError && menus && !menu && (
         <p className="text-body-regular text-ink-3">메뉴를 찾을 수 없습니다.</p>

--- a/src/app/(main)/menu/new/page.tsx
+++ b/src/app/(main)/menu/new/page.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { MenuForm } from "@/features/menu/components/MenuForm";
 import { useMenus } from "@/features/menu/hooks/useMenus";
 import { useActiveIngredients } from "@/features/menu/hooks/useActiveIngredients";
+import { PageHeader } from "@/components/ui/page-header";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 
 export default function MenuNewPage(): React.ReactElement {
   const { data: menus, isLoading: menusLoading } = useMenus();
@@ -14,20 +16,17 @@ export default function MenuNewPage(): React.ReactElement {
 
   return (
     <section className="flex flex-col gap-section">
-      <header className="flex items-center justify-between">
-        <h1 className="text-title-lg text-ink-1">메뉴 추가</h1>
-        <Link href="/menu" className="text-body-regular text-ink-3 hover:text-ink-2">
-          취소
-        </Link>
-      </header>
+      <PageHeader
+        title="메뉴 추가"
+        action={
+          <Link href="/menu" className="text-body-regular text-ink-3 hover:text-ink-2">
+            취소
+          </Link>
+        }
+      />
 
-      {isLoading && <p className="text-body-regular text-ink-3">불러오는 중…</p>}
-
-      {error && (
-        <p role="alert" className="text-body-regular text-red">
-          재료 목록을 불러오지 못했어요: {error.message}
-        </p>
-      )}
+      {isLoading && <LoadingText />}
+      {error && <ErrorAlert prefix="재료 목록을 불러오지 못했어요:" message={error.message} />}
 
       {!isLoading && !error && (
         <MenuForm ingredients={ingredients ?? []} mode={{ kind: "create", isFirstMenu }} />

--- a/src/app/(main)/menu/page.tsx
+++ b/src/app/(main)/menu/page.tsx
@@ -5,21 +5,22 @@ import { useMenus } from "@/features/menu/hooks/useMenus";
 import { MenuList } from "@/features/menu/components/MenuList";
 import { TemplateLoadDialog } from "@/features/menu/components/TemplateLoadDialog";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
+import { PageHeader } from "@/components/ui/page-header";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
 export default function MenuPage(): React.ReactElement {
   const { data, isLoading, error } = useMenus();
 
   return (
     <section className="flex flex-col gap-section">
-      <header className="flex items-center justify-between">
-        <h1 className="text-title-lg text-ink-1">메뉴</h1>
-        <Link
-          href="/menu/new"
-          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover"
-        >
-          + 추가
-        </Link>
-      </header>
+      <PageHeader
+        title="메뉴"
+        action={
+          <Link href="/menu/new" className={SECONDARY_BUTTON_CLASSES}>
+            + 추가
+          </Link>
+        }
+      />
 
       {isLoading && <LoadingText />}
       {error && <ErrorAlert prefix="메뉴를 불러오지 못했어요:" message={error.message} />}

--- a/src/app/(main)/sale/[date]/page.tsx
+++ b/src/app/(main)/sale/[date]/page.tsx
@@ -6,6 +6,7 @@ import { SaleInputForm } from "@/features/sale/components/SaleInputForm";
 import { SaleEditDialog } from "@/features/sale/components/SaleEditDialog";
 import { useIsFirstSale } from "@/features/sale/hooks/useIsFirstSale";
 import { useSaleByDate } from "@/features/sale/hooks/useSaleByDate";
+import { LoadingText } from "@/components/ui/query-state";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -35,7 +36,7 @@ export default function RetroactiveSalePage(): React.ReactElement {
       {!isValid ? (
         <p className="text-body-regular text-red">잘못된 날짜 형식입니다.</p>
       ) : isLoading || isFirstSale === undefined ? (
-        <p className="text-body-regular text-ink-3">불러오는 중…</p>
+        <LoadingText />
       ) : existingSale ? (
         <SaleEditDialog sale={existingSale} />
       ) : (

--- a/src/app/(main)/sale/page.tsx
+++ b/src/app/(main)/sale/page.tsx
@@ -2,6 +2,8 @@
 
 import { SaleInputForm } from "@/features/sale/components/SaleInputForm";
 import { useIsFirstSale } from "@/features/sale/hooks/useIsFirstSale";
+import { PageHeader } from "@/components/ui/page-header";
+import { LoadingText } from "@/components/ui/query-state";
 
 export default function SalePage(): React.ReactElement {
   const { data: isFirstSale, isLoading } = useIsFirstSale();
@@ -9,13 +11,13 @@ export default function SalePage(): React.ReactElement {
 
   return (
     <section className="flex flex-col gap-section">
-      <header className="flex items-center justify-between">
-        <h1 className="text-title-lg text-ink-1">오늘 판매 입력</h1>
-        <span className="text-caption text-ink-3 tabular-nums">{today}</span>
-      </header>
+      <PageHeader
+        title="오늘 판매 입력"
+        action={<span className="text-caption text-ink-3 tabular-nums">{today}</span>}
+      />
 
       {isLoading || isFirstSale === undefined ? (
-        <p className="text-body-regular text-ink-3">불러오는 중…</p>
+        <LoadingText />
       ) : (
         <SaleInputForm soldAt={today} isFirstSale={isFirstSale} />
       )}

--- a/src/components/ui/button-classes.ts
+++ b/src/components/ui/button-classes.ts
@@ -1,0 +1,6 @@
+/**
+ * 보조 버튼/링크 공용 클래스 — 헤더 액션, 폼 보조 버튼 등에서 4곳 이상 동일.
+ * Link/button 모두에 적용 가능하도록 className 상수 단일 출처.
+ */
+export const SECONDARY_BUTTON_CLASSES =
+  "rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-2 hover:bg-card-hover";

--- a/src/components/ui/metric.tsx
+++ b/src/components/ui/metric.tsx
@@ -1,0 +1,19 @@
+interface MetricProps {
+  label: string;
+  value: string;
+}
+
+/**
+ * KPI 카드 단위 메트릭 — label + value 2줄.
+ * YesterdayKpi / MonthCumulative / CellDetail 패널에서 4-grid 셀 단위로 사용.
+ *
+ * StickyTotalCard의 Metric은 accent variant + "원" suffix로 변형이 커서 자체 보유.
+ */
+export function Metric({ label, value }: MetricProps): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-micro text-ink-3">{label}</span>
+      <span className="text-metric-md tabular-nums text-ink-1">{value}</span>
+    </div>
+  );
+}

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -1,0 +1,18 @@
+interface PageHeaderProps {
+  title: string;
+  /** 우측 액션 영역 — Link / button / Chip 등 ReactNode 그대로 넘김. */
+  action?: React.ReactNode;
+}
+
+/**
+ * 페이지 상단 헤더 — `<h1 text-title-lg>` + 우측 액션 슬롯.
+ * 6개 페이지에서 동일 markup이 반복되어 단일 출처로.
+ */
+export function PageHeader({ title, action }: PageHeaderProps): React.ReactElement {
+  return (
+    <header className="flex items-center justify-between gap-stack-tight">
+      <h1 className="text-title-lg text-ink-1">{title}</h1>
+      {action}
+    </header>
+  );
+}

--- a/src/features/calendar/components/CellDetailPanel.tsx
+++ b/src/features/calendar/components/CellDetailPanel.tsx
@@ -5,6 +5,7 @@ import { differenceInCalendarDays } from "date-fns";
 import { cn } from "@/lib/utils";
 import { formatDateKoFromIso, formatWon, parseLocalDateFromIso } from "@/lib/utils/format";
 import { MARGIN_LABEL } from "@/lib/domain/margin";
+import { Metric } from "@/components/ui/metric";
 import type { EnrichedCalendarCell } from "../lib/consecutive-missing";
 
 interface CellDetailPanelProps {
@@ -127,20 +128,6 @@ function Notice({ tone, children }: NoticeProps): React.ReactElement {
       )}
     >
       {children}
-    </div>
-  );
-}
-
-interface MetricProps {
-  label: string;
-  value: string;
-}
-
-function Metric({ label, value }: MetricProps): React.ReactElement {
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="text-micro text-ink-3">{label}</span>
-      <span className="text-metric-md tabular-nums text-ink-1">{value}</span>
     </div>
   );
 }

--- a/src/features/calendar/components/MonthCumulativeCard.tsx
+++ b/src/features/calendar/components/MonthCumulativeCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Metric } from "@/components/ui/metric";
 import { formatWon, formatNumber } from "@/lib/utils/format";
 import type { CalendarCumulative } from "@/lib/supabase/rpc";
 
@@ -19,29 +20,15 @@ export function MonthCumulativeCard({
   return (
     <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
       <div className="grid grid-cols-2 gap-stack">
-        <KpiSlot label="총 매출" value={`${formatWon(cumulative.totalRevenue)}원`} />
-        <KpiSlot label="순수익" value={`${formatWon(cumulative.totalNetProfit)}원`} />
-        <KpiSlot
+        <Metric label="총 매출" value={`${formatWon(cumulative.totalRevenue)}원`} />
+        <Metric label="순수익" value={`${formatWon(cumulative.totalNetProfit)}원`} />
+        <Metric
           label="일평균 매출"
           value={cumulative.operatingDays > 0 ? `${formatWon(cumulative.avgDailyRevenue)}원` : "—"}
         />
-        <KpiSlot label="영업일수" value={`${formatNumber(cumulative.operatingDays)}일`} />
+        <Metric label="영업일수" value={`${formatNumber(cumulative.operatingDays)}일`} />
       </div>
       <p className="text-micro text-ink-3">{marginLabel}</p>
     </article>
-  );
-}
-
-interface KpiSlotProps {
-  label: string;
-  value: string;
-}
-
-function KpiSlot({ label, value }: KpiSlotProps): React.ReactElement {
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="text-micro text-ink-3">{label}</span>
-      <span className="text-metric-md tabular-nums text-ink-1">{value}</span>
-    </div>
   );
 }

--- a/src/features/dashboard/components/YesterdayKpiCard.tsx
+++ b/src/features/dashboard/components/YesterdayKpiCard.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 import { formatWon, weekdayKoFromIso } from "@/lib/utils/format";
 import { MARGIN_LABEL } from "@/lib/domain/margin";
+import { Metric } from "@/components/ui/metric";
 import type { DashboardYesterday, DashboardWeeklyChartPoint } from "@/lib/supabase/rpc";
 
 interface YesterdayKpiCardProps {
@@ -36,8 +37,8 @@ export function YesterdayKpiCard({
       </div>
 
       <div className="grid grid-cols-2 gap-stack border-t border-border pt-stack">
-        <KpiSlot label="순수익" value={hasRevenue ? `${formatWon(yesterday.netProfit)}원` : "—"} />
-        <KpiSlot
+        <Metric label="순수익" value={hasRevenue ? `${formatWon(yesterday.netProfit)}원` : "—"} />
+        <Metric
           label="마진율"
           value={hasRevenue ? `${yesterday.marginPercent.toFixed(1)}%` : "—"}
         />
@@ -47,20 +48,6 @@ export function YesterdayKpiCard({
 
       <WeeklyMiniChart data={weeklyChart} maxRevenue={maxRevenue} highlightKey={yesterday.soldAt} />
     </article>
-  );
-}
-
-interface KpiSlotProps {
-  label: string;
-  value: string;
-}
-
-function KpiSlot({ label, value }: KpiSlotProps): React.ReactElement {
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="text-micro text-ink-3">{label}</span>
-      <span className="text-metric-md tabular-nums text-ink-1">{value}</span>
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

페이지·컴포넌트 6곳에서 반복되던 마크업을 단일 출처로.

- **\`Metric\`** (\`components/ui/metric.tsx\`) — KPI 카드 단위 (label + value 2줄). YesterdayKpi / MonthCumulative / CellDetail에 반복되던 동일 KpiSlot 3 copies 제거. StickyTotalCard의 Metric은 accent variant + "원" suffix로 변형이 커서 자체 보유 (주석 명시).
- **\`PageHeader\`** (\`components/ui/page-header.tsx\`) — \`<h1 text-title-lg>\` + 우측 액션 슬롯. 6개 페이지(menu/menu-new/menu-edit/inventory/inventory-stock-count/sale) 동일 구조.
- **\`SECONDARY_BUTTON_CLASSES\`** (\`components/ui/button-classes.ts\`) — \`border + bg-card hover\` 보조 버튼/링크 className 상수. Link/button 어디든 적용.
- **LoadingText / ErrorAlert 마이그레이션** — atom은 이미 있었지만 inline copy가 4곳에 남아있어 일괄 치환.

동작 변경 없음 — 모든 페이지의 시각/행동 동일.

## Test plan

- [x] typecheck / lint / format:check / build green
- [x] \`npm run test:unit\` 102 passed
- [x] 각 페이지 헤더/메트릭 marked-up 출력 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)