### PR TITLE
refactor: split rpc core and add application tests

### DIFF
--- a/src/features/calendar/hooks/useCalendarMonth.ts
+++ b/src/features/calendar/hooks/useCalendarMonth.ts
@@ -2,12 +2,7 @@
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { getCalendarMonth, type CalendarMonthData } from "@/lib/supabase/rpc";
-import { withConsecutiveMissingDays, type EnrichedCalendarCell } from "../lib/consecutive-missing";
-
-export interface CalendarMonthView extends Omit<CalendarMonthData, "cells"> {
-  cells: EnrichedCalendarCell[];
-}
+import { loadCalendarMonth, type CalendarMonthView } from "@/lib/application/calendar";
 
 export function calendarMonthQueryKey(
   year: number,
@@ -18,10 +13,7 @@ export function calendarMonthQueryKey(
 
 async function fetchCalendarMonth(year: number, month: number): Promise<CalendarMonthView> {
   const supabase = createClient();
-  const { data, error } = await getCalendarMonth(supabase, { year, month });
-  if (error) throw new Error(error.message);
-  if (!data) throw new Error("calendar data missing");
-  return { ...data, cells: withConsecutiveMissingDays(data.cells) };
+  return loadCalendarMonth(supabase, year, month);
 }
 
 export function useCalendarMonth(

--- a/src/features/calendar/lib/consecutive-missing.ts
+++ b/src/features/calendar/lib/consecutive-missing.ts
@@ -1,21 +1,2 @@
-import type { CalendarCell } from "@/lib/supabase/rpc";
-
-/**
- * RPC가 반환한 날짜순 셀 배열에 `consecutiveMissingDays` 필드를 추가.
- * - 해당 셀이 누락이면: 직전까지의 연속 누락일 수 + 1
- * - 누락 아니면 0 (런 종료)
- *
- * 헌법 IV: 사용자별 데이터이므로 RPC가 user_id 격리 — 이 함수는 순수 변환.
- * SQL window 함수 대신 단순 reduce로 처리해 SQL 복잡도 감소.
- */
-export interface EnrichedCalendarCell extends CalendarCell {
-  consecutiveMissingDays: number;
-}
-
-export function withConsecutiveMissingDays(cells: readonly CalendarCell[]): EnrichedCalendarCell[] {
-  let counter = 0;
-  return cells.map((cell) => {
-    counter = cell.isMissing ? counter + 1 : 0;
-    return { ...cell, consecutiveMissingDays: counter };
-  });
-}
+export { withConsecutiveMissingDays } from "@/lib/application/calendar";
+export type { EnrichedCalendarCell } from "@/lib/application/calendar";

--- a/src/features/dashboard/hooks/useTodayDashboard.ts
+++ b/src/features/dashboard/hooks/useTodayDashboard.ts
@@ -2,16 +2,14 @@
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { getTodayDashboard, type TodayDashboardData } from "@/lib/supabase/rpc";
+import { loadTodayDashboard } from "@/lib/application/dashboard";
+import type { TodayDashboardData } from "@/lib/supabase/rpc";
 
 export const todayDashboardQueryKey = ["dashboard", "today"] as const;
 
 async function fetchTodayDashboard(): Promise<TodayDashboardData> {
   const supabase = createClient();
-  const { data, error } = await getTodayDashboard(supabase);
-  if (error) throw new Error(error.message);
-  if (!data) throw new Error("dashboard data missing");
-  return data;
+  return loadTodayDashboard(supabase);
 }
 
 export function useTodayDashboard(): UseQueryResult<TodayDashboardData> {

--- a/src/features/inventory/hooks/useDepletionForecast.ts
+++ b/src/features/inventory/hooks/useDepletionForecast.ts
@@ -2,56 +2,31 @@
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { getDepletionForecast } from "@/lib/supabase/rpc";
-import {
-  forecastIngredient,
-  type ForecastResult,
-  type DailyConsumption,
-} from "@/lib/domain/forecast";
+import { loadDepletionForecast, type IngredientForecastView } from "@/lib/application/inventory";
+import type { ForecastResult } from "@/lib/domain/forecast";
 
 /**
  * RPC `get_depletion_forecast`로 raw 데이터를 받아 클라이언트에서
  * `forecastIngredient`로 분류. 분류 로직 단일 출처(forecast.ts) 유지.
  */
 
-export interface IngredientForecastView extends ForecastResult {
-  ingredientId: string;
-  name: string;
-  unit: "g" | "ml" | "piece";
-  currentStock: number;
-  leadTimeDays: number;
-}
-
 export const depletionForecastQueryKey = ["inventory", "forecast"] as const;
 
-async function fetchDepletionForecast(): Promise<IngredientForecastView[]> {
-  const supabase = createClient();
-  const { data, error } = await getDepletionForecast(supabase);
-  if (error) throw new Error(error.message);
+export type { IngredientForecastView } from "@/lib/application/inventory";
 
-  const today = new Date();
-  return (data ?? []).map((row) => {
-    const samples: DailyConsumption[] = row.consumptionSamples.map((s) => ({
-      date: new Date(s.date),
-      amount: Number(s.amount),
-    }));
-    const forecast = forecastIngredient({
-      currentStock: row.currentStock,
-      leadTimeDays: row.leadTimeDays,
-      consumptionSamples: samples,
-      daysOff: row.regularDaysOff,
-      signupDate: new Date(row.signedUpAt),
-      today,
-    });
-    return {
-      ingredientId: row.ingredientId,
-      name: row.name,
-      unit: row.unit,
-      currentStock: row.currentStock,
-      leadTimeDays: row.leadTimeDays,
-      ...forecast,
-    };
-  });
+async function fetchDepletionForecast(): Promise<
+  Array<
+    {
+      ingredientId: string;
+      name: string;
+      unit: "g" | "ml" | "piece";
+      currentStock: number;
+      leadTimeDays: number;
+    } & ForecastResult
+  >
+> {
+  const supabase = createClient();
+  return loadDepletionForecast(supabase);
 }
 
 export function useDepletionForecast(): UseQueryResult<IngredientForecastView[]> {

--- a/src/features/menu/hooks/useMenuMutations.ts
+++ b/src/features/menu/hooks/useMenuMutations.ts
@@ -2,8 +2,8 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { deleteMenu, editMenu, saveMenu } from "@/lib/supabase/rpc";
 import type { MenuInput } from "../schemas";
+import { createMenu, removeMenu, updateMenu, type EditMenuInput } from "@/lib/application/menu";
 import { invalidateMenuCaches, menuListQueryKey } from "./useMenus";
 
 interface EditMenuVariables {
@@ -18,11 +18,7 @@ export function useCreateMenu(): UseMutationResult<string, Error, MenuInput> {
   return useMutation({
     mutationFn: async (values) => {
       const supabase = createClient();
-      const { data, error } = await saveMenu(supabase, values);
-      if (error) throw new Error(error.message);
-      const row = data?.[0];
-      if (!row) throw new Error("save_menu returned empty");
-      return row.menu_id;
+      return createMenu(supabase, values);
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: menuListQueryKey }),
   });
@@ -33,16 +29,13 @@ export function useEditMenu(): UseMutationResult<string, Error, EditMenuVariable
   return useMutation({
     mutationFn: async ({ menuId, values }) => {
       const supabase = createClient();
-      const { data, error } = await editMenu(supabase, {
+      const payload: EditMenuInput = {
         menuId,
         name: values.name,
         price: values.price,
         recipe: values.recipe,
-      });
-      if (error) throw new Error(error.message);
-      const row = data?.[0];
-      if (!row) throw new Error("edit_menu returned empty");
-      return row.menu_id;
+      };
+      return updateMenu(supabase, payload);
     },
     onSuccess: () => invalidateMenuCaches(queryClient),
   });
@@ -53,8 +46,7 @@ export function useDeleteMenu(): UseMutationResult<void, Error, string> {
   return useMutation({
     mutationFn: async (menuId) => {
       const supabase = createClient();
-      const { error } = await deleteMenu(supabase, menuId);
-      if (error) throw new Error(error.message);
+      return removeMenu(supabase, menuId);
     },
     onSuccess: () => invalidateMenuCaches(queryClient),
   });

--- a/src/features/purchase/hooks/usePurchaseSubmit.ts
+++ b/src/features/purchase/hooks/usePurchaseSubmit.ts
@@ -2,8 +2,9 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { savePurchase, type SavePurchaseResult } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
+import { submitPurchase, type SubmitPurchaseInput } from "@/lib/application/purchase";
+import type { SavePurchaseResult } from "@/lib/supabase/rpc";
 import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import { ingredientListQueryKey } from "./useIngredients";
@@ -15,14 +16,12 @@ interface SubmitVariables extends SavePurchaseInput {
 
 async function submit(input: SubmitVariables): Promise<SavePurchaseResult> {
   const supabase = createClient();
-  const { data, error } = await savePurchase(supabase, {
+  const payload: SubmitPurchaseInput = {
     vendorId: input.vendorId,
     purchasedAt: input.purchasedAt,
     items: input.items,
-  });
-  if (error) throw new Error(error.message);
-  if (!data) throw new Error("save_purchase: empty response");
-  return data;
+  };
+  return submitPurchase(supabase, payload);
 }
 
 export function usePurchaseSubmit(): UseMutationResult<SavePurchaseResult, Error, SubmitVariables> {

--- a/src/features/sale/hooks/useSaleEdit.ts
+++ b/src/features/sale/hooks/useSaleEdit.ts
@@ -2,38 +2,20 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { editSale, deleteSale } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
+import {
+  editSale as editSaleUseCase,
+  removeSale,
+  type EditSaleInput as EditSaleUseCaseInput,
+  type EditSaleResult,
+} from "@/lib/application/sale";
 import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import { salesQueryKey } from "./_keys";
-import type { EditSaleInput } from "../schemas";
 
-interface EditResult {
-  totalRevenue: number;
-  totalCostSnapshot: number;
-}
-
-async function edit(input: EditSaleInput): Promise<EditResult> {
+async function edit(input: EditSaleUseCaseInput): Promise<EditSaleResult> {
   const supabase = createClient();
-  const { data, error } = await editSale(supabase, {
-    saleId: input.saleId,
-    newItems: input.newItems.map((it) => ({ menuId: it.menuId, quantity: it.quantity })),
-    reason: input.reason,
-  });
-  if (error) throw new Error(error.message);
-  const row = data?.[0];
-  if (!row) throw new Error("edit_sale: no row");
-  return {
-    totalRevenue: Number(row.total_revenue),
-    totalCostSnapshot: Number(row.total_cost_snapshot),
-  };
-}
-
-async function remove(saleId: string): Promise<void> {
-  const supabase = createClient();
-  const { error } = await deleteSale(supabase, saleId);
-  if (error) throw new Error(error.message);
+  return editSaleUseCase(supabase, input);
 }
 
 // sale 편집/삭제도 재료 재고 보정 + price_history insert를 RPC가 수행하므로 sale 키
@@ -44,7 +26,7 @@ function invalidateSaleAndIngredientCaches(queryClient: ReturnType<typeof useQue
   void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
 }
 
-export function useSaleEdit(): UseMutationResult<EditResult, Error, EditSaleInput> {
+export function useSaleEdit(): UseMutationResult<EditSaleResult, Error, EditSaleUseCaseInput> {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: edit,
@@ -58,7 +40,10 @@ export function useSaleEdit(): UseMutationResult<EditResult, Error, EditSaleInpu
 export function useSaleDelete(): UseMutationResult<void, Error, string> {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: remove,
+    mutationFn: async (saleId) => {
+      const supabase = createClient();
+      return removeSale(supabase, saleId);
+    },
     onSuccess: () => invalidateSaleAndIngredientCaches(queryClient),
   });
 }

--- a/src/features/sale/hooks/useSaleSubmit.ts
+++ b/src/features/sale/hooks/useSaleSubmit.ts
@@ -2,9 +2,9 @@
 
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { saveSale } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { requestPushPermissionAndSubscribe } from "@/lib/push/client";
+import { submitSale, type SubmitSaleInput, type SubmitSaleResult } from "@/lib/application/sale";
 import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
 import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
@@ -15,33 +15,16 @@ interface SubmitVariables extends SaveSaleInput {
   isFirstSale: boolean;
 }
 
-interface SubmitResult {
-  saleId: string;
-  totalRevenue: number;
-  totalCostSnapshot: number;
-  totalNetProfit: number;
-  marginPercent: number;
-}
-
-async function submit(input: SubmitVariables): Promise<SubmitResult> {
+async function submit(input: SubmitVariables): Promise<SubmitSaleResult> {
   const supabase = createClient();
-  const { data, error } = await saveSale(supabase, {
+  const payload: SubmitSaleInput = {
     soldAt: input.soldAt,
-    items: input.items.map((it) => ({ menuId: it.menuId, quantity: it.quantity })),
-  });
-  if (error) throw new Error(error.message);
-  const row = data?.[0];
-  if (!row) throw new Error("save_sale: no row returned");
-  return {
-    saleId: row.sale_id,
-    totalRevenue: Number(row.total_revenue),
-    totalCostSnapshot: Number(row.total_cost_snapshot),
-    totalNetProfit: Number(row.total_net_profit),
-    marginPercent: Number(row.margin_percent),
+    items: input.items,
   };
+  return submitSale(supabase, payload);
 }
 
-export function useSaleSubmit(): UseMutationResult<SubmitResult, Error, SubmitVariables> {
+export function useSaleSubmit(): UseMutationResult<SubmitSaleResult, Error, SubmitVariables> {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/src/lib/application/calendar.ts
+++ b/src/lib/application/calendar.ts
@@ -1,0 +1,33 @@
+import type { CalendarCell, CalendarMonthData } from "@/lib/supabase/rpc";
+import { getCalendarMonth } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface EnrichedCalendarCell extends CalendarCell {
+  consecutiveMissingDays: number;
+}
+
+export interface CalendarMonthView extends Omit<CalendarMonthData, "cells"> {
+  cells: EnrichedCalendarCell[];
+}
+
+export function withConsecutiveMissingDays(cells: readonly CalendarCell[]): EnrichedCalendarCell[] {
+  let counter = 0;
+  return cells.map((cell) => {
+    counter = cell.isMissing ? counter + 1 : 0;
+    return { ...cell, consecutiveMissingDays: counter };
+  });
+}
+
+export async function loadCalendarMonth(
+  client: RpcClient,
+  year: number,
+  month: number,
+): Promise<CalendarMonthView> {
+  const { data, error } = await getCalendarMonth(client, { year, month });
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("calendar data missing");
+  return { ...data, cells: withConsecutiveMissingDays(data.cells) };
+}

--- a/src/lib/application/dashboard.ts
+++ b/src/lib/application/dashboard.ts
@@ -1,0 +1,13 @@
+import type { TodayDashboardData } from "@/lib/supabase/rpc";
+import { getTodayDashboard } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export async function loadTodayDashboard(client: RpcClient): Promise<TodayDashboardData> {
+  const { data, error } = await getTodayDashboard(client);
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("dashboard data missing");
+  return data;
+}

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -1,0 +1,47 @@
+import {
+  forecastIngredient,
+  type DailyConsumption,
+  type ForecastResult,
+} from "@/lib/domain/forecast";
+import { getDepletionForecast } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface IngredientForecastView extends ForecastResult {
+  ingredientId: string;
+  name: string;
+  unit: "g" | "ml" | "piece";
+  currentStock: number;
+  leadTimeDays: number;
+}
+
+export async function loadDepletionForecast(client: RpcClient): Promise<IngredientForecastView[]> {
+  const { data, error } = await getDepletionForecast(client);
+  if (error) throw new Error(error.message);
+
+  const today = new Date();
+  return (data ?? []).map((row) => {
+    const samples: DailyConsumption[] = row.consumptionSamples.map((s) => ({
+      date: new Date(s.date),
+      amount: Number(s.amount),
+    }));
+    const forecast = forecastIngredient({
+      currentStock: row.currentStock,
+      leadTimeDays: row.leadTimeDays,
+      consumptionSamples: samples,
+      daysOff: row.regularDaysOff,
+      signupDate: new Date(row.signedUpAt),
+      today,
+    });
+    return {
+      ingredientId: row.ingredientId,
+      name: row.name,
+      unit: row.unit,
+      currentStock: row.currentStock,
+      leadTimeDays: row.leadTimeDays,
+      ...forecast,
+    };
+  });
+}

--- a/src/lib/application/menu.ts
+++ b/src/lib/application/menu.ts
@@ -1,4 +1,8 @@
-import { deleteMenu as deleteMenuRpc, editMenu as editMenuRpc, saveMenu as saveMenuRpc } from "@/lib/supabase/rpc";
+import {
+  deleteMenu as deleteMenuRpc,
+  editMenu as editMenuRpc,
+  saveMenu as saveMenuRpc,
+} from "@/lib/supabase/rpc";
 
 interface RpcClient {
   rpc: unknown;

--- a/src/lib/application/menu.ts
+++ b/src/lib/application/menu.ts
@@ -1,0 +1,36 @@
+import { deleteMenu as deleteMenuRpc, editMenu as editMenuRpc, saveMenu as saveMenuRpc } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface SaveMenuInput {
+  name: string;
+  price: number;
+  recipe: ReadonlyArray<{ ingredientId: string; quantityPerServing: number }>;
+}
+
+export interface EditMenuInput extends SaveMenuInput {
+  menuId: string;
+}
+
+export async function createMenu(client: RpcClient, input: SaveMenuInput): Promise<string> {
+  const { data, error } = await saveMenuRpc(client, input);
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("save_menu returned empty");
+  return row.menu_id;
+}
+
+export async function updateMenu(client: RpcClient, input: EditMenuInput): Promise<string> {
+  const { data, error } = await editMenuRpc(client, input);
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("edit_menu returned empty");
+  return row.menu_id;
+}
+
+export async function removeMenu(client: RpcClient, menuId: string): Promise<void> {
+  const { error } = await deleteMenuRpc(client, menuId);
+  if (error) throw new Error(error.message);
+}

--- a/src/lib/application/purchase.ts
+++ b/src/lib/application/purchase.ts
@@ -1,0 +1,31 @@
+import { savePurchase, type SavePurchaseResult } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface SubmitPurchaseItemInput {
+  ingredientId: string;
+  quantity: number;
+  amount: number;
+}
+
+export interface SubmitPurchaseInput {
+  vendorId: string;
+  purchasedAt: string;
+  items: ReadonlyArray<SubmitPurchaseItemInput>;
+}
+
+export async function submitPurchase(
+  client: RpcClient,
+  input: SubmitPurchaseInput,
+): Promise<SavePurchaseResult> {
+  const { data, error } = await savePurchase(client, {
+    vendorId: input.vendorId,
+    purchasedAt: input.purchasedAt,
+    items: input.items,
+  });
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("save_purchase: empty response");
+  return data;
+}

--- a/src/lib/application/sale.ts
+++ b/src/lib/application/sale.ts
@@ -1,4 +1,8 @@
-import { deleteSale as deleteSaleRpc, editSale as editSaleRpc, saveSale as saveSaleRpc } from "@/lib/supabase/rpc";
+import {
+  deleteSale as deleteSaleRpc,
+  editSale as editSaleRpc,
+  saveSale as saveSaleRpc,
+} from "@/lib/supabase/rpc";
 
 interface RpcClient {
   rpc: unknown;
@@ -58,7 +62,10 @@ function mapEditRow(row: SaleRpcRow): EditSaleResult {
   };
 }
 
-export async function submitSale(client: RpcClient, input: SubmitSaleInput): Promise<SubmitSaleResult> {
+export async function submitSale(
+  client: RpcClient,
+  input: SubmitSaleInput,
+): Promise<SubmitSaleResult> {
   const { data, error } = await saveSaleRpc(client, {
     soldAt: input.soldAt,
     items: input.items,

--- a/src/lib/application/sale.ts
+++ b/src/lib/application/sale.ts
@@ -1,0 +1,87 @@
+import { deleteSale as deleteSaleRpc, editSale as editSaleRpc, saveSale as saveSaleRpc } from "@/lib/supabase/rpc";
+
+interface RpcClient {
+  rpc: unknown;
+}
+
+export interface SubmitSaleItemInput {
+  menuId: string;
+  quantity: number;
+}
+
+export interface SubmitSaleInput {
+  soldAt: string;
+  items: ReadonlyArray<SubmitSaleItemInput>;
+}
+
+export interface SubmitSaleResult {
+  saleId: string;
+  totalRevenue: number;
+  totalCostSnapshot: number;
+  totalNetProfit: number;
+  marginPercent: number;
+}
+
+export interface EditSaleInput {
+  saleId: string;
+  newItems: ReadonlyArray<SubmitSaleItemInput>;
+  reason?: string;
+}
+
+export interface EditSaleResult {
+  totalRevenue: number;
+  totalCostSnapshot: number;
+}
+
+interface SaleRpcRow {
+  sale_id: string;
+  total_revenue: number;
+  total_cost_snapshot: number;
+  total_net_profit: number;
+  margin_percent: number;
+}
+
+function mapSaleRow(row: SaleRpcRow): SubmitSaleResult {
+  return {
+    saleId: row.sale_id,
+    totalRevenue: Number(row.total_revenue),
+    totalCostSnapshot: Number(row.total_cost_snapshot),
+    totalNetProfit: Number(row.total_net_profit),
+    marginPercent: Number(row.margin_percent),
+  };
+}
+
+function mapEditRow(row: SaleRpcRow): EditSaleResult {
+  return {
+    totalRevenue: Number(row.total_revenue),
+    totalCostSnapshot: Number(row.total_cost_snapshot),
+  };
+}
+
+export async function submitSale(client: RpcClient, input: SubmitSaleInput): Promise<SubmitSaleResult> {
+  const { data, error } = await saveSaleRpc(client, {
+    soldAt: input.soldAt,
+    items: input.items,
+  });
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("save_sale: no row returned");
+  return mapSaleRow(row);
+}
+
+export async function editSale(client: RpcClient, input: EditSaleInput): Promise<EditSaleResult> {
+  const { data, error } = await editSaleRpc(client, {
+    saleId: input.saleId,
+    newItems: input.newItems,
+    reason: input.reason,
+  });
+  if (error) throw new Error(error.message);
+  const row = data?.[0];
+  if (!row) throw new Error("edit_sale: no row");
+  return mapEditRow(row);
+}
+
+export async function removeSale(client: RpcClient, saleId: string): Promise<void> {
+  const { error } = await deleteSaleRpc(client, saleId);
+  if (error) throw new Error(error.message);
+}

--- a/src/lib/supabase/rpc-core.ts
+++ b/src/lib/supabase/rpc-core.ts
@@ -1,0 +1,56 @@
+interface RpcResult<T> {
+  data: T | null;
+  error: { message: string; code?: string } | null;
+}
+
+interface ClientLike {
+  rpc: unknown;
+}
+
+async function callRpc<T>(
+  client: ClientLike,
+  fn: string,
+  args?: Record<string, unknown>,
+): Promise<RpcResult<T>> {
+  const rpcFn = client.rpc as (...rest: unknown[]) => PromiseLike<RpcResult<T>>;
+  const result = await Reflect.apply(rpcFn, client, args === undefined ? [fn] : [fn, args]);
+  return result;
+}
+
+function numeric(value: string | number | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  const n = Number(value);
+  if (Number.isNaN(n)) {
+    throw new Error(`numeric() received non-numeric value: ${value}`);
+  }
+  return n;
+}
+
+async function callRpcSingleRow<TRaw, TOut>(
+  client: ClientLike,
+  fn: string,
+  args: Record<string, unknown>,
+  mapRow: (row: TRaw) => TOut,
+): Promise<RpcResult<TOut>> {
+  const result = await callRpc<TRaw[]>(client, fn, args);
+  if (result.error || !result.data?.[0]) {
+    return { data: null, error: result.error };
+  }
+  return { data: mapRow(result.data[0]), error: null };
+}
+
+async function callRpcMapped<TRaw, TOut>(
+  client: ClientLike,
+  fn: string,
+  args: Record<string, unknown> | undefined,
+  map: (raw: TRaw) => TOut,
+): Promise<RpcResult<TOut>> {
+  const result = await callRpc<TRaw>(client, fn, args);
+  if (result.error || !result.data) {
+    return { data: null, error: result.error };
+  }
+  return { data: map(result.data), error: null };
+}
+
+export type { ClientLike, RpcResult };
+export { callRpc, callRpcMapped, callRpcSingleRow, numeric };

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -1,79 +1,15 @@
 import type { Database } from "./types";
+import {
+  callRpc,
+  callRpcMapped,
+  callRpcSingleRow,
+  numeric,
+  type ClientLike,
+  type RpcResult,
+} from "./rpc-core";
 
 type Weekday = Database["public"]["Enums"]["weekday"];
 type StoreType = Database["public"]["Enums"]["store_type"];
-
-/**
- * 타입 있는 RPC 래퍼.
- *
- * Supabase v2 rpc() 제네릭이 자동 생성 Database 타입과 일부 추론 충돌이 있어
- * 런타임 결과를 명시 타입으로 단언한다 (이 wrapping이 unsafe-cast 지점).
- * 또한 분리된 변수에 rpc를 대입하면 `this` 바인딩이 끊겨 Supabase 내부
- * fetcher가 깨지므로 `Reflect.apply`로 client를 receiver로 유지.
- */
-
-interface RpcResult<T> {
-  data: T | null;
-  error: { message: string; code?: string } | null;
-}
-
-interface ClientLike {
-  rpc: unknown;
-}
-
-async function callRpc<T>(
-  client: ClientLike,
-  fn: string,
-  args?: Record<string, unknown>,
-): Promise<RpcResult<T>> {
-  const rpcFn = client.rpc as (...rest: unknown[]) => PromiseLike<RpcResult<T>>;
-  const result = await Reflect.apply(rpcFn, client, args === undefined ? [fn] : [fn, args]);
-  return result;
-}
-
-/**
- * PostgREST가 numeric(p,s) 컬럼을 string으로 직렬화하므로 number 변환 필요.
- * 단순 `Number()`는 NaN을 silent 통과 → 명시적 가드를 둔 단일 출처 헬퍼.
- */
-function numeric(value: string | number | null | undefined): number {
-  if (value === null || value === undefined) return 0;
-  const n = Number(value);
-  if (Number.isNaN(n)) {
-    throw new Error(`numeric() received non-numeric value: ${value}`);
-  }
-  return n;
-}
-
-/**
- * 첫 행만 사용하는 RPC 래퍼 — `apply_stock_count` / `save_purchase`처럼 SETOF 1건을
- * 반환하지만 호출 측은 단일 객체로 다루는 패턴 단일 출처. data[0]이 없으면 null.
- */
-async function callRpcSingleRow<TRaw, TOut>(
-  client: ClientLike,
-  fn: string,
-  args: Record<string, unknown>,
-  mapRow: (row: TRaw) => TOut,
-): Promise<RpcResult<TOut>> {
-  const result = await callRpc<TRaw[]>(client, fn, args);
-  if (result.error || !result.data?.[0]) {
-    return { data: null, error: result.error };
-  }
-  return { data: mapRow(result.data[0]), error: null };
-}
-
-/** 단일 row payload(객체 1개)를 반환하는 RPC 래퍼 — `get_today_dashboard` 등. */
-async function callRpcMapped<TRaw, TOut>(
-  client: ClientLike,
-  fn: string,
-  args: Record<string, unknown> | undefined,
-  map: (raw: TRaw) => TOut,
-): Promise<RpcResult<TOut>> {
-  const result = await callRpc<TRaw>(client, fn, args);
-  if (result.error || !result.data) {
-    return { data: null, error: result.error };
-  }
-  return { data: map(result.data), error: null };
-}
 
 interface UpdateRegularDaysOffArgs {
   p_days_off: readonly Weekday[];

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -1,0 +1,420 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpcMocks = vi.hoisted(() => ({
+  getCalendarMonth: vi.fn(),
+  getTodayDashboard: vi.fn(),
+  getDepletionForecast: vi.fn(),
+  savePurchase: vi.fn(),
+  saveSale: vi.fn(),
+  editSale: vi.fn(),
+  deleteSale: vi.fn(),
+  saveMenu: vi.fn(),
+  editMenu: vi.fn(),
+  deleteMenu: vi.fn(),
+}));
+
+const forecastMocks = vi.hoisted(() => ({
+  forecastIngredient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/rpc", () => ({
+  getCalendarMonth: rpcMocks.getCalendarMonth,
+  getTodayDashboard: rpcMocks.getTodayDashboard,
+  getDepletionForecast: rpcMocks.getDepletionForecast,
+  savePurchase: rpcMocks.savePurchase,
+  saveSale: rpcMocks.saveSale,
+  editSale: rpcMocks.editSale,
+  deleteSale: rpcMocks.deleteSale,
+  saveMenu: rpcMocks.saveMenu,
+  editMenu: rpcMocks.editMenu,
+  deleteMenu: rpcMocks.deleteMenu,
+}));
+
+vi.mock("@/lib/domain/forecast", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/domain/forecast")>("@/lib/domain/forecast");
+  return {
+    ...actual,
+    forecastIngredient: forecastMocks.forecastIngredient,
+  };
+});
+
+import { createMenu, removeMenu, updateMenu } from "@/lib/application/menu";
+import { loadTodayDashboard } from "@/lib/application/dashboard";
+import { loadCalendarMonth, withConsecutiveMissingDays } from "@/lib/application/calendar";
+import { loadDepletionForecast } from "@/lib/application/inventory";
+import { submitPurchase } from "@/lib/application/purchase";
+import { editSale, submitSale } from "@/lib/application/sale";
+
+describe("application layer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("calendar", () => {
+    it("withConsecutiveMissingDays counts missing streaks", () => {
+      const cells = [
+        {
+          date: "2026-06-01",
+          isFuture: false,
+          isBeforeSignup: false,
+          isRegularDayOff: false,
+          hasSale: false,
+          hasPurchase: false,
+          isMissing: true,
+          revenue: null,
+          netProfit: null,
+        },
+        {
+          date: "2026-06-02",
+          isFuture: false,
+          isBeforeSignup: false,
+          isRegularDayOff: false,
+          hasSale: false,
+          hasPurchase: false,
+          isMissing: true,
+          revenue: null,
+          netProfit: null,
+        },
+        {
+          date: "2026-06-03",
+          isFuture: false,
+          isBeforeSignup: false,
+          isRegularDayOff: false,
+          hasSale: true,
+          hasPurchase: false,
+          isMissing: false,
+          revenue: 12000,
+          netProfit: 4000,
+        },
+      ];
+
+      expect(withConsecutiveMissingDays(cells)).toEqual([
+        { ...cells[0], consecutiveMissingDays: 1 },
+        { ...cells[1], consecutiveMissingDays: 2 },
+        { ...cells[2], consecutiveMissingDays: 0 },
+      ]);
+    });
+
+    it("loadCalendarMonth maps RPC data into calendar view", async () => {
+      rpcMocks.getCalendarMonth.mockResolvedValue({
+        data: {
+          year: 2026,
+          month: 6,
+          cumulative: {
+            totalRevenue: 123000,
+            totalNetProfit: 54000,
+            avgDailyRevenue: 17642.85,
+            operatingDays: 7,
+          },
+          cells: [
+            {
+              date: "2026-06-01",
+              isFuture: false,
+              isBeforeSignup: false,
+              isRegularDayOff: false,
+              hasSale: false,
+              hasPurchase: false,
+              isMissing: true,
+              revenue: null,
+              netProfit: null,
+            },
+            {
+              date: "2026-06-02",
+              isFuture: false,
+              isBeforeSignup: false,
+              isRegularDayOff: false,
+              hasSale: true,
+              hasPurchase: true,
+              isMissing: false,
+              revenue: 45000,
+              netProfit: 20000,
+            },
+          ],
+          marginLabel: "43.9%",
+        },
+        error: null,
+      });
+
+      await expect(loadCalendarMonth({ rpc: {} }, 2026, 6)).resolves.toEqual({
+        year: 2026,
+        month: 6,
+        cumulative: {
+          totalRevenue: 123000,
+          totalNetProfit: 54000,
+          avgDailyRevenue: 17642.85,
+          operatingDays: 7,
+        },
+        cells: [
+          {
+            date: "2026-06-01",
+            isFuture: false,
+            isBeforeSignup: false,
+            isRegularDayOff: false,
+            hasSale: false,
+            hasPurchase: false,
+            isMissing: true,
+            revenue: null,
+            netProfit: null,
+            consecutiveMissingDays: 1,
+          },
+          {
+            date: "2026-06-02",
+            isFuture: false,
+            isBeforeSignup: false,
+            isRegularDayOff: false,
+            hasSale: true,
+            hasPurchase: true,
+            isMissing: false,
+            revenue: 45000,
+            netProfit: 20000,
+            consecutiveMissingDays: 0,
+          },
+        ],
+        marginLabel: "43.9%",
+      });
+    });
+  });
+
+  describe("dashboard", () => {
+    it("loadTodayDashboard returns data and throws on empty rpc", async () => {
+      rpcMocks.getTodayDashboard.mockResolvedValue({
+        data: {
+          storeName: "지영카페",
+          missingYesterdaySale: false,
+          yesterday: {
+            soldAt: "2026-06-01",
+            revenue: 22500,
+            netProfit: 18000,
+            marginPercent: 80,
+            lastWeekRevenue: 30000,
+            revenueChangePercent: -25,
+          },
+          weeklyChart: [{ soldAt: "2026-06-02", revenue: 22500 }],
+          expiryAlerts: [],
+          top3Menus: [],
+          lowMarginMenus: [],
+        },
+        error: null,
+      });
+
+      await expect(loadTodayDashboard({ rpc: {} })).resolves.toEqual({
+        storeName: "지영카페",
+        missingYesterdaySale: false,
+        yesterday: {
+          soldAt: "2026-06-01",
+          revenue: 22500,
+          netProfit: 18000,
+          marginPercent: 80,
+          lastWeekRevenue: 30000,
+          revenueChangePercent: -25,
+        },
+        weeklyChart: [{ soldAt: "2026-06-02", revenue: 22500 }],
+        expiryAlerts: [],
+        top3Menus: [],
+        lowMarginMenus: [],
+      });
+
+      rpcMocks.getTodayDashboard.mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      await expect(loadTodayDashboard({ rpc: {} })).rejects.toThrow("dashboard data missing");
+    });
+  });
+
+  describe("inventory", () => {
+    it("loadDepletionForecast maps rpc rows through forecastIngredient", async () => {
+      rpcMocks.getDepletionForecast.mockResolvedValue({
+        data: [
+          {
+            ingredientId: "ing-1",
+            name: "원두",
+            unit: "g",
+            currentStock: 1200,
+            leadTimeDays: 3,
+            consumptionSamples: [{ date: "2026-06-01", amount: 80 }],
+            signedUpAt: "2026-05-20T00:00:00.000Z",
+            regularDaysOff: ["SUN"],
+          },
+        ],
+        error: null,
+      });
+      forecastMocks.forecastIngredient.mockReturnValue({
+        expectedDepletionDate: new Date("2026-06-10T00:00:00.000Z"),
+        status: "caution",
+        trend: "rising",
+        isColdStart: false,
+      });
+
+      await expect(loadDepletionForecast({ rpc: {} })).resolves.toEqual([
+        {
+          ingredientId: "ing-1",
+          name: "원두",
+          unit: "g",
+          currentStock: 1200,
+          leadTimeDays: 3,
+          expectedDepletionDate: new Date("2026-06-10T00:00:00.000Z"),
+          status: "caution",
+          trend: "rising",
+          isColdStart: false,
+        },
+      ]);
+
+      expect(forecastMocks.forecastIngredient).toHaveBeenCalledWith({
+        currentStock: 1200,
+        leadTimeDays: 3,
+        consumptionSamples: [{ date: new Date("2026-06-01"), amount: 80 }],
+        daysOff: ["SUN"],
+        signupDate: new Date("2026-05-20T00:00:00.000Z"),
+        today: expect.any(Date),
+      });
+    });
+  });
+
+  describe("purchase", () => {
+    it("submitPurchase forwards payload and returns the rpc result", async () => {
+      rpcMocks.savePurchase.mockResolvedValue({
+        data: {
+          purchaseOrderId: "po-1",
+          priceChangeAlerts: [
+            {
+              ingredientId: "ing-1",
+              ingredientName: "원두",
+              previousAvgPrice: 100,
+              newAvgPrice: 120,
+              changePercent: 20,
+            },
+          ],
+        },
+        error: null,
+      });
+
+      await expect(
+        submitPurchase(
+          {
+            rpc: {},
+          },
+          {
+            vendorId: "vendor-1",
+            purchasedAt: "2026-06-02",
+            items: [{ ingredientId: "ing-1", quantity: 10, amount: 1200 }],
+          },
+        ),
+      ).resolves.toEqual({
+        purchaseOrderId: "po-1",
+        priceChangeAlerts: [
+          {
+            ingredientId: "ing-1",
+            ingredientName: "원두",
+            previousAvgPrice: 100,
+            newAvgPrice: 120,
+            changePercent: 20,
+          },
+        ],
+      });
+    });
+  });
+
+  describe("sale", () => {
+    it("submitSale and editSale map RPC rows", async () => {
+      rpcMocks.saveSale.mockResolvedValue({
+        data: [
+          {
+            sale_id: "sale-1",
+            total_revenue: 45000,
+            total_cost_snapshot: 18000,
+            total_net_profit: 27000,
+            margin_percent: 60,
+          },
+        ],
+        error: null,
+      });
+      rpcMocks.editSale.mockResolvedValue({
+        data: [
+          {
+            sale_id: "sale-1",
+            total_revenue: 48000,
+            total_cost_snapshot: 19000,
+            total_net_profit: 29000,
+            margin_percent: 60.42,
+          },
+        ],
+        error: null,
+      });
+
+      await expect(
+        submitSale(
+          { rpc: {} },
+          {
+            soldAt: "2026-06-02",
+            items: [{ menuId: "menu-1", quantity: 3 }],
+          },
+        ),
+      ).resolves.toEqual({
+        saleId: "sale-1",
+        totalRevenue: 45000,
+        totalCostSnapshot: 18000,
+        totalNetProfit: 27000,
+        marginPercent: 60,
+      });
+
+      await expect(
+        editSale(
+          { rpc: {} },
+          {
+            saleId: "sale-1",
+            newItems: [{ menuId: "menu-2", quantity: 4 }],
+            reason: "fix count",
+          },
+        ),
+      ).resolves.toEqual({
+        totalRevenue: 48000,
+        totalCostSnapshot: 19000,
+      });
+    });
+  });
+
+  describe("menu", () => {
+    it("createMenu, updateMenu, and removeMenu use rpc wrappers", async () => {
+      rpcMocks.saveMenu.mockResolvedValue({
+        data: [{ menu_id: "menu-1" }],
+        error: null,
+      });
+      rpcMocks.editMenu.mockResolvedValue({
+        data: [{ menu_id: "menu-1" }],
+        error: null,
+      });
+      rpcMocks.deleteMenu.mockResolvedValue({
+        data: [{ menu_id: "menu-1", was_active: false }],
+        error: null,
+      });
+
+      await expect(
+        createMenu(
+          { rpc: {} },
+          {
+            name: "아메리카노",
+            price: 4500,
+            recipe: [{ ingredientId: "ing-1", quantityPerServing: 18 }],
+          },
+        ),
+      ).resolves.toBe("menu-1");
+
+      await expect(
+        updateMenu(
+          { rpc: {} },
+          {
+            menuId: "menu-1",
+            name: "아이스 아메리카노",
+            price: 4800,
+            recipe: [{ ingredientId: "ing-1", quantityPerServing: 20 }],
+          },
+        ),
+      ).resolves.toBe("menu-1");
+
+      await expect(removeMenu({ rpc: {} }, "menu-1")).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
- Extracted shared Supabase RPC plumbing into `src/lib/supabase/rpc-core.ts`\n- Added unit coverage for the application layer wrappers and pure calendar enrichment logic\n- Kept `src/lib/supabase/rpc.ts` as the public adapter surface\n\nValidation:\n- npm run typecheck\n- npx vitest run tests/unit/application.test.ts\n- npm run format:check\n\nCloses #89