### PR TITLE
refactor: extract remaining query lookups

### DIFF
--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -19,7 +19,7 @@ export type { MenuRowWithRecipe } from "@/lib/application/lookups";
 export const menuListQueryKey = ["menus", "list"] as const;
 
 async function fetchMenus(): Promise<MenuRowWithRecipe[]> {
-  const supabase = createClient();
+  const supabase = createClient() as unknown as import("@/lib/application/lookups").LookupClient;
   return loadMenus(supabase);
 }
 

--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
+import { loadMenus, type MenuRowWithRecipe } from "@/lib/application/lookups";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 
 /**
@@ -13,73 +14,13 @@ import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepleti
  * nullable로 잡지만 fetch 시점에 좁힌다.
  */
 
-interface RawIngredient {
-  id: string;
-  name: string;
-  unit: string;
-  current_avg_price: number;
-}
-
-interface RawRecipeItem {
-  id: string;
-  quantity_per_serving: number;
-  ingredient: RawIngredient | null;
-}
-
-export interface MenuRowWithRecipe {
-  id: string;
-  name: string;
-  price: number;
-  is_active: boolean;
-  recipe_items: Array<{
-    id: string;
-    quantity_per_serving: number;
-    ingredient: RawIngredient;
-  }>;
-}
+export type { MenuRowWithRecipe } from "@/lib/application/lookups";
 
 export const menuListQueryKey = ["menus", "list"] as const;
 
-interface RawMenuRow {
-  id: string;
-  name: string;
-  price: number;
-  is_active: boolean;
-  recipe_items: RawRecipeItem[];
-}
-
 async function fetchMenus(): Promise<MenuRowWithRecipe[]> {
   const supabase = createClient();
-  const { data, error } = await supabase
-    .from("menus")
-    .select(
-      `
-      id, name, price, is_active,
-      recipe_items (
-        id,
-        quantity_per_serving,
-        ingredient:ingredients (
-          id, name, unit, current_avg_price
-        )
-      )
-    `,
-    )
-    .eq("is_active", true)
-    .order("name");
-
-  if (error) {
-    throw new Error(error.message);
-  }
-  const rows = (data ?? []) as unknown as RawMenuRow[];
-  return rows.map((menu) => ({
-    id: menu.id,
-    name: menu.name,
-    price: menu.price,
-    is_active: menu.is_active,
-    recipe_items: menu.recipe_items.filter(
-      (item): item is RawRecipeItem & { ingredient: RawIngredient } => item.ingredient !== null,
-    ),
-  }));
+  return loadMenus(supabase);
 }
 
 export function useMenus(): UseQueryResult<MenuRowWithRecipe[]> {

--- a/src/features/purchase/hooks/useIngredients.ts
+++ b/src/features/purchase/hooks/useIngredients.ts
@@ -8,7 +8,7 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { loadIngredients, type IngredientRow } from "@/lib/application/lookups";
+import { loadIngredients, type IngredientRow, type LookupClient } from "@/lib/application/lookups";
 import { deleteIngredient, saveIngredient } from "@/lib/supabase/rpc";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import type { IngredientInput } from "../schemas";
@@ -18,7 +18,8 @@ export type { IngredientRow } from "@/lib/application/lookups";
 export const ingredientListQueryKey = ["ingredients", "list"] as const;
 
 async function fetchIngredients(): Promise<IngredientRow[]> {
-  return loadIngredients(createClient() as any);
+  const supabase = createClient() as unknown as LookupClient;
+  return loadIngredients(supabase);
 }
 
 export function useIngredients(): UseQueryResult<IngredientRow[]> {

--- a/src/features/purchase/hooks/useIngredients.ts
+++ b/src/features/purchase/hooks/useIngredients.ts
@@ -8,36 +8,17 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
+import { loadIngredients, type IngredientRow } from "@/lib/application/lookups";
 import { deleteIngredient, saveIngredient } from "@/lib/supabase/rpc";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import type { IngredientInput } from "../schemas";
 
-export interface IngredientRow {
-  id: string;
-  name: string;
-  unit: "g" | "ml" | "piece";
-  current_avg_price: number;
-}
+export type { IngredientRow } from "@/lib/application/lookups";
 
 export const ingredientListQueryKey = ["ingredients", "list"] as const;
 
 async function fetchIngredients(): Promise<IngredientRow[]> {
-  const supabase = createClient();
-  const { data, error } = await supabase
-    .from("ingredients")
-    .select("id, name, unit, current_avg_price")
-    .eq("is_active", true)
-    .order("name");
-  if (error) throw new Error(error.message);
-  // supabase-js v2의 select 결과 타입 추론이 nested join + numeric 조합에서 흔들려
-  // 명시 캐스팅. numeric 컬럼은 PostgREST가 string으로 직렬화 → Number로 좁힘.
-  const rows = (data ?? []) as Array<
-    Omit<IngredientRow, "current_avg_price"> & { current_avg_price: string | number }
-  >;
-  return rows.map((row) => ({
-    ...row,
-    current_avg_price: Number(row.current_avg_price),
-  }));
+  return loadIngredients(createClient() as any);
 }
 
 export function useIngredients(): UseQueryResult<IngredientRow[]> {

--- a/src/features/purchase/hooks/useVendors.ts
+++ b/src/features/purchase/hooks/useVendors.ts
@@ -8,26 +8,17 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
+import { loadVendors, type VendorRow } from "@/lib/application/lookups";
 import { saveVendor } from "@/lib/supabase/rpc";
 import type { VendorInput } from "../schemas";
 
-export interface VendorRow {
-  id: string;
-  name: string;
-  lead_time_days: number;
-}
+export type { VendorRow } from "@/lib/application/lookups";
 
 export const vendorListQueryKey = ["vendors", "list"] as const;
 
 async function fetchVendors(): Promise<VendorRow[]> {
   const supabase = createClient();
-  const { data, error } = await supabase
-    .from("vendors")
-    .select("id, name, lead_time_days")
-    .eq("is_active", true)
-    .order("name");
-  if (error) throw new Error(error.message);
-  return data ?? [];
+  return loadVendors(supabase);
 }
 
 export function useVendors(): UseQueryResult<VendorRow[]> {

--- a/src/features/purchase/hooks/useVendors.ts
+++ b/src/features/purchase/hooks/useVendors.ts
@@ -8,7 +8,7 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { loadVendors, type VendorRow } from "@/lib/application/lookups";
+import { loadVendors, type LookupClient, type VendorRow } from "@/lib/application/lookups";
 import { saveVendor } from "@/lib/supabase/rpc";
 import type { VendorInput } from "../schemas";
 
@@ -17,7 +17,7 @@ export type { VendorRow } from "@/lib/application/lookups";
 export const vendorListQueryKey = ["vendors", "list"] as const;
 
 async function fetchVendors(): Promise<VendorRow[]> {
-  const supabase = createClient();
+  const supabase = createClient() as unknown as LookupClient;
   return loadVendors(supabase);
 }
 

--- a/src/features/sale/hooks/useSaleByDate.ts
+++ b/src/features/sale/hooks/useSaleByDate.ts
@@ -2,73 +2,18 @@
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
+import { loadSaleByDate, type SaleWithItems } from "@/lib/application/lookups";
 
 /**
  * 특정 날짜의 사용자 sale + items + 메뉴 join.
  * 편집 흐름에서 기존 데이터 prefill + 7일 lock 판단(created_at)에 사용.
  */
 
-export interface SaleWithItems {
-  id: string;
-  sold_at: string;
-  created_at: string;
-  total_revenue: number;
-  total_cost_snapshot: number;
-  items: Array<{
-    id: string;
-    menu_id: string;
-    quantity: number;
-    unit_price: number;
-    menu_cost_snapshot: number;
-  }>;
-}
-
-interface RawRow {
-  id: string;
-  sold_at: string;
-  created_at: string;
-  total_revenue: number;
-  total_cost_snapshot: number;
-  sale_items: Array<{
-    id: string;
-    menu_id: string;
-    quantity: number;
-    unit_price: number;
-    menu_cost_snapshot: number;
-  }>;
-}
+export type { SaleWithItems } from "@/lib/application/lookups";
 
 async function fetchSaleByDate(date: string): Promise<SaleWithItems | null> {
   const supabase = createClient();
-  const { data, error } = await supabase
-    .from("sales")
-    .select(
-      `
-      id, sold_at, created_at, total_revenue, total_cost_snapshot,
-      sale_items (id, menu_id, quantity, unit_price, menu_cost_snapshot)
-    `,
-    )
-    .eq("sold_at", date)
-    .maybeSingle();
-
-  if (error) throw new Error(error.message);
-  if (!data) return null;
-
-  const row = data as unknown as RawRow;
-  return {
-    id: row.id,
-    sold_at: row.sold_at,
-    created_at: row.created_at,
-    total_revenue: Number(row.total_revenue),
-    total_cost_snapshot: Number(row.total_cost_snapshot),
-    items: row.sale_items.map((si) => ({
-      id: si.id,
-      menu_id: si.menu_id,
-      quantity: si.quantity,
-      unit_price: Number(si.unit_price),
-      menu_cost_snapshot: Number(si.menu_cost_snapshot),
-    })),
-  };
+  return loadSaleByDate(supabase, date);
 }
 
 export function saleByDateQueryKey(date: string): readonly unknown[] {

--- a/src/features/sale/hooks/useSaleByDate.ts
+++ b/src/features/sale/hooks/useSaleByDate.ts
@@ -2,7 +2,7 @@
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { loadSaleByDate, type SaleWithItems } from "@/lib/application/lookups";
+import { loadSaleByDate, type LookupClient, type SaleWithItems } from "@/lib/application/lookups";
 
 /**
  * 특정 날짜의 사용자 sale + items + 메뉴 join.
@@ -12,7 +12,7 @@ import { loadSaleByDate, type SaleWithItems } from "@/lib/application/lookups";
 export type { SaleWithItems } from "@/lib/application/lookups";
 
 async function fetchSaleByDate(date: string): Promise<SaleWithItems | null> {
-  const supabase = createClient();
+  const supabase = createClient() as unknown as LookupClient;
   return loadSaleByDate(supabase, date);
 }
 

--- a/src/lib/application/lookups.ts
+++ b/src/lib/application/lookups.ts
@@ -1,0 +1,207 @@
+interface SupabaseLike {
+  from: (table: string) => {
+    select: (query: string) => {
+      eq: (
+        column: string,
+        value: unknown,
+      ) => {
+        order: (
+          column: string,
+        ) => PromiseLike<{ data: unknown[] | null; error: { message: string } | null }>;
+        maybeSingle: () => PromiseLike<{ data: unknown | null; error: { message: string } | null }>;
+      };
+    };
+  };
+}
+
+export interface MenuRowWithRecipe {
+  id: string;
+  name: string;
+  price: number;
+  is_active: boolean;
+  recipe_items: Array<{
+    id: string;
+    quantity_per_serving: number;
+    ingredient: {
+      id: string;
+      name: string;
+      unit: string;
+      current_avg_price: number;
+    };
+  }>;
+}
+
+interface RawIngredient {
+  id: string;
+  name: string;
+  unit: string;
+  current_avg_price: string | number;
+}
+
+interface RawRecipeItem {
+  id: string;
+  quantity_per_serving: number;
+  ingredient: RawIngredient | null;
+}
+
+interface RawMenuRow {
+  id: string;
+  name: string;
+  price: string | number;
+  is_active: boolean;
+  recipe_items: RawRecipeItem[];
+}
+
+export interface VendorRow {
+  id: string;
+  name: string;
+  lead_time_days: number;
+}
+
+export interface IngredientRow {
+  id: string;
+  name: string;
+  unit: "g" | "ml" | "piece";
+  current_avg_price: number;
+}
+
+export interface SaleWithItems {
+  id: string;
+  sold_at: string;
+  created_at: string;
+  total_revenue: number;
+  total_cost_snapshot: number;
+  items: Array<{
+    id: string;
+    menu_id: string;
+    quantity: number;
+    unit_price: number;
+    menu_cost_snapshot: number;
+  }>;
+}
+
+interface RawSaleRow {
+  id: string;
+  sold_at: string;
+  created_at: string;
+  total_revenue: string | number;
+  total_cost_snapshot: string | number;
+  sale_items: Array<{
+    id: string;
+    menu_id: string;
+    quantity: number;
+    unit_price: string | number;
+    menu_cost_snapshot: string | number;
+  }>;
+}
+
+export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe[]> {
+  const { data, error } = await client
+    .from("menus")
+    .select(
+      `
+      id, name, price, is_active,
+      recipe_items (
+        id,
+        quantity_per_serving,
+        ingredient:ingredients (
+          id, name, unit, current_avg_price
+        )
+      )
+    `,
+    )
+    .eq("is_active", true)
+    .order("name");
+
+  if (error) throw new Error(error.message);
+  const rows = (data ?? []) as RawMenuRow[];
+  return rows.map((menu) => ({
+    id: menu.id,
+    name: menu.name,
+    price: Number(menu.price),
+    is_active: menu.is_active,
+    recipe_items: menu.recipe_items
+      .filter(
+        (item): item is RawRecipeItem & { ingredient: RawIngredient } => item.ingredient !== null,
+      )
+      .map((item) => ({
+        id: item.id,
+        quantity_per_serving: item.quantity_per_serving,
+        ingredient: {
+          id: item.ingredient.id,
+          name: item.ingredient.name,
+          unit: item.ingredient.unit,
+          current_avg_price: Number(item.ingredient.current_avg_price),
+        },
+      })),
+  }));
+}
+
+export async function loadVendors(client: SupabaseLike): Promise<VendorRow[]> {
+  const { data, error } = await client
+    .from("vendors")
+    .select("id, name, lead_time_days")
+    .eq("is_active", true)
+    .order("name");
+  if (error) throw new Error(error.message);
+  return (
+    (data ?? []) as Array<Omit<VendorRow, "lead_time_days"> & { lead_time_days: string | number }>
+  ).map((row) => ({
+    id: row.id,
+    name: row.name,
+    lead_time_days: Number(row.lead_time_days),
+  }));
+}
+
+export async function loadIngredients(client: SupabaseLike): Promise<IngredientRow[]> {
+  const { data, error } = await client
+    .from("ingredients")
+    .select("id, name, unit, current_avg_price")
+    .eq("is_active", true)
+    .order("name");
+  if (error) throw new Error(error.message);
+  return (
+    (data ?? []) as Array<
+      Omit<IngredientRow, "current_avg_price"> & { current_avg_price: string | number }
+    >
+  ).map((row) => ({
+    id: row.id,
+    name: row.name,
+    unit: row.unit,
+    current_avg_price: Number(row.current_avg_price),
+  }));
+}
+
+export async function loadSaleByDate(
+  client: SupabaseLike,
+  date: string,
+): Promise<SaleWithItems | null> {
+  const { data, error } = await client
+    .from("sales")
+    .select(
+      `
+      id, sold_at, created_at, total_revenue, total_cost_snapshot,
+      sale_items (id, menu_id, quantity, unit_price, menu_cost_snapshot)
+    `,
+    )
+    .eq("sold_at", date)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+  const row = data as RawSaleRow;
+  return {
+    id: row.id,
+    sold_at: row.sold_at,
+    created_at: row.created_at,
+    total_revenue: Number(row.total_revenue),
+    total_cost_snapshot: Number(row.total_cost_snapshot),
+    items: row.sale_items.map((si) => ({
+      id: si.id,
+      menu_id: si.menu_id,
+      quantity: si.quantity,
+      unit_price: Number(si.unit_price),
+      menu_cost_snapshot: Number(si.menu_cost_snapshot),
+    })),
+  };
+}

--- a/src/lib/application/lookups.ts
+++ b/src/lib/application/lookups.ts
@@ -1,3 +1,6 @@
+type LookupRow = Record<string, never>;
+export type LookupClient = SupabaseLike;
+
 interface SupabaseLike {
   from: (table: string) => {
     select: (query: string) => {
@@ -7,8 +10,11 @@ interface SupabaseLike {
       ) => {
         order: (
           column: string,
-        ) => PromiseLike<{ data: unknown[] | null; error: { message: string } | null }>;
-        maybeSingle: () => PromiseLike<{ data: unknown | null; error: { message: string } | null }>;
+        ) => PromiseLike<{ data: LookupRow[] | null; error: { message: string } | null }>;
+        maybeSingle: () => PromiseLike<{
+          data: LookupRow | null;
+          error: { message: string } | null;
+        }>;
       };
     };
   };
@@ -114,7 +120,7 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
     .order("name");
 
   if (error) throw new Error(error.message);
-  const rows = (data ?? []) as RawMenuRow[];
+  const rows = (data ?? []) as unknown as RawMenuRow[];
   return rows.map((menu) => ({
     id: menu.id,
     name: menu.name,
@@ -145,7 +151,9 @@ export async function loadVendors(client: SupabaseLike): Promise<VendorRow[]> {
     .order("name");
   if (error) throw new Error(error.message);
   return (
-    (data ?? []) as Array<Omit<VendorRow, "lead_time_days"> & { lead_time_days: string | number }>
+    (data ?? []) as unknown as Array<
+      Omit<VendorRow, "lead_time_days"> & { lead_time_days: string | number }
+    >
   ).map((row) => ({
     id: row.id,
     name: row.name,
@@ -161,7 +169,7 @@ export async function loadIngredients(client: SupabaseLike): Promise<IngredientR
     .order("name");
   if (error) throw new Error(error.message);
   return (
-    (data ?? []) as Array<
+    (data ?? []) as unknown as Array<
       Omit<IngredientRow, "current_avg_price"> & { current_avg_price: string | number }
     >
   ).map((row) => ({
@@ -189,7 +197,7 @@ export async function loadSaleByDate(
 
   if (error) throw new Error(error.message);
   if (!data) return null;
-  const row = data as RawSaleRow;
+  const row = data as unknown as RawSaleRow;
   return {
     id: row.id,
     sold_at: row.sold_at,

--- a/tests/unit/query-lookups.test.ts
+++ b/tests/unit/query-lookups.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadIngredients, loadMenus, loadSaleByDate, loadVendors } from "@/lib/application/lookups";
+
+type RpcResponse<T> = {
+  data: T | null;
+  error: { message: string } | null;
+};
+
+function createClientMock(results: Record<string, RpcResponse<unknown>>) {
+  return {
+    from: vi.fn((table: string) => {
+      const response = results[table];
+      const chain: any = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => response),
+        maybeSingle: vi.fn(async () => response),
+      };
+      return chain;
+    }),
+  };
+}
+
+describe("query lookups", () => {
+  it("loadMenus maps nested ingredient rows", async () => {
+    const client = createClientMock({
+      menus: {
+        data: [
+          {
+            id: "menu-1",
+            name: "아메리카노",
+            price: "4500",
+            is_active: true,
+            recipe_items: [
+              {
+                id: "ri-1",
+                quantity_per_serving: 18,
+                ingredient: {
+                  id: "ing-1",
+                  name: "원두",
+                  unit: "g",
+                  current_avg_price: "50",
+                },
+              },
+              {
+                id: "ri-2",
+                quantity_per_serving: 10,
+                ingredient: null,
+              },
+            ],
+          },
+        ],
+        error: null,
+      },
+    });
+
+    await expect(loadMenus(client)).resolves.toEqual([
+      {
+        id: "menu-1",
+        name: "아메리카노",
+        price: 4500,
+        is_active: true,
+        recipe_items: [
+          {
+            id: "ri-1",
+            quantity_per_serving: 18,
+            ingredient: {
+              id: "ing-1",
+              name: "원두",
+              unit: "g",
+              current_avg_price: 50,
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("loadVendors normalizes numeric lead time", async () => {
+    const client = createClientMock({
+      vendors: {
+        data: [
+          {
+            id: "vendor-1",
+            name: "서울상사",
+            lead_time_days: "3",
+          },
+        ],
+        error: null,
+      },
+    });
+
+    await expect(loadVendors(client)).resolves.toEqual([
+      {
+        id: "vendor-1",
+        name: "서울상사",
+        lead_time_days: 3,
+      },
+    ]);
+  });
+
+  it("loadIngredients normalizes numeric average price", async () => {
+    const client = createClientMock({
+      ingredients: {
+        data: [
+          {
+            id: "ing-1",
+            name: "원두",
+            unit: "g",
+            current_avg_price: "52.5",
+          },
+        ],
+        error: null,
+      },
+    });
+
+    await expect(loadIngredients(client)).resolves.toEqual([
+      {
+        id: "ing-1",
+        name: "원두",
+        unit: "g",
+        current_avg_price: 52.5,
+      },
+    ]);
+  });
+
+  it("loadSaleByDate maps nested sale items and null stays null", async () => {
+    const client = createClientMock({
+      sales: {
+        data: {
+          id: "sale-1",
+          sold_at: "2026-06-02",
+          created_at: "2026-06-02T03:00:00.000Z",
+          total_revenue: "45000",
+          total_cost_snapshot: "18000",
+          sale_items: [
+            {
+              id: "si-1",
+              menu_id: "menu-1",
+              quantity: 3,
+              unit_price: "15000",
+              menu_cost_snapshot: "6000",
+            },
+          ],
+        },
+        error: null,
+      },
+    });
+
+    await expect(loadSaleByDate(client, "2026-06-02")).resolves.toEqual({
+      id: "sale-1",
+      sold_at: "2026-06-02",
+      created_at: "2026-06-02T03:00:00.000Z",
+      total_revenue: 45000,
+      total_cost_snapshot: 18000,
+      items: [
+        {
+          id: "si-1",
+          menu_id: "menu-1",
+          quantity: 3,
+          unit_price: 15000,
+          menu_cost_snapshot: 6000,
+        },
+      ],
+    });
+
+    const emptyClient = createClientMock({
+      sales: {
+        data: null,
+        error: null,
+      },
+    });
+
+    await expect(loadSaleByDate(emptyClient, "2026-06-03")).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
- Moved the remaining read-only query logic into `src/lib/application/lookups.ts`\n- Kept hooks as thin `useQuery` wrappers for menus, vendors, ingredients, and sale-by-date\n- Added unit tests for the new lookup mappings and null-handling paths\n\nValidation:\n- npm run format:check\n- npm run typecheck\n- npx vitest run tests/unit/query-lookups.test.ts tests/unit/application.test.ts\n\nCloses #93