### PR TITLE
feat: add forecast safety buffer setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ specs/001-mvp-core/        spec.md / data-model.md / contracts / tasks.md
 
 1. **서버에서 raw 데이터 수집**
    - [021_get_depletion_forecast_rpc.sql](/Users/yamon/Desktop/projects/ezstock/supabase/migrations/021_get_depletion_forecast_rpc.sql)
-   - 각 재료별로 `current_stock`, `signed_up_at`, `regular_days_off`, 최근 30일 `consumption_samples`를 반환합니다.
+   - 각 재료별로 `current_stock`, `signed_up_at`, `regular_days_off`, `safety_buffer_days`, 최근 30일 `consumption_samples`를 반환합니다.
    - `consumption_samples`는 `sale_items.quantity × recipe_items.quantity_per_serving`를 날짜별로 합산한 값입니다.
    - 거래처 리드타임은 해당 재료에 대해 **가장 자주 사용한 vendor의 리드타임**을 쓰고, 이력이 없으면 기본 `1일`을 사용합니다.
 
@@ -130,7 +130,8 @@ specs/001-mvp-core/        spec.md / data-model.md / contracts / tasks.md
 
 5. **리드타임 + 안전여유 1일로 상태 분류**
    - [forecast.ts](/Users/yamon/Desktop/projects/ezstock/src/lib/domain/forecast.ts)
-   - 소진일까지 남은 일수에서 `거래처 리드타임 + 안전여유 1일`을 뺀 `buffer`로 상태를 나눕니다.
+   - 소진일까지 남은 일수에서 `거래처 리드타임 + 설정된 안전여유일`을 뺀 `buffer`로 상태를 나눕니다.
+   - 기본값은 `안전여유 1일`이고, 설정 화면에서 `0~7일` 범위로 조정할 수 있습니다.
    - `critical`: buffer ≤ 1
    - `order_needed`: buffer = 2
    - `caution`: buffer 3~4

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { STORE_TYPE_LABELS } from "@/features/auth/schemas";
 import { LogoutButton } from "@/features/settings/components/LogoutButton";
 import { RegularDaysOffEditor } from "@/features/settings/components/RegularDaysOffEditor";
+import { SafetyBufferEditor } from "@/features/settings/components/SafetyBufferEditor";
 import { StoreNameEditor } from "@/features/settings/components/StoreNameEditor";
 import type { Weekday } from "@/lib/domain/regular-days-off";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
@@ -22,7 +23,7 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
 
   const { data } = await supabase
     .from("users")
-    .select("store_name, store_type, regular_days_off")
+    .select("store_name, store_type, regular_days_off, safety_buffer_days")
     .eq("id", user.id)
     .maybeSingle();
 
@@ -30,8 +31,10 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
     store_name: string;
     store_type: StoreType;
     regular_days_off: Weekday[];
+    safety_buffer_days: number;
   } | null;
   const initialDaysOff: Weekday[] = profile?.regular_days_off ?? [];
+  const safetyBufferDays = profile?.safety_buffer_days ?? 1;
   const storeName = profile?.store_name ?? "내 가게";
   const storeType = profile?.store_type ?? "cafe";
 
@@ -77,17 +80,15 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
         <RegularDaysOffEditor initialDaysOff={initialDaysOff} />
 
         <div className="grid gap-stack-tight border-t border-border pt-stack">
+          <SafetyBufferEditor initialSafetyBufferDays={safetyBufferDays} userId={user.id} />
           <SettingRow
             label="거래처 리드타임"
-            value="각 재료 예측은 가장 자주 쓰는 거래처 리드타임을 사용합니다."
+            value={`각 재료 예측은 가장 자주 쓰는 거래처 리드타임 + 안전여유 ${safetyBufferDays}일을 기준으로 상태를 나눕니다.`}
           />
           <div className="flex flex-wrap gap-stack-tight">
             <Link href="/purchase" className={SECONDARY_BUTTON_CLASSES}>
               거래처 관리로 이동
             </Link>
-            <button type="button" disabled className={`${SECONDARY_BUTTON_CLASSES} opacity-50`}>
-              안전여유일 설정
-            </button>
           </div>
         </div>
       </section>

--- a/src/features/inventory/hooks/useDepletionForecast.ts
+++ b/src/features/inventory/hooks/useDepletionForecast.ts
@@ -22,6 +22,7 @@ async function fetchDepletionForecast(): Promise<
       unit: "g" | "ml" | "piece";
       currentStock: number;
       leadTimeDays: number;
+      safetyBufferDays: number;
     } & ForecastResult
   >
 > {

--- a/src/features/settings/components/SafetyBufferEditor.tsx
+++ b/src/features/settings/components/SafetyBufferEditor.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { useUpdateSafetyBufferDays } from "@/features/settings/hooks/useSettingsMutations";
+
+const safetyBufferSchema = z.object({
+  safetyBufferDays: z
+    .number({ invalid_type_error: "안전여유일은 숫자로 입력해주세요" })
+    .int("안전여유일은 정수여야 합니다")
+    .min(0, "안전여유일은 0일 이상이어야 합니다")
+    .max(7, "안전여유일은 7일 이하로 입력해주세요"),
+});
+
+type SafetyBufferFormInput = z.infer<typeof safetyBufferSchema>;
+
+interface SafetyBufferEditorProps {
+  initialSafetyBufferDays: number;
+  userId: string;
+}
+
+export function SafetyBufferEditor({
+  initialSafetyBufferDays,
+  userId,
+}: SafetyBufferEditorProps): React.ReactElement {
+  const router = useRouter();
+  const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+  const mutation = useUpdateSafetyBufferDays();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty, isSubmitting },
+    reset,
+  } = useForm<SafetyBufferFormInput>({
+    resolver: zodResolver(safetyBufferSchema),
+    defaultValues: { safetyBufferDays: initialSafetyBufferDays },
+  });
+
+  async function onSubmit(values: SafetyBufferFormInput): Promise<void> {
+    setSubmitMessage(null);
+
+    try {
+      const nextValue = await mutation.mutateAsync({
+        userId,
+        safetyBufferDays: values.safetyBufferDays,
+      });
+      reset({ safetyBufferDays: nextValue });
+      setSubmitMessage("예측 안전여유일을 저장했어요.");
+      router.refresh();
+    } catch (error) {
+      setSubmitMessage(error instanceof Error ? error.message : "안전여유일 저장에 실패했어요.");
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(event) => void handleSubmit(onSubmit)(event)}
+      className="flex flex-col gap-stack"
+      noValidate
+    >
+      <Field label="안전여유일" error={errors.safetyBufferDays?.message}>
+        <input
+          {...register("safetyBufferDays", { valueAsNumber: true })}
+          type="number"
+          min={0}
+          max={7}
+          inputMode="numeric"
+          className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+        />
+      </Field>
+
+      <p className="text-caption text-ink-3">
+        소진일까지 남은 일수에서 거래처 리드타임과 이 값을 함께 빼서 위험 단계를 정합니다.
+      </p>
+
+      <div className="flex items-center gap-stack-tight">
+        <PrimaryButton type="submit" disabled={isSubmitting || !isDirty}>
+          {isSubmitting ? "저장 중..." : "안전여유일 저장"}
+        </PrimaryButton>
+        {submitMessage && (
+          <p
+            role="status"
+            className={mutation.isError ? "text-caption text-red" : "text-caption text-green"}
+          >
+            {submitMessage}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/features/settings/hooks/useSettingsMutations.ts
+++ b/src/features/settings/hooks/useSettingsMutations.ts
@@ -23,6 +23,11 @@ interface UpdateRegularDaysOffInput {
   daysOff: readonly Weekday[];
 }
 
+interface UpdateSafetyBufferDaysInput {
+  userId: string;
+  safetyBufferDays: number;
+}
+
 export async function invalidateSettingsRelatedQueries(queryClient: QueryClient): Promise<void> {
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: todayDashboardQueryKey }),
@@ -57,6 +62,22 @@ async function persistRegularDaysOff(
   return data?.[0]?.days_off ?? input.daysOff;
 }
 
+async function updateSafetyBufferDays(input: UpdateSafetyBufferDaysInput): Promise<number> {
+  const supabase = createClient() as unknown as SupabaseClient<Database>;
+  const { data, error } = await supabase
+    .from("users")
+    .update({ safety_buffer_days: input.safetyBufferDays })
+    .eq("id", input.userId)
+    .select("safety_buffer_days")
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (typeof data?.safety_buffer_days !== "number") {
+    throw new Error("안전여유일 저장 결과가 비어 있습니다.");
+  }
+  return data.safety_buffer_days;
+}
+
 export function useUpdateStoreName(): UseMutationResult<string, Error, UpdateStoreNameInput> {
   const queryClient = useQueryClient();
   return useMutation({
@@ -75,6 +96,20 @@ export function useUpdateRegularDaysOff(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: persistRegularDaysOff,
+    onSuccess: async () => {
+      await invalidateSettingsRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function useUpdateSafetyBufferDays(): UseMutationResult<
+  number,
+  Error,
+  UpdateSafetyBufferDaysInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateSafetyBufferDays,
     onSuccess: async () => {
       await invalidateSettingsRelatedQueries(queryClient);
     },

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -19,6 +19,7 @@ export interface IngredientForecastView extends ForecastResult {
   unit: "g" | "ml" | "piece";
   currentStock: number;
   leadTimeDays: number;
+  safetyBufferDays: number;
 }
 
 export async function loadDepletionForecast(client: RpcClient): Promise<IngredientForecastView[]> {
@@ -34,6 +35,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
     const forecast = forecastIngredient({
       currentStock: row.currentStock,
       leadTimeDays: row.leadTimeDays,
+      safetyBufferDays: row.safetyBufferDays,
       consumptionSamples: samples,
       daysOff: row.regularDaysOff,
       signupDate: new Date(row.signedUpAt),
@@ -45,6 +47,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       unit: row.unit,
       currentStock: row.currentStock,
       leadTimeDays: row.leadTimeDays,
+      safetyBufferDays: row.safetyBufferDays,
       ...forecast,
     };
   });

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -12,13 +12,12 @@ import { isRegularDayOff, weekdayOf, type Weekday } from "./regular-days-off";
  *     (정확히 7일 경계는 cold가 아님 — `tests/unit/forecast.test.ts` 참고)
  *  2. 요일별 가중 평균 산정 (정기휴무 제외)
  *  3. 오늘부터 일별 시뮬레이션 (정기휴무는 소비 0)
- *  4. 리드타임 + 안전여유 1일 차감해 status 분류
+ *  4. 리드타임 + 안전여유일 설정값 차감해 status 분류
  *  5. trend는 7일 평균 vs 30일 평균 ±20% 비교
  */
 
 const COLD_START_DAYS = 7;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-const SAFETY_BUFFER_DAYS = 1;
 const MAX_FORECAST_DAYS = 365;
 const TREND_THRESHOLD = 0.2;
 
@@ -33,6 +32,7 @@ export interface DailyConsumption {
 export interface ForecastInput {
   currentStock: number;
   leadTimeDays: number;
+  safetyBufferDays: number;
   consumptionSamples: readonly DailyConsumption[];
   daysOff: readonly Weekday[];
   signupDate: Date;
@@ -117,7 +117,7 @@ function overallWeekdayAverage(weekdayAvg: ReadonlyMap<Weekday, Decimal>): Decim
 }
 
 /**
- * 리드타임 + 안전여유 1일 빼고 남은 buffer일 수로 status 분류 (FR-013).
+ * 리드타임 + 안전여유일을 빼고 남은 buffer일 수로 status 분류 (FR-013).
  * - buffer ≤ 1: critical (당일/익일 소진 임박)
  * - buffer == 2: order_needed (지금 발주해야)
  * - buffer 3~4: caution
@@ -128,6 +128,7 @@ function overallWeekdayAverage(weekdayAvg: ReadonlyMap<Weekday, Decimal>): Decim
 export function classifyStatus(
   depletionDate: Date | null,
   leadTimeDays: number,
+  safetyBufferDays: number,
   today: Date,
 ): DepletionStatus {
   if (!depletionDate) return "safe";
@@ -136,7 +137,7 @@ export function classifyStatus(
     0,
     Math.floor((depletionDate.getTime() - today.getTime()) / ONE_DAY_MS),
   );
-  const buffer = daysUntilDepletion - leadTimeDays - SAFETY_BUFFER_DAYS;
+  const buffer = daysUntilDepletion - leadTimeDays - safetyBufferDays;
 
   if (buffer <= 1) return "critical";
   if (buffer === 2) return "order_needed";
@@ -198,7 +199,7 @@ export function forecastIngredient(input: ForecastInput): ForecastResult {
 
   return {
     expectedDepletionDate: depletionDate,
-    status: classifyStatus(depletionDate, input.leadTimeDays, input.today),
+    status: classifyStatus(depletionDate, input.leadTimeDays, input.safetyBufferDays, input.today),
     trend: detectTrend(input.consumptionSamples, input.today),
     isColdStart: false,
   };

--- a/src/lib/supabase/rpc-queries.ts
+++ b/src/lib/supabase/rpc-queries.ts
@@ -6,6 +6,7 @@ export interface DepletionForecastRow {
   unit: "g" | "ml" | "piece";
   currentStock: number;
   leadTimeDays: number;
+  safetyBufferDays: number;
   consumptionSamples: Array<{ date: string; amount: number }>;
   signedUpAt: string;
   regularDaysOff: ReadonlyArray<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -17,6 +18,7 @@ interface DepletionForecastRawRow {
   unit: "g" | "ml" | "piece";
   current_stock: number;
   lead_time_days: number;
+  safety_buffer_days: number;
   consumption_samples: Array<{ date: string; amount: number }>;
   signed_up_at: string;
   regular_days_off: Array<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -248,6 +250,7 @@ export async function getDepletionForecast(
       unit: row.unit,
       currentStock: numeric(row.current_stock),
       leadTimeDays: row.lead_time_days,
+      safetyBufferDays: row.safety_buffer_days,
       consumptionSamples: row.consumption_samples ?? [],
       signedUpAt: row.signed_up_at,
       regularDaysOff: row.regular_days_off ?? [],

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -613,6 +613,7 @@ export type Database = {
           id: string
           permanent_delete_at: string | null
           regular_days_off: Database["public"]["Enums"]["weekday"][]
+          safety_buffer_days: number
           signed_up_at: string
           store_name: string
           store_type: Database["public"]["Enums"]["store_type"]
@@ -626,6 +627,7 @@ export type Database = {
           id: string
           permanent_delete_at?: string | null
           regular_days_off?: Database["public"]["Enums"]["weekday"][]
+          safety_buffer_days?: number
           signed_up_at?: string
           store_name: string
           store_type: Database["public"]["Enums"]["store_type"]
@@ -639,6 +641,7 @@ export type Database = {
           id?: string
           permanent_delete_at?: string | null
           regular_days_off?: Database["public"]["Enums"]["weekday"][]
+          safety_buffer_days?: number
           signed_up_at?: string
           store_name?: string
           store_type?: Database["public"]["Enums"]["store_type"]
@@ -755,6 +758,7 @@ export type Database = {
           lead_time_days: number
           name: string
           regular_days_off: Database["public"]["Enums"]["weekday"][]
+          safety_buffer_days: number
           signed_up_at: string
           unit: Database["public"]["Enums"]["ingredient_unit"]
         }[]

--- a/supabase/migrations/021_get_depletion_forecast_rpc.sql
+++ b/supabase/migrations/021_get_depletion_forecast_rpc.sql
@@ -2,7 +2,8 @@
 -- Spec: contracts/domain-rpc.md L215-241
 --
 -- 분류 자체는 클라이언트 forecast.ts가 담당. 서버는 ingredient + 30일 sale 소비
--- 샘플 + lead_time(첫 거래처 또는 기본 1일) + signed_up_at + regular_days_off만 반환.
+-- 샘플 + lead_time(첫 거래처 또는 기본 1일) + safety_buffer_days + signed_up_at
+-- + regular_days_off만 반환.
 -- "raw 데이터 + 클라이언트 분류" 결정 (tasks.md T124의 latter 방식): 테스트 단순화 +
 -- 클라이언트가 forecast.ts 그대로 재사용.
 
@@ -13,6 +14,7 @@ returns table (
   unit public.ingredient_unit,
   current_stock numeric,
   lead_time_days integer,
+  safety_buffer_days integer,
   consumption_samples jsonb,
   signed_up_at timestamptz,
   regular_days_off public.weekday[]
@@ -48,6 +50,7 @@ begin
        limit 1),
       1
     ) as lead_time_days,
+    u.safety_buffer_days,
     -- 30일치 일별 소비량: sale_items.quantity × recipe_items.quantity_per_serving 합산
     coalesce(
       (select jsonb_agg(jsonb_build_object('date', day, 'amount', total))

--- a/supabase/migrations/036_add_safety_buffer_days_to_users.sql
+++ b/supabase/migrations/036_add_safety_buffer_days_to_users.sql
@@ -1,0 +1,15 @@
+-- Migration: 사용자별 재고 예측 안전여유일 설정
+-- Settings에서 조정하는 예측 기준값. 상태 분류 시 lead_time_days와 함께 사용.
+
+alter table public.users
+add column if not exists safety_buffer_days integer not null default 1;
+
+alter table public.users
+drop constraint if exists users_safety_buffer_days_range;
+
+alter table public.users
+add constraint users_safety_buffer_days_range
+check (safety_buffer_days between 0 and 7);
+
+comment on column public.users.safety_buffer_days is
+  '재고 소진 예측 안전여유일. 상태 분류 시 리드타임과 함께 차감한다. 기본 1일.';

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -238,6 +238,7 @@ describe("application layer", () => {
             unit: "g",
             currentStock: 1200,
             leadTimeDays: 3,
+            safetyBufferDays: 2,
             consumptionSamples: [{ date: "2026-06-01", amount: 80 }],
             signedUpAt: "2026-05-20T00:00:00.000Z",
             regularDaysOff: ["SUN"],
@@ -259,6 +260,7 @@ describe("application layer", () => {
           unit: "g",
           currentStock: 1200,
           leadTimeDays: 3,
+          safetyBufferDays: 2,
           expectedDepletionDate: new Date("2026-06-10T00:00:00.000Z"),
           status: "caution",
           trend: "rising",
@@ -269,6 +271,7 @@ describe("application layer", () => {
       expect(forecastMocks.forecastIngredient).toHaveBeenCalledWith({
         currentStock: 1200,
         leadTimeDays: 3,
+        safetyBufferDays: 2,
         consumptionSamples: [{ date: new Date("2026-06-01"), amount: 80 }],
         daysOff: ["SUN"],
         signupDate: new Date("2026-05-20T00:00:00.000Z"),

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -154,36 +154,42 @@ describe("predictDepletionDate", () => {
 
 describe("classifyStatus (FR-013)", () => {
   it("데이터 부족(depletionDate=null) → safe", () => {
-    expect(classifyStatus(null, 1, today)).toBe("safe");
+    expect(classifyStatus(null, 1, 1, today)).toBe("safe");
   });
 
   it("buffer ≤ 1 → critical", () => {
     // 소진 1일 후, 리드타임 0, 안전여유 1 → buffer = 0 → critical
     const date = new Date(today.getTime() + 1 * ONE_DAY);
-    expect(classifyStatus(date, 0, today)).toBe("critical");
+    expect(classifyStatus(date, 0, 1, today)).toBe("critical");
   });
 
   it("buffer == 2 → order_needed", () => {
     // 소진 4일 후, 리드타임 1, 안전여유 1 → buffer = 2 → order_needed
     const date = new Date(today.getTime() + 4 * ONE_DAY);
-    expect(classifyStatus(date, 1, today)).toBe("order_needed");
+    expect(classifyStatus(date, 1, 1, today)).toBe("order_needed");
   });
 
   it("buffer 3~4 → caution", () => {
     // 소진 6일 후, 리드타임 1, 안전여유 1 → buffer = 4 → caution
     const date = new Date(today.getTime() + 6 * ONE_DAY);
-    expect(classifyStatus(date, 1, today)).toBe("caution");
+    expect(classifyStatus(date, 1, 1, today)).toBe("caution");
   });
 
   it("buffer ≥ 5 → safe", () => {
     const date = new Date(today.getTime() + 10 * ONE_DAY);
-    expect(classifyStatus(date, 1, today)).toBe("safe");
+    expect(classifyStatus(date, 1, 1, today)).toBe("safe");
   });
 
   it("리드타임 긴 거래처는 더 빨리 critical", () => {
     // 소진 5일 후, 리드타임 5 → buffer = -1 → critical
     const date = new Date(today.getTime() + 5 * ONE_DAY);
-    expect(classifyStatus(date, 5, today)).toBe("critical");
+    expect(classifyStatus(date, 5, 1, today)).toBe("critical");
+  });
+
+  it("안전여유일이 커질수록 더 빨리 위험 단계로 간다", () => {
+    const date = new Date(today.getTime() + 6 * ONE_DAY);
+    expect(classifyStatus(date, 1, 1, today)).toBe("caution");
+    expect(classifyStatus(date, 1, 3, today)).toBe("order_needed");
   });
 });
 
@@ -230,6 +236,7 @@ describe("forecastIngredient (합성)", () => {
     const result = forecastIngredient({
       currentStock: 100,
       leadTimeDays: 1,
+      safetyBufferDays: 1,
       consumptionSamples: baseSamples(),
       daysOff: [],
       signupDate: daysAgo(3),
@@ -245,6 +252,7 @@ describe("forecastIngredient (합성)", () => {
     const result = forecastIngredient({
       currentStock: 50,
       leadTimeDays: 1,
+      safetyBufferDays: 1,
       consumptionSamples: baseSamples(),
       daysOff: [],
       signupDate: daysAgo(60),
@@ -260,6 +268,7 @@ describe("forecastIngredient (합성)", () => {
     const noOffDay = forecastIngredient({
       currentStock: 100,
       leadTimeDays: 1,
+      safetyBufferDays: 1,
       consumptionSamples: baseSamples(),
       daysOff: [],
       signupDate: daysAgo(60),
@@ -268,6 +277,7 @@ describe("forecastIngredient (합성)", () => {
     const oneOffDay = forecastIngredient({
       currentStock: 100,
       leadTimeDays: 1,
+      safetyBufferDays: 1,
       consumptionSamples: baseSamples(),
       daysOff: ["SUN"],
       signupDate: daysAgo(60),


### PR DESCRIPTION
## Summary
- add per-store safety buffer days to the user settings model and depletion forecast pipeline
- wire a safety buffer editor into the settings page and invalidate forecast-related caches after save
- update forecast tests and README to reflect the configurable buffer logic

## Testing
- npm run format:check
- npm run typecheck
- npm run lint
- npx vitest run tests/unit/forecast.test.ts tests/unit/application.test.ts