### PR TITLE
feat: add settings entry skeleton

### DIFF
--- a/src/app/(main)/today/page.tsx
+++ b/src/app/(main)/today/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Settings } from "lucide-react";
 import { useTodayDashboard } from "@/features/dashboard/hooks/useTodayDashboard";
 import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
 import { YesterdayKpiCard } from "@/features/dashboard/components/YesterdayKpiCard";
@@ -10,6 +11,7 @@ import { MarginTop3Card } from "@/features/dashboard/components/MarginTop3Card";
 import { MissingSaleBadge } from "@/features/dashboard/components/MissingSaleBadge";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { formatTodayKo } from "@/lib/utils/format";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
 /**
  * 홈 (오늘) 대시보드 — patterns.md "홈" 위계 순서대로 렌더.
@@ -61,7 +63,19 @@ export default function TodayPage(): React.ReactElement {
           <h1 className="text-title-lg text-ink-1">{data.storeName}</h1>
           <p className="text-caption text-ink-3">{todayLabel}</p>
         </div>
-        {data.missingYesterdaySale && <MissingSaleBadge yesterdaySoldAt={data.yesterday.soldAt} />}
+        <div className="flex items-center gap-stack-tight">
+          {data.missingYesterdaySale && (
+            <MissingSaleBadge yesterdaySoldAt={data.yesterday.soldAt} />
+          )}
+          <Link
+            href="/settings"
+            aria-label="가게 설정"
+            title="가게 설정"
+            className={`${SECONDARY_BUTTON_CLASSES} flex h-11 w-11 items-center justify-center px-0`}
+          >
+            <Settings size={18} aria-hidden="true" />
+          </Link>
+        </div>
       </header>
 
       <YesterdayKpiCard yesterday={data.yesterday} weeklyChart={data.weeklyChart} />

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,8 +1,12 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { STORE_TYPE_LABELS } from "@/features/auth/schemas";
 import { RegularDaysOffEditor } from "@/features/settings/components/RegularDaysOffEditor";
 import type { Weekday } from "@/lib/domain/regular-days-off";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
+
+type StoreType = keyof typeof STORE_TYPE_LABELS;
 
 export default async function SettingsPage(): Promise<React.ReactElement> {
   const supabase = await createClient();
@@ -16,23 +20,136 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
 
   const { data } = await supabase
     .from("users")
-    .select("regular_days_off")
+    .select("store_name, store_type, regular_days_off")
     .eq("id", user.id)
     .maybeSingle();
 
-  const profile = data as { regular_days_off: Weekday[] } | null;
+  const profile = data as {
+    store_name: string;
+    store_type: StoreType;
+    regular_days_off: Weekday[];
+  } | null;
   const initialDaysOff: Weekday[] = profile?.regular_days_off ?? [];
+  const storeName = profile?.store_name ?? "내 가게";
+  const storeType = profile?.store_type ?? "cafe";
 
   return (
     <main className="mx-auto flex min-h-screen max-w-screen-md flex-col gap-section p-screen pb-20">
       <header className="flex items-center justify-between">
-        <h1 className="text-title-lg text-ink-1">가게 설정</h1>
+        <div className="flex flex-col gap-1">
+          <p className="text-micro text-ink-3">설정</p>
+          <h1 className="text-title-lg text-ink-1">가게 설정</h1>
+        </div>
         <Link href="/today" className="text-body-regular text-ink-3 hover:text-ink-2">
           닫기
         </Link>
       </header>
 
-      <RegularDaysOffEditor initialDaysOff={initialDaysOff} />
+      <section className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
+        <header className="flex flex-col gap-1">
+          <h2 className="text-title-md text-ink-1">가게 정보</h2>
+          <p className="text-caption text-ink-3">
+            매장 이름과 가게 유형처럼 홈 화면과 리포트에 바로 보이는 정보입니다.
+          </p>
+        </header>
+
+        <SettingRow label="가게 이름" value={storeName} />
+        <SettingRow label="가게 유형" value={STORE_TYPE_LABELS[storeType]} />
+        <SettingRow label="로그인 이메일" value={user.email ?? "이메일 없음"} />
+
+        <div className="flex flex-wrap gap-stack-tight pt-2">
+          <button type="button" disabled className={`${SECONDARY_BUTTON_CLASSES} opacity-50`}>
+            가게 이름 변경
+          </button>
+          <button type="button" disabled className={`${SECONDARY_BUTTON_CLASSES} opacity-50`}>
+            가게 유형 관리
+          </button>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
+        <header className="flex flex-col gap-1">
+          <h2 className="text-title-md text-ink-1">예측 · 운영 설정</h2>
+          <p className="text-caption text-ink-3">
+            소진 예측과 운영 알림에 직접 영향을 주는 값입니다.
+          </p>
+        </header>
+
+        <RegularDaysOffEditor initialDaysOff={initialDaysOff} />
+
+        <div className="grid gap-stack-tight border-t border-border pt-stack">
+          <SettingRow
+            label="거래처 리드타임"
+            value="각 재료 예측은 가장 자주 쓰는 거래처 리드타임을 사용합니다."
+          />
+          <div className="flex flex-wrap gap-stack-tight">
+            <Link href="/purchase" className={SECONDARY_BUTTON_CLASSES}>
+              거래처 관리로 이동
+            </Link>
+            <button type="button" disabled className={`${SECONDARY_BUTTON_CLASSES} opacity-50`}>
+              안전여유일 설정
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-stack rounded-lg border border-border bg-card p-tile">
+        <header className="flex flex-col gap-1">
+          <h2 className="text-title-md text-ink-1">계정</h2>
+          <p className="text-caption text-ink-3">
+            로그인 상태와 알림, 계정 접근을 관리하는 영역입니다.
+          </p>
+        </header>
+
+        <SettingRow
+          label="로그아웃"
+          value="다음 단계에서 현재 기기 로그아웃과 세션 정리를 연결합니다."
+        />
+        <SettingRow
+          label="푸시 알림"
+          value="주문 알림과 마감 리마인더를 받을 기기 설정을 여기에 붙일 예정입니다."
+        />
+      </section>
+
+      <section className="flex flex-col gap-stack rounded-lg border border-red-soft bg-red-soft p-tile">
+        <header className="flex flex-col gap-1">
+          <h2 className="text-title-md text-red-deep">위험영역</h2>
+          <p className="text-caption text-red-deep">
+            되돌리기 어려운 작업은 별도 확인 단계를 붙여서 배치할 예정입니다.
+          </p>
+        </header>
+
+        <SettingRow
+          label="탈퇴 신청"
+          value="탈퇴를 신청하면 30일 후 영구 삭제됩니다. 다음 단계에서 안내와 확인 모달을 연결합니다."
+          tone="danger"
+        />
+      </section>
     </main>
+  );
+}
+
+function SettingRow({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string;
+  value: string;
+  tone?: "default" | "danger";
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1 rounded-md bg-bg px-stack py-stack-tight">
+      <p className={tone === "danger" ? "text-label text-red-deep" : "text-label text-ink-2"}>
+        {label}
+      </p>
+      <p
+        className={
+          tone === "danger" ? "text-body-regular text-red-deep" : "text-body-regular text-ink-1"
+        }
+      >
+        {value}
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a settings entry button to the today dashboard header
- expand the settings page into a first-step skeleton for store info, forecast settings, account, and danger zone
- keep follow-up actions visible as disabled placeholders so the next settings work can attach cleanly

## Testing
- npm run format:check
- npm run typecheck