### PR TITLE
feat: add inventory replay preview and apply RPCs

### DIFF
--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -3,7 +3,11 @@ import {
   type DailyConsumption,
   type ForecastResult,
 } from "@/lib/domain/forecast";
-import { getDepletionForecast } from "@/lib/supabase/rpc";
+import {
+  applyInventoryReplay as applyInventoryReplayRpc,
+  getDepletionForecast,
+  type ApplyInventoryReplayResult,
+} from "@/lib/supabase/rpc";
 
 interface RpcClient {
   rpc: unknown;
@@ -44,4 +48,19 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       ...forecast,
     };
   });
+}
+
+export interface ApplyInventoryReplayInput {
+  fromDate: string;
+  note?: string;
+}
+
+export async function applyInventoryReplay(
+  client: RpcClient,
+  input: ApplyInventoryReplayInput,
+): Promise<ApplyInventoryReplayResult> {
+  const { data, error } = await applyInventoryReplayRpc(client, input);
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("apply_inventory_replay: no row returned");
+  return data;
 }

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -283,6 +283,45 @@ export function applyStockCount(
   );
 }
 
+interface ApplyInventoryReplayArgs {
+  fromDate: string;
+  note?: string;
+}
+
+export interface ApplyInventoryReplayResult {
+  replayRunId: string;
+  affectedIngredientCount: number;
+  stockDeltaTotal: number;
+  avgPriceDeltaTotal: number;
+}
+
+interface ApplyInventoryReplayRawRow {
+  replay_run_id: string;
+  affected_ingredient_count: number;
+  stock_delta_total: number;
+  avg_price_delta_total: number;
+}
+
+export function applyInventoryReplay(
+  client: ClientLike,
+  args: ApplyInventoryReplayArgs,
+): Promise<RpcResult<ApplyInventoryReplayResult>> {
+  return callRpcSingleRow<ApplyInventoryReplayRawRow, ApplyInventoryReplayResult>(
+    client,
+    "apply_inventory_replay",
+    {
+      p_from_date: args.fromDate,
+      p_note: args.note ?? null,
+    },
+    (row) => ({
+      replayRunId: row.replay_run_id,
+      affectedIngredientCount: Number(row.affected_ingredient_count),
+      stockDeltaTotal: numeric(row.stock_delta_total),
+      avgPriceDeltaTotal: numeric(row.avg_price_delta_total),
+    }),
+  );
+}
+
 interface SubscribePushArgs {
   endpoint: string;
   keysP256dh: string;

--- a/supabase/migrations/031_inventory_replay_preview_rpc.sql
+++ b/supabase/migrations/031_inventory_replay_preview_rpc.sql
@@ -1,0 +1,290 @@
+-- Migration: inventory replay preview RPC
+--
+-- This is a read-only rehearsal step for historical recalculation. It enriches
+-- inventory_events with replay inputs and exposes a preview RPC that replays
+-- events from a business date without mutating ingredients or sales.
+
+create or replace function public.build_inventory_event_metadata(
+  p_reason public.price_history_reason,
+  p_reference_id uuid,
+  p_ingredient_id uuid,
+  p_quantity_delta numeric
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_purchase record;
+  v_stock_count record;
+  v_sale record;
+begin
+  if p_reason = 'purchase' then
+    select
+      poi.quantity,
+      poi.amount,
+      poi.unit_price,
+      po.purchased_at
+    into v_purchase
+    from public.purchase_order_items poi
+    join public.purchase_orders po on po.id = poi.purchase_order_id
+    where poi.purchase_order_id = p_reference_id
+      and poi.ingredient_id = p_ingredient_id
+      and abs(poi.quantity - p_quantity_delta) < 0.0005
+    order by poi.id
+    limit 1;
+
+    if found then
+      return jsonb_build_object(
+        'purchase_quantity', v_purchase.quantity,
+        'purchase_amount', v_purchase.amount,
+        'purchase_unit_price', v_purchase.unit_price,
+        'purchased_at', v_purchase.purchased_at
+      );
+    end if;
+  elsif p_reason = 'stock_count_correction' then
+    select
+      sci.actual_stock,
+      sci.system_stock_at_count,
+      dsc.counted_at
+    into v_stock_count
+    from public.stock_count_items sci
+    join public.daily_stock_counts dsc on dsc.id = sci.stock_count_id
+    where sci.stock_count_id = p_reference_id
+      and sci.ingredient_id = p_ingredient_id
+    order by sci.id
+    limit 1;
+
+    if found then
+      return jsonb_build_object(
+        'actual_stock', v_stock_count.actual_stock,
+        'system_stock_at_count', v_stock_count.system_stock_at_count,
+        'counted_at', v_stock_count.counted_at
+      );
+    end if;
+  elsif p_reason in ('sale_consumption', 'sale_edit_revert', 'sale_edit_apply') then
+    select s.sold_at
+    into v_sale
+    from public.sales s
+    where s.id = p_reference_id;
+
+    if found then
+      return jsonb_build_object('sold_at', v_sale.sold_at);
+    end if;
+  end if;
+
+  return '{}'::jsonb;
+end;
+$$;
+
+comment on function public.build_inventory_event_metadata(
+  public.price_history_reason,
+  uuid,
+  uuid,
+  numeric
+) is
+  'Builds replay metadata for an inventory event from its source domain record.';
+
+create or replace function public.mirror_price_history_to_inventory_events()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.inventory_events (
+    user_id,
+    ingredient_id,
+    effective_date,
+    occurred_at,
+    event_type,
+    reference_id,
+    price_history_id,
+    quantity_delta,
+    stock_before,
+    stock_after,
+    avg_price_before,
+    avg_price_after,
+    metadata
+  ) values (
+    new.user_id,
+    new.ingredient_id,
+    public.resolve_inventory_event_effective_date(new.reason, new.reference_id, new.changed_at),
+    new.changed_at,
+    new.reason::text::public.inventory_event_type,
+    new.reference_id,
+    new.id,
+    new.new_stock - new.previous_stock,
+    new.previous_stock,
+    new.new_stock,
+    new.previous_avg_price,
+    new.new_avg_price,
+    jsonb_build_object('source', 'ingredient_price_history')
+      || public.build_inventory_event_metadata(
+        new.reason,
+        new.reference_id,
+        new.ingredient_id,
+        new.new_stock - new.previous_stock
+      )
+  );
+
+  return new;
+end;
+$$;
+
+update public.inventory_events ie
+set metadata = ie.metadata
+  || public.build_inventory_event_metadata(
+    ph.reason,
+    ph.reference_id,
+    ph.ingredient_id,
+    ph.new_stock - ph.previous_stock
+  )
+from public.ingredient_price_history ph
+where ie.price_history_id = ph.id;
+
+create index inventory_events_user_replay_idx
+on public.inventory_events (user_id, effective_date, occurred_at, event_seq);
+
+create or replace function public.preview_inventory_replay(p_from_date date)
+returns table (
+  ingredient_id uuid,
+  ingredient_name text,
+  unit public.ingredient_unit,
+  replayed_stock numeric,
+  current_stock numeric,
+  stock_delta numeric,
+  replayed_avg_price numeric,
+  current_avg_price numeric,
+  avg_price_delta numeric,
+  event_count integer,
+  first_event_date date,
+  last_event_date date
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_event record;
+  v_state record;
+  v_next_stock numeric(12, 3);
+  v_next_avg numeric(12, 4);
+  v_purchase_unit_price numeric(12, 4);
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if p_from_date is null then
+    raise exception 'invalid_input: from_date is required' using errcode = '22023';
+  end if;
+
+  create temporary table if not exists inventory_replay_state (
+    ingredient_id uuid primary key,
+    replayed_stock numeric(12, 3) not null,
+    replayed_avg_price numeric(12, 4) not null,
+    event_count integer not null,
+    first_event_date date not null,
+    last_event_date date not null
+  ) on commit drop;
+
+  truncate table inventory_replay_state;
+
+  for v_event in
+    select *
+    from public.inventory_events ie
+    where ie.user_id = v_user_id
+      and ie.effective_date >= p_from_date
+    order by ie.ingredient_id, ie.effective_date, ie.occurred_at, ie.event_seq
+  loop
+    select *
+    into v_state
+    from inventory_replay_state s
+    where s.ingredient_id = v_event.ingredient_id;
+
+    if not found then
+      insert into inventory_replay_state (
+        ingredient_id,
+        replayed_stock,
+        replayed_avg_price,
+        event_count,
+        first_event_date,
+        last_event_date
+      ) values (
+        v_event.ingredient_id,
+        v_event.stock_before,
+        v_event.avg_price_before,
+        0,
+        v_event.effective_date,
+        v_event.effective_date
+      );
+
+      select *
+      into v_state
+      from inventory_replay_state s
+      where s.ingredient_id = v_event.ingredient_id;
+    end if;
+
+    if v_event.event_type = 'purchase' then
+      v_purchase_unit_price := nullif(v_event.metadata ->> 'purchase_unit_price', '')::numeric;
+      if v_purchase_unit_price is null then
+        v_purchase_unit_price := v_event.avg_price_after;
+      end if;
+
+      v_next_stock := v_state.replayed_stock + v_event.quantity_delta;
+      if v_state.replayed_stock = 0 then
+        v_next_avg := v_purchase_unit_price;
+      elsif v_next_stock = 0 then
+        v_next_avg := v_purchase_unit_price;
+      else
+        v_next_avg := (
+          v_state.replayed_stock * v_state.replayed_avg_price
+          + v_event.quantity_delta * v_purchase_unit_price
+        ) / v_next_stock;
+      end if;
+    elsif v_event.event_type = 'stock_count_correction' then
+      v_next_stock := v_event.stock_after;
+      v_next_avg := v_state.replayed_avg_price;
+    else
+      v_next_stock := v_state.replayed_stock + v_event.quantity_delta;
+      v_next_avg := v_state.replayed_avg_price;
+    end if;
+
+    update inventory_replay_state as state
+    set replayed_stock = v_next_stock,
+        replayed_avg_price = v_next_avg,
+        event_count = state.event_count + 1,
+        last_event_date = v_event.effective_date
+    where state.ingredient_id = v_event.ingredient_id;
+  end loop;
+
+  return query
+  select
+    i.id,
+    i.name,
+    i.unit,
+    s.replayed_stock,
+    i.current_stock,
+    s.replayed_stock - i.current_stock,
+    s.replayed_avg_price,
+    i.current_avg_price,
+    s.replayed_avg_price - i.current_avg_price,
+    s.event_count,
+    s.first_event_date,
+    s.last_event_date
+  from inventory_replay_state s
+  join public.ingredients i on i.id = s.ingredient_id
+  where i.user_id = v_user_id
+  order by i.name;
+end;
+$$;
+
+comment on function public.preview_inventory_replay(date) is
+  'Read-only inventory replay preview from a business date. Does not mutate ingredients or historical sales.';
+
+revoke all on function public.preview_inventory_replay(date) from public;
+grant execute on function public.preview_inventory_replay(date) to authenticated;

--- a/supabase/migrations/032_apply_inventory_replay_rpc.sql
+++ b/supabase/migrations/032_apply_inventory_replay_rpc.sql
@@ -1,0 +1,164 @@
+-- Migration: apply inventory replay RPC
+--
+-- Applies the read-only replay result to ingredients.current_stock/current_avg_price
+-- and records an audit trail. Historical sale snapshots are intentionally not
+-- rewritten in this step.
+
+create table public.inventory_replay_runs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  from_date date not null,
+  applied_at timestamptz not null default now(),
+  affected_ingredient_count integer not null default 0,
+  note text,
+
+  constraint inventory_replay_runs_affected_nonneg check (affected_ingredient_count >= 0)
+);
+
+comment on table public.inventory_replay_runs is
+  'Audit header for applied inventory replay runs.';
+comment on column public.inventory_replay_runs.from_date is
+  'Business date from which inventory_events were replayed.';
+
+create table public.inventory_replay_run_items (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references public.inventory_replay_runs (id) on delete cascade,
+  user_id uuid not null references public.users (id) on delete cascade,
+  ingredient_id uuid not null references public.ingredients (id) on delete cascade,
+  previous_stock numeric(12, 3) not null,
+  applied_stock numeric(12, 3) not null,
+  stock_delta numeric(12, 3) not null,
+  previous_avg_price numeric(12, 4) not null,
+  applied_avg_price numeric(12, 4) not null,
+  avg_price_delta numeric(12, 4) not null,
+  event_count integer not null,
+  first_event_date date not null,
+  last_event_date date not null,
+
+  constraint inventory_replay_run_items_event_count_positive check (event_count > 0),
+  constraint inventory_replay_run_items_unique_ingredient unique (run_id, ingredient_id)
+);
+
+comment on table public.inventory_replay_run_items is
+  'Per-ingredient before/after audit rows for an applied inventory replay run.';
+
+create index inventory_replay_runs_user_applied_idx
+on public.inventory_replay_runs (user_id, applied_at desc);
+
+create index inventory_replay_run_items_run_idx
+on public.inventory_replay_run_items (run_id);
+
+alter table public.inventory_replay_runs enable row level security;
+alter table public.inventory_replay_run_items enable row level security;
+
+create policy inventory_replay_runs_isolated
+on public.inventory_replay_runs
+for select
+using (auth.uid() = user_id);
+
+create policy inventory_replay_run_items_isolated
+on public.inventory_replay_run_items
+for select
+using (auth.uid() = user_id);
+
+grant select on public.inventory_replay_runs to authenticated;
+grant select on public.inventory_replay_run_items to authenticated;
+
+create or replace function public.apply_inventory_replay(
+  p_from_date date,
+  p_note text default null
+)
+returns table (
+  replay_run_id uuid,
+  affected_ingredient_count integer,
+  stock_delta_total numeric,
+  avg_price_delta_total numeric
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_run_id uuid;
+  v_preview record;
+  v_affected_count integer := 0;
+  v_stock_delta_total numeric(14, 3) := 0;
+  v_avg_price_delta_total numeric(14, 4) := 0;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if p_from_date is null then
+    raise exception 'invalid_input: from_date is required' using errcode = '22023';
+  end if;
+
+  insert into public.inventory_replay_runs (user_id, from_date, note)
+  values (v_user_id, p_from_date, nullif(btrim(p_note), ''))
+  returning id into v_run_id;
+
+  for v_preview in
+    select *
+    from public.preview_inventory_replay(p_from_date)
+    where stock_delta <> 0
+       or avg_price_delta <> 0
+    order by ingredient_name
+  loop
+    insert into public.inventory_replay_run_items (
+      run_id,
+      user_id,
+      ingredient_id,
+      previous_stock,
+      applied_stock,
+      stock_delta,
+      previous_avg_price,
+      applied_avg_price,
+      avg_price_delta,
+      event_count,
+      first_event_date,
+      last_event_date
+    ) values (
+      v_run_id,
+      v_user_id,
+      v_preview.ingredient_id,
+      v_preview.current_stock,
+      v_preview.replayed_stock,
+      v_preview.stock_delta,
+      v_preview.current_avg_price,
+      v_preview.replayed_avg_price,
+      v_preview.avg_price_delta,
+      v_preview.event_count,
+      v_preview.first_event_date,
+      v_preview.last_event_date
+    );
+
+    update public.ingredients
+    set current_stock = v_preview.replayed_stock,
+        current_avg_price = v_preview.replayed_avg_price,
+        updated_at = now()
+    where id = v_preview.ingredient_id
+      and user_id = v_user_id;
+
+    v_affected_count := v_affected_count + 1;
+    v_stock_delta_total := v_stock_delta_total + v_preview.stock_delta;
+    v_avg_price_delta_total := v_avg_price_delta_total + v_preview.avg_price_delta;
+  end loop;
+
+  update public.inventory_replay_runs
+  set affected_ingredient_count = v_affected_count
+  where id = v_run_id;
+
+  return query select
+    v_run_id,
+    v_affected_count,
+    v_stock_delta_total,
+    v_avg_price_delta_total;
+end;
+$$;
+
+comment on function public.apply_inventory_replay(date, text) is
+  'Applies inventory replay preview to ingredients current stock/average cost and writes audit rows. Does not rewrite sale snapshots.';
+
+revoke all on function public.apply_inventory_replay(date, text) from public;
+grant execute on function public.apply_inventory_replay(date, text) to authenticated;

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -4,6 +4,7 @@ const rpcMocks = vi.hoisted(() => ({
   getCalendarMonth: vi.fn(),
   getTodayDashboard: vi.fn(),
   getDepletionForecast: vi.fn(),
+  applyInventoryReplay: vi.fn(),
   savePurchase: vi.fn(),
   saveSale: vi.fn(),
   editSale: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("@/lib/supabase/rpc", () => ({
   getCalendarMonth: rpcMocks.getCalendarMonth,
   getTodayDashboard: rpcMocks.getTodayDashboard,
   getDepletionForecast: rpcMocks.getDepletionForecast,
+  applyInventoryReplay: rpcMocks.applyInventoryReplay,
   savePurchase: rpcMocks.savePurchase,
   saveSale: rpcMocks.saveSale,
   editSale: rpcMocks.editSale,
@@ -42,7 +44,7 @@ vi.mock("@/lib/domain/forecast", async () => {
 import { createMenu, removeMenu, updateMenu } from "@/lib/application/menu";
 import { loadTodayDashboard } from "@/lib/application/dashboard";
 import { loadCalendarMonth, withConsecutiveMissingDays } from "@/lib/application/calendar";
-import { loadDepletionForecast } from "@/lib/application/inventory";
+import { applyInventoryReplay, loadDepletionForecast } from "@/lib/application/inventory";
 import { submitPurchase } from "@/lib/application/purchase";
 import { editSale, submitSale } from "@/lib/application/sale";
 
@@ -269,6 +271,33 @@ describe("application layer", () => {
         daysOff: ["SUN"],
         signupDate: new Date("2026-05-20T00:00:00.000Z"),
         today: expect.any(Date),
+      });
+    });
+
+    it("applyInventoryReplay returns applied replay summary", async () => {
+      rpcMocks.applyInventoryReplay.mockResolvedValue({
+        data: {
+          replayRunId: "run-1",
+          affectedIngredientCount: 2,
+          stockDeltaTotal: -120,
+          avgPriceDeltaTotal: 15.5,
+        },
+        error: null,
+      });
+
+      await expect(
+        applyInventoryReplay(
+          { rpc: {} },
+          {
+            fromDate: "2026-06-01",
+            note: "관리자 재계산",
+          },
+        ),
+      ).resolves.toEqual({
+        replayRunId: "run-1",
+        affectedIngredientCount: 2,
+        stockDeltaTotal: -120,
+        avgPriceDeltaTotal: 15.5,
       });
     });
   });


### PR DESCRIPTION
## Summary
- Add read-only inventory replay preview RPC from a business date
- Enrich inventory event metadata with purchase, stock-count, and sale replay inputs
- Add apply_inventory_replay RPC to update ingredients current stock/average cost from replayed values
- Add replay run audit tables and TypeScript RPC/application wrappers

## Notes
- This applies recalculated ingredient current_stock/current_avg_price only.
- It intentionally does not rewrite historical sale item snapshots in this PR.
- apply_inventory_replay writes inventory_replay_runs and inventory_replay_run_items audit rows.

## Validation
- git diff --check
- npm run typecheck
- npx vitest run tests/unit/application.test.ts
- npm run lint
- npm run format:check
- npm run build

Closes #101