### PR TITLE
feat: wire settings actions

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,9 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { STORE_TYPE_LABELS } from "@/features/auth/schemas";
+import { LogoutButton } from "@/features/settings/components/LogoutButton";
 import { RegularDaysOffEditor } from "@/features/settings/components/RegularDaysOffEditor";
+import { StoreNameEditor } from "@/features/settings/components/StoreNameEditor";
 import type { Weekday } from "@/lib/domain/regular-days-off";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
@@ -53,14 +55,11 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
           </p>
         </header>
 
-        <SettingRow label="가게 이름" value={storeName} />
+        <StoreNameEditor initialStoreName={storeName} userId={user.id} />
         <SettingRow label="가게 유형" value={STORE_TYPE_LABELS[storeType]} />
         <SettingRow label="로그인 이메일" value={user.email ?? "이메일 없음"} />
 
         <div className="flex flex-wrap gap-stack-tight pt-2">
-          <button type="button" disabled className={`${SECONDARY_BUTTON_CLASSES} opacity-50`}>
-            가게 이름 변경
-          </button>
           <button type="button" disabled className={`${SECONDARY_BUTTON_CLASSES} opacity-50`}>
             가게 유형 관리
           </button>
@@ -103,8 +102,9 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
 
         <SettingRow
           label="로그아웃"
-          value="다음 단계에서 현재 기기 로그아웃과 세션 정리를 연결합니다."
+          value="현재 기기 세션을 종료하고 로그인 화면으로 돌아갑니다."
         />
+        <LogoutButton />
         <SettingRow
           label="푸시 알림"
           value="주문 알림과 마감 리마인더를 받을 기기 설정을 여기에 붙일 예정입니다."

