### PR TITLE
refactor: split application-layer use cases

### DIFF
--- a/src/features/menu/hooks/useMenuMutations.ts
+++ b/src/features/menu/hooks/useMenuMutations.ts
@@ -2,8 +2,8 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { deleteMenu, editMenu, saveMenu } from "@/lib/supabase/rpc";
 import type { MenuInput } from "../schemas";
+import { createMenu, removeMenu, updateMenu, type EditMenuInput } from "@/lib/application/menu";
 import { invalidateMenuCaches, menuListQueryKey } from "./useMenus";
 
 interface EditMenuVariables {
@@ -18,11 +18,7 @@ export function useCreateMenu(): UseMutationResult<string, Error, MenuInput> {
   return useMutation({
     mutationFn: async (values) => {
       const supabase = createClient();
-      const { data, error } = await saveMenu(supabase, values);
-      if (error) throw new Error(error.message);
-      const row = data?.[0];
-      if (!row) throw new Error("save_menu returned empty");
-      return row.menu_id;
+      return createMenu(supabase, values);
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: menuListQueryKey }),
   });
@@ -33,16 +29,13 @@ export function useEditMenu(): UseMutationResult<string, Error, EditMenuVariable
   return useMutation({
     mutationFn: async ({ menuId, values }) => {
       const supabase = createClient();
-      const { data, error } = await editMenu(supabase, {
+      const payload: EditMenuInput = {
         menuId,
         name: values.name,
         price: values.price,
         recipe: values.recipe,
-      });
-      if (error) throw new Error(error.message);
-      const row = data?.[0];
-      if (!row) throw new Error("edit_menu returned empty");
-      return row.menu_id;
+      };
+      return updateMenu(supabase, payload);
     },
     onSuccess: () => invalidateMenuCaches(queryClient),
   });
@@ -53,8 +46,7 @@ export function useDeleteMenu(): UseMutationResult<void, Error, string> {
   return useMutation({
     mutationFn: async (menuId) => {
       const supabase = createClient();
-      const { error } = await deleteMenu(supabase, menuId);
-      if (error) throw new Error(error.message);
+      return removeMenu(supabase, menuId);
     },
     onSuccess: () => invalidateMenuCaches(queryClient),
   });

--- a/src/features/purchase/hooks/usePurchaseSubmit.ts
+++ b/src/features/purchase/hooks/usePurchaseSubmit.ts
@@ -2,8 +2,9 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { savePurchase, type SavePurchaseResult } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
+import { submitPurchase, type SubmitPurchaseInput } from "@/lib/application/purchase";
+import type { SavePurchaseResult } from "@/lib/supabase/rpc";
 import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import { ingredientListQueryKey } from "./useIngredients";
@@ -15,14 +16,12 @@ interface SubmitVariables extends SavePurchaseInput {
 
 async function submit(input: SubmitVariables): Promise<SavePurchaseResult> {
   const supabase = createClient();
-  const { data, error } = await savePurchase(supabase, {
+  const payload: SubmitPurchaseInput = {
     vendorId: input.vendorId,
     purchasedAt: input.purchasedAt,
     items: input.items,
-  });
-  if (error) throw new Error(error.message);
-  if (!data) throw new Error("save_purchase: empty response");
-  return data;
+  };
+  return submitPurchase(supabase, payload);
 }
 
 export function usePurchaseSubmit(): UseMutationResult<SavePurchaseResult, Error, SubmitVariables> {

--- a/src/features/sale/hooks/useSaleEdit.ts
+++ b/src/features/sale/hooks/useSaleEdit.ts
@@ -2,38 +2,20 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { editSale, deleteSale } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
+import {
+  editSale as editSaleUseCase,
+  removeSale,
+  type EditSaleInput as EditSaleUseCaseInput,
+  type EditSaleResult,
+} from "@/lib/application/sale";
 import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import { salesQueryKey } from "./_keys";
-import type { EditSaleInput } from "../schemas";
 
-interface EditResult {
-  totalRevenue: number;
-  totalCostSnapshot: number;
-}
-
-async function edit(input: EditSaleInput): Promise<EditResult> {
+async function edit(input: EditSaleUseCaseInput): Promise<EditSaleResult> {
   const supabase = createClient();
-  const { data, error } = await editSale(supabase, {
-    saleId: input.saleId,
-    newItems: input.newItems.map((it) => ({ menuId: it.menuId, quantity: it.quantity })),
-    reason: input.reason,
-  });
-  if (error) throw new Error(error.message);
-  const row = data?.[0];
-  if (!row) throw new Error("edit_sale: no row");
-  return {
-    totalRevenue: Number(row.total_revenue),
-    totalCostSnapshot: Number(row.total_cost_snapshot),
-  };
-}
-
-async function remove(saleId: string): Promise<void> {
-  const supabase = createClient();
-  const { error } = await deleteSale(supabase, saleId);
-  if (error) throw new Error(error.message);
+  return editSaleUseCase(supabase, input);
 }
 
 // sale 편집/삭제도 재료 재고 보정 + price_history insert를 RPC가 수행하므로 sale 키
@@ -44,7 +26,7 @@ function invalidateSaleAndIngredientCaches(queryClient: ReturnType<typeof useQue
   void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
 }
 
-export function useSaleEdit(): UseMutationResult<EditResult, Error, EditSaleInput> {
+export function useSaleEdit(): UseMutationResult<EditSaleResult, Error, EditSaleUseCaseInput> {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: edit,
@@ -58,7 +40,10 @@ export function useSaleEdit(): UseMutationResult<EditResult, Error, EditSaleInpu
 export function useSaleDelete(): UseMutationResult<void, Error, string> {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: remove,
+    mutationFn: async (saleId) => {
+      const supabase = createClient();
+      return removeSale(supabase, saleId);
+    },
     onSuccess: () => invalidateSaleAndIngredientCaches(queryClient),
   });
 }

--- a/src/features/sale/hooks/useSaleSubmit.ts
+++ b/src/features/sale/hooks/useSaleSubmit.ts
@@ -2,9 +2,9 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { saveSale } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { requestPushPermissionAndSubscribe } from "@/lib/push/client";
+import { submitSale, type SubmitSaleInput, type SubmitSaleResult } from "@/lib/application/sale";
 import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
 import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
@@ -15,33 +15,16 @@ interface SubmitVariables extends SaveSaleInput {
   isFirstSale: boolean;
 }
 
-interface SubmitResult {
-  saleId: string;
-  totalRevenue: number;
-  totalCostSnapshot: number;
-  totalNetProfit: number;
-  marginPercent: number;
-}
-
-async function submit(input: SubmitVariables): Promise<SubmitResult> {
+async function submit(input: SubmitVariables): Promise<SubmitSaleResult> {
   const supabase = createClient();
-  const { data, error } = await saveSale(supabase, {
+  const payload: SubmitSaleInput = {
     soldAt: input.soldAt,
-    items: input.items.map((it) => ({ menuId: it.menuId, quantity: it.quantity })),
-  });
-  if (error) throw new Error(error.message);
-  const row = data?.[0];
-  if (!row) throw new Error("save_sale: no row returned");
-  return {
-    saleId: row.sale_id,
-    totalRevenue: Number(row.total_revenue),
-    totalCostSnapshot: Number(row.total_cost_snapshot),
-    totalNetProfit: Number(row.total_net_profit),
-    marginPercent: Number(row.margin_percent),
+    items: input.items,
   };
+  return submitSale(supabase, payload);
 }
 
-export function useSaleSubmit(): UseMutationResult<SubmitResult, Error, SubmitVariables> {
+export function useSaleSubmit(): UseMutationResult<SubmitSaleResult, Error, SubmitVariables> {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/src/lib/application/menu.ts
+++ b/src/lib/application/menu.ts
@@ -1,4 +1,8 @@
-import { deleteMenu as deleteMenuRpc, editMenu as editMenuRpc, saveMenu as saveMenuRpc } from "@/lib/supabase/rpc";
+import {
+  deleteMenu as deleteMenuRpc,
+  editMenu as editMenuRpc,
+  saveMenu as saveMenuRpc,
+} from "@/lib/supabase/rpc";
 
 interface RpcClient {
   rpc: unknown;

--- a/src/lib/application/menu.ts
+++ b/src/lib/application/menu.ts
@@ -1,0 +1,36 @@
+import { deleteMenu as deleteMenuRpc, editMenu as editMenuRpc, saveMenu as saveMenuRpc } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface SaveMenuInput {
+  name: string;
+  price: number;
+  recipe: ReadonlyArray<{ ingredientId: string; quantityPerServing: number }>;
+}
+
+export interface EditMenuInput extends SaveMenuInput {
+  menuId: string;
+}
+
+export async function createMenu(client: RpcClient, input: SaveMenuInput): Promise<string> {
+  const { data, error } = await saveMenuRpc(client, input);
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("save_menu returned empty");
+  return row.menu_id;
+}
+
+export async function updateMenu(client: RpcClient, input: EditMenuInput): Promise<string> {
+  const { data, error } = await editMenuRpc(client, input);
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("edit_menu returned empty");
+  return row.menu_id;
+}
+
+export async function removeMenu(client: RpcClient, menuId: string): Promise<void> {
+  const { error } = await deleteMenuRpc(client, menuId);
+  if (error) throw new Error(error.message);
+}

--- a/src/lib/application/purchase.ts
+++ b/src/lib/application/purchase.ts
@@ -1,0 +1,31 @@
+import { savePurchase, type SavePurchaseResult } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface SubmitPurchaseItemInput {
+  ingredientId: string;
+  quantity: number;
+  amount: number;
+}
+
+export interface SubmitPurchaseInput {
+  vendorId: string;
+  purchasedAt: string;
+  items: ReadonlyArray<SubmitPurchaseItemInput>;
+}
+
+export async function submitPurchase(
+  client: RpcClient,
+  input: SubmitPurchaseInput,
+): Promise<SavePurchaseResult> {
+  const { data, error } = await savePurchase(client, {
+    vendorId: input.vendorId,
+    purchasedAt: input.purchasedAt,
+    items: input.items,
+  });
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("save_purchase: empty response");
+  return data;
+}

--- a/src/lib/application/sale.ts
+++ b/src/lib/application/sale.ts
@@ -1,4 +1,8 @@
-import { deleteSale as deleteSaleRpc, editSale as editSaleRpc, saveSale as saveSaleRpc } from "@/lib/supabase/rpc";
+import {
+  deleteSale as deleteSaleRpc,
+  editSale as editSaleRpc,
+  saveSale as saveSaleRpc,
+} from "@/lib/supabase/rpc";
 
 interface RpcClient {
   rpc: unknown;
@@ -58,7 +62,10 @@ function mapEditRow(row: SaleRpcRow): EditSaleResult {
   };
 }
 
-export async function submitSale(client: RpcClient, input: SubmitSaleInput): Promise<SubmitSaleResult> {
+export async function submitSale(
+  client: RpcClient,
+  input: SubmitSaleInput,
+): Promise<SubmitSaleResult> {
   const { data, error } = await saveSaleRpc(client, {
     soldAt: input.soldAt,
     items: input.items,

--- a/src/lib/application/sale.ts
+++ b/src/lib/application/sale.ts
@@ -1,0 +1,87 @@
+import { deleteSale as deleteSaleRpc, editSale as editSaleRpc, saveSale as saveSaleRpc } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface SubmitSaleItemInput {
+  menuId: string;
+  quantity: number;
+}
+
+export interface SubmitSaleInput {
+  soldAt: string;
+  items: ReadonlyArray<SubmitSaleItemInput>;
+}
+
+export interface SubmitSaleResult {
+  saleId: string;
+  totalRevenue: number;
+  totalCostSnapshot: number;
+  totalNetProfit: number;
+  marginPercent: number;
+}
+
+export interface EditSaleInput {
+  saleId: string;
+  newItems: ReadonlyArray<SubmitSaleItemInput>;
+  reason?: string;
+}
+
+export interface EditSaleResult {
+  totalRevenue: number;
+  totalCostSnapshot: number;
+}
+
+interface SaleRpcRow {
+  sale_id: string;
+  total_revenue: number;
+  total_cost_snapshot: number;
+  total_net_profit: number;
+  margin_percent: number;
+}
+
+function mapSaleRow(row: SaleRpcRow): SubmitSaleResult {
+  return {
+    saleId: row.sale_id,
+    totalRevenue: Number(row.total_revenue),
+    totalCostSnapshot: Number(row.total_cost_snapshot),
+    totalNetProfit: Number(row.total_net_profit),
+    marginPercent: Number(row.margin_percent),
+  };
+}
+
+function mapEditRow(row: SaleRpcRow): EditSaleResult {
+  return {
+    totalRevenue: Number(row.total_revenue),
+    totalCostSnapshot: Number(row.total_cost_snapshot),
+  };
+}
+
+export async function submitSale(client: RpcClient, input: SubmitSaleInput): Promise<SubmitSaleResult> {
+  const { data, error } = await saveSaleRpc(client, {
+    soldAt: input.soldAt,
+    items: input.items,
+  });
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("save_sale: no row returned");
+  return mapSaleRow(row);
+}
+
+export async function editSale(client: RpcClient, input: EditSaleInput): Promise<EditSaleResult> {
+  const { data, error } = await editSaleRpc(client, {
+    saleId: input.saleId,
+    newItems: input.newItems,
+    reason: input.reason,
+  });
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("edit_sale: no row");
+  return mapEditRow(row);
+}
+
+export async function removeSale(client: RpcClient, saleId: string): Promise<void> {
+  const { error } = await deleteSaleRpc(client, saleId);
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
refactor(application): split purchase/sale/menu use cases into application layer (#85)

세 가지 작은 정리:

1. purchase/sale/menu 훅에서 Supabase RPC 호출과 응답 해석을 빼서 `src/lib/application/*`로 이동.
   훅은 이제 client 생성, tracking, cache invalidation만 담당하도록 정리.

2. domain/application 경계가 더 명확해짐.
   순수 규칙은 `src/lib/domain/*`에 유지하고, 외부 의존성은 application/adapter 경계로 넘길 수 있는 기반을 마련.

3. 로컬 검증 완료.
   `npm run typecheck` 통과.

Closes #85

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