--- a/src/features/settings/components/LogoutButton.tsx
+++ b/src/features/settings/components/LogoutButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
+import { createClient } from "@/lib/supabase/client";
+
+export function LogoutButton(): React.ReactElement {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleLogout(): Promise<void> {
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    const supabase = createClient();
+    const { error } = await supabase.auth.signOut();
+
+    if (error) {
+      setErrorMessage(error.message);
+      setIsSubmitting(false);
+      return;
+    }
+
+    queryClient.clear();
+    router.replace("/login");
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col gap-stack-tight">
+      <button
+        type="button"
+        onClick={() => void handleLogout()}
+        disabled={isSubmitting}
+        className={`${SECONDARY_BUTTON_CLASSES} w-fit disabled:opacity-50`}
+      >
+        {isSubmitting ? "로그아웃 중..." : "로그아웃"}
+      </button>
+      {errorMessage && (
+        <p role="alert" className="text-caption text-red">
+          로그아웃 실패: {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/settings/components/RegularDaysOffEditor.tsx
+++ b/src/features/settings/components/RegularDaysOffEditor.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
-import { createClient } from "@/lib/supabase/client";
-import { updateRegularDaysOff } from "@/lib/supabase/rpc";
 import { WEEKDAYS, WEEKDAY_LABELS } from "@/features/auth/schemas";
+import { useUpdateRegularDaysOff } from "@/features/settings/hooks/useSettingsMutations";
 import type { Weekday } from "@/lib/domain/regular-days-off";
 import { cn } from "@/lib/utils";
 
@@ -16,9 +16,11 @@ type SaveStatus = "idle" | "saving" | "saved" | "error";
 export function RegularDaysOffEditor({
   initialDaysOff,
 }: RegularDaysOffEditorProps): React.ReactElement {
+  const router = useRouter();
   const [selected, setSelected] = useState<Set<Weekday>>(() => new Set(initialDaysOff));
   const [status, setStatus] = useState<SaveStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const mutation = useUpdateRegularDaysOff();
 
   // 빠른 연속 토글 시 늦게 도착한 응답이 최신 상태를 덮어쓰지 않도록 monotonic id로 가드.
   const latestRequestId = useRef(0);
@@ -40,17 +42,19 @@ export function RegularDaysOffEditor({
     setErrorMessage(null);
 
     const payload = WEEKDAYS.filter((d) => next.has(d));
-    const supabase = createClient();
-    const { error } = await updateRegularDaysOff(supabase, { p_days_off: payload });
+    try {
+      await mutation.mutateAsync({ daysOff: payload });
+    } catch (error) {
+      if (requestId !== latestRequestId.current) return;
+      setStatus("error");
+      setErrorMessage(error instanceof Error ? error.message : "알 수 없는 오류");
+      return;
+    }
 
     if (requestId !== latestRequestId.current) return;
 
-    if (error) {
-      setStatus("error");
-      setErrorMessage(error.message);
-      return;
-    }
     setStatus("saved");
+    router.refresh();
   }
 
   return (

--- a/src/features/settings/components/StoreNameEditor.tsx
+++ b/src/features/settings/components/StoreNameEditor.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { useUpdateStoreName } from "@/features/settings/hooks/useSettingsMutations";
+
+const storeNameSchema = z.object({
+  storeName: z
+    .string()
+    .trim()
+    .min(1, "가게 이름을 입력해주세요")
+    .max(50, "가게 이름은 50자 이내로 입력해주세요"),
+});
+
+type StoreNameFormInput = z.infer<typeof storeNameSchema>;
+
+interface StoreNameEditorProps {
+  initialStoreName: string;
+  userId: string;
+}
+
+export function StoreNameEditor({
+  initialStoreName,
+  userId,
+}: StoreNameEditorProps): React.ReactElement {
+  const router = useRouter();
+  const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+  const mutation = useUpdateStoreName();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isDirty },
+    reset,
+  } = useForm<StoreNameFormInput>({
+    resolver: zodResolver(storeNameSchema),
+    defaultValues: { storeName: initialStoreName },
+  });
+
+  async function onSubmit(values: StoreNameFormInput): Promise<void> {
+    setSubmitMessage(null);
+
+    try {
+      const nextStoreName = await mutation.mutateAsync({
+        userId,
+        storeName: values.storeName.trim(),
+      });
+      reset({ storeName: nextStoreName });
+      setSubmitMessage("가게 이름을 저장했어요.");
+      router.refresh();
+    } catch (error) {
+      setSubmitMessage(error instanceof Error ? error.message : "가게 이름 저장에 실패했어요.");
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(event) => void handleSubmit(onSubmit)(event)}
+      className="flex flex-col gap-stack"
+      noValidate
+    >
+      <Field label="가게 이름" error={errors.storeName?.message}>
+        <input
+          {...register("storeName")}
+          type="text"
+          maxLength={50}
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+        />
+      </Field>
+
+      <div className="flex items-center gap-stack-tight">
+        <PrimaryButton type="submit" disabled={isSubmitting || !isDirty}>
+          {isSubmitting ? "저장 중..." : "가게 이름 저장"}
+        </PrimaryButton>
+        {submitMessage && (
+          <p
+            role="status"
+            className={mutation.isError ? "text-caption text-red" : "text-caption text-green"}
+          >
+            {submitMessage}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/features/settings/hooks/useSettingsMutations.ts
+++ b/src/features/settings/hooks/useSettingsMutations.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/client";
+import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
+import { todayDashboardQueryKey } from "@/features/dashboard/hooks/useTodayDashboard";
+import type { Weekday } from "@/lib/domain/regular-days-off";
+import { updateRegularDaysOff } from "@/lib/supabase/rpc";
+import type { Database } from "@/lib/supabase/types";
+
+interface UpdateStoreNameInput {
+  userId: string;
+  storeName: string;
+}
+
+interface UpdateRegularDaysOffInput {
+  daysOff: readonly Weekday[];
+}
+
+export async function invalidateSettingsRelatedQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: todayDashboardQueryKey }),
+    queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey }),
+    queryClient.invalidateQueries({ queryKey: ["calendar"] }),
+  ]);
+}
+
+async function updateStoreName(input: UpdateStoreNameInput): Promise<string> {
+  const supabase = createClient() as unknown as SupabaseClient<Database>;
+  const { data, error } = await supabase
+    .from("users")
+    .update({ store_name: input.storeName })
+    .eq("id", input.userId)
+    .select("store_name")
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data?.store_name) throw new Error("가게 이름 저장 결과가 비어 있습니다.");
+  return data.store_name;
+}
+
+async function persistRegularDaysOff(
+  input: UpdateRegularDaysOffInput,
+): Promise<readonly Weekday[]> {
+  const supabase = createClient();
+  const { data, error } = await updateRegularDaysOff(supabase, {
+    p_days_off: input.daysOff,
+  });
+
+  if (error) throw new Error(error.message);
+  return data?.[0]?.days_off ?? input.daysOff;
+}
+
+export function useUpdateStoreName(): UseMutationResult<string, Error, UpdateStoreNameInput> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateStoreName,
+    onSuccess: async () => {
+      await invalidateSettingsRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function useUpdateRegularDaysOff(): UseMutationResult<
+  readonly Weekday[],
+  Error,
+  UpdateRegularDaysOffInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: persistRegularDaysOff,
+    onSuccess: async () => {
+      await invalidateSettingsRelatedQueries(queryClient);
+    },
+  });
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -4,6 +4,8 @@ import type { Database } from "./types";
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
 
-export function createClient(): ReturnType<typeof createBrowserClient<Database>> {
+type BrowserSupabaseClient = ReturnType<typeof createBrowserClient<Database>>;
+
+export function createClient(): BrowserSupabaseClient {
   return createBrowserClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
 }


### PR DESCRIPTION
## Summary
- add a real store-name editor to settings
- invalidate dashboard, calendar, and forecast data when regular days off or store settings change
- connect logout so the current device session and client cache are cleared cleanly

## Testing
- npm run format:check
- npm run typecheck
- npm run lint