### PR TITLE
feat: improve depletion demand forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ specs/001-mvp-core/        spec.md / data-model.md / contracts / tasks.md
 
 ## 재료 소진 예측 알고리즘
 
-이지스톡의 소진 예측은 단순 최근 7일 평균이 아니라, **실제 판매 이력에서 재료별 일일 소비량을 만들고, 정기휴무와 거래처 리드타임까지 반영한 뒤 하루씩 시뮬레이션**하는 방식입니다. 스펙 기준은 `FR-012`, `FR-013`, `FR-018`, `FR-025`, `FR-042`이고, 실제 구현 단일 출처는 [forecast.ts](/Users/yamon/Desktop/projects/ezstock/src/lib/domain/forecast.ts)입니다.
+이지스톡의 소진 예측은 단순 최근 7일 평균이 아니라, **실제 판매 이력에서 재료별 일일 소비량을 만들고, 정기휴무·최근 추세·거래처 리드타임까지 반영한 뒤 하루씩 시뮬레이션**하는 방식입니다. 스펙 기준은 `FR-012`, `FR-013`, `FR-018`, `FR-025`, `FR-042`이고, 실제 구현 단일 출처는 [forecast.ts](/Users/yamon/Desktop/projects/ezstock/src/lib/domain/forecast.ts)입니다.
 
 핵심 흐름은 이렇습니다.
 
 1. **서버에서 raw 데이터 수집**
    - [021_get_depletion_forecast_rpc.sql](/Users/yamon/Desktop/projects/ezstock/supabase/migrations/021_get_depletion_forecast_rpc.sql)
-   - 각 재료별로 `current_stock`, `signed_up_at`, `regular_days_off`, `safety_buffer_days`, 최근 30일 `consumption_samples`를 반환합니다.
+   - 각 재료별로 `current_stock`, `signed_up_at`, `regular_days_off`, `safety_buffer_days`, 최근 90일 `consumption_samples`를 반환합니다.
    - `consumption_samples`는 `sale_items.quantity × recipe_items.quantity_per_serving`를 날짜별로 합산한 값입니다.
    - 거래처 리드타임은 해당 재료에 대해 **가장 자주 사용한 vendor의 리드타임**을 쓰고, 이력이 없으면 기본 `1일`을 사용합니다.
 
@@ -116,15 +116,17 @@ specs/001-mvp-core/        spec.md / data-model.md / contracts / tasks.md
    - 가입 후 `7일 미만`이면 `isColdStart=true`로 처리하고, 소진일 예측은 돌리지 않습니다.
    - 그래서 재료 화면에는 “데이터 수집 중” 안내가 먼저 뜹니다.
 
-3. **정기휴무를 제외한 요일별 평균 소비량 계산**
+3. **정기휴무를 제외한 영업일 타입별 최근가중 평균 계산**
    - [forecast.ts](/Users/yamon/Desktop/projects/ezstock/src/lib/domain/forecast.ts)
-   - 같은 요일의 sample들을 평균내서 `월/화/수...`별 평균 소비량을 만듭니다.
+   - 요일 7개를 그대로 쪼개지 않고, 빙수집/카페 운영 패턴에 맞춰 `평일(월~목)`, `금요일`, `주말(토~일)` 그룹으로 묶습니다.
+   - 최근 sample일수록 `exp(-daysAgo / 14)` 방식으로 더 큰 가중치를 줍니다.
    - 정기휴무일은 평균 산정에서 제외합니다.
-   - 어떤 요일 데이터가 비어 있으면 그 요일을 0으로 두지 않고, **전체 영업일 평균**으로 대체해서 실제보다 지나치게 낙관적인 예측을 막습니다.
+   - 단체주문 같은 극단값은 중앙값의 3배로 cap해서 예측 폭주를 완화합니다.
+   - 그룹 표본이 8개 미만이면 **전체 영업일 평균과 섞는 shrinkage**를 적용해, 가맹점 초기 데이터가 적을 때도 예측이 과하게 튀지 않게 합니다.
 
 4. **오늘부터 하루씩 재고 소진 시뮬레이션**
    - [forecast.ts](/Users/yamon/Desktop/projects/ezstock/src/lib/domain/forecast.ts)
-   - 내일부터 최대 365일까지 하루씩 진행하면서, 영업일이면 그 요일 평균 소비량만큼 재고를 차감합니다.
+   - 내일부터 최대 365일까지 하루씩 진행하면서, 영업일이면 그 날짜의 영업일 타입 평균 소비량만큼 재고를 차감합니다.
    - 정기휴무는 소비 0으로 건너뜁니다.
    - 재고가 `0 이하`가 되는 첫 날짜를 예상 소진일로 잡습니다.
 
@@ -137,10 +139,12 @@ specs/001-mvp-core/        spec.md / data-model.md / contracts / tasks.md
    - `caution`: buffer 3~4
    - `safe`: buffer ≥ 5
 
-6. **최근 사용량 급증/급감 감지**
+6. **최근 사용량 급증/급감 감지 + 완만한 추세 보정**
    - [forecast.ts](/Users/yamon/Desktop/projects/ezstock/src/lib/domain/forecast.ts)
    - 최근 7일 평균과 30일 평균을 비교합니다.
    - 비율 차이가 `±20%`를 넘으면 `rising` 또는 `falling`으로 분류합니다.
+   - 실제 소진일 계산에도 최근 추세를 반영하되, 계수는 `0.85~1.25`로 제한합니다.
+   - 그래서 날씨/이벤트로 하루 매출이 튄 경우에도 예측이 과하게 흔들리지 않습니다.
 
 중요한 구현 포인트:
 

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -10,19 +10,29 @@ import { isRegularDayOff, weekdayOf, type Weekday } from "./regular-days-off";
  * 핵심 로직:
  *  1. 콜드스타트 (가입 < 7일) → 모든 항목 isColdStart=true, 예측 안 함
  *     (정확히 7일 경계는 cold가 아님 — `tests/unit/forecast.test.ts` 참고)
- *  2. 요일별 가중 평균 산정 (정기휴무 제외)
+ *  2. 영업일 타입별 최근가중 평균 산정 (정기휴무 제외)
+ *     - weekday: 월~목
+ *     - friday: 금
+ *     - weekend: 토~일
+ *     - 표본 부족 그룹은 전체 영업일 평균으로 shrinkage
  *  3. 오늘부터 일별 시뮬레이션 (정기휴무는 소비 0)
  *  4. 리드타임 + 안전여유일 설정값 차감해 status 분류
- *  5. trend는 7일 평균 vs 30일 평균 ±20% 비교
+ *  5. trend는 7일 평균 vs 30일 평균 ±20% 비교, 소진일에는 완만한 계수만 반영
  */
 
 const COLD_START_DAYS = 7;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_FORECAST_DAYS = 365;
 const TREND_THRESHOLD = 0.2;
+const RECENCY_DECAY_DAYS = 14;
+const MIN_GROUP_SAMPLE_SIZE = 8;
+const OUTLIER_CAP_MULTIPLIER = 3;
+const TREND_FACTOR_MIN = 0.85;
+const TREND_FACTOR_MAX = 1.25;
 
 export type DepletionStatus = "safe" | "caution" | "order_needed" | "critical";
 export type ConsumptionTrend = "normal" | "rising" | "falling";
+export type BusinessDayType = "weekday" | "friday" | "weekend";
 
 export interface DailyConsumption {
   date: Date;
@@ -44,6 +54,11 @@ export interface ForecastResult {
   status: DepletionStatus;
   trend: ConsumptionTrend;
   isColdStart: boolean;
+}
+
+export interface UsageForecastModel {
+  usageByDayType: ReadonlyMap<BusinessDayType, Decimal>;
+  fallbackDailyUsage: Decimal;
 }
 
 export function isColdStart(signupDate: Date, today: Date): boolean {
@@ -76,31 +91,152 @@ export function computeWeekdayUsageAverage(
 }
 
 /**
+ * 영업일 타입 분류.
+ *
+ * 빙수집/카페류는 요일 7개를 모두 쪼개면 최근 90일이어도 요일당 표본이 작아
+ * 노이즈가 커진다. MVP 운영 예측은 평일/금요일/주말 단위가 더 안정적이다.
+ */
+export function businessDayTypeOf(date: Date, daysOff: readonly Weekday[]): BusinessDayType | null {
+  if (isRegularDayOff(date, daysOff)) return null;
+
+  const weekday = weekdayOf(date);
+  if (weekday === "FRI") return "friday";
+  if (weekday === "SAT" || weekday === "SUN") return "weekend";
+  return "weekday";
+}
+
+/**
+ * 영업일 타입별 최근가중 평균 소비량.
+ *
+ * - 최근 sample일수록 exp(-daysAgo / 14)로 더 크게 반영
+ * - 단체주문 같은 극단값은 중앙값의 3배로 cap
+ * - 그룹 표본이 8개 미만이면 전체 영업일 평균과 섞어 안정화
+ */
+export function computeBusinessDayUsageModel(
+  samples: readonly DailyConsumption[],
+  daysOff: readonly Weekday[],
+  today: Date,
+): UsageForecastModel {
+  const usableSamples = samples
+    .filter((sample) => !isRegularDayOff(sample.date, daysOff) && sample.amount > 0)
+    .map((sample) => ({
+      ...sample,
+      amount: capOutlier(sample.amount, samples),
+      dayType: businessDayTypeOf(sample.date, daysOff),
+      weight: recencyWeight(sample.date, today),
+    }))
+    .filter((sample): sample is DailyConsumption & { dayType: BusinessDayType; weight: number } =>
+      Boolean(sample.dayType),
+    );
+
+  if (usableSamples.length === 0) {
+    return {
+      usageByDayType: new Map(),
+      fallbackDailyUsage: new Decimal(0),
+    };
+  }
+
+  const globalAverage = weightedAverage(
+    usableSamples.map((sample) => ({ amount: sample.amount, weight: sample.weight })),
+  );
+  const buckets = new Map<
+    BusinessDayType,
+    { weightedSum: Decimal; weightSum: Decimal; count: number }
+  >();
+
+  for (const sample of usableSamples) {
+    const bucket = buckets.get(sample.dayType) ?? {
+      weightedSum: new Decimal(0),
+      weightSum: new Decimal(0),
+      count: 0,
+    };
+    const weight = new Decimal(sample.weight);
+    bucket.weightedSum = bucket.weightedSum.plus(new Decimal(sample.amount).times(weight));
+    bucket.weightSum = bucket.weightSum.plus(weight);
+    bucket.count += 1;
+    buckets.set(sample.dayType, bucket);
+  }
+
+  const usageByDayType = new Map<BusinessDayType, Decimal>();
+  for (const [dayType, bucket] of buckets) {
+    const groupAverage = bucket.weightSum.isZero()
+      ? globalAverage
+      : bucket.weightedSum.dividedBy(bucket.weightSum);
+    const confidence = Math.min(bucket.count / MIN_GROUP_SAMPLE_SIZE, 1);
+    const stabilized = groupAverage.times(confidence).plus(globalAverage.times(1 - confidence));
+    usageByDayType.set(dayType, stabilized);
+  }
+
+  return {
+    usageByDayType,
+    fallbackDailyUsage: globalAverage,
+  };
+}
+
+function recencyWeight(date: Date, today: Date): number {
+  const daysAgo = Math.max(0, (today.getTime() - date.getTime()) / ONE_DAY_MS);
+  return Math.exp(-daysAgo / RECENCY_DECAY_DAYS);
+}
+
+function capOutlier(amount: number, samples: readonly DailyConsumption[]): number {
+  const positiveAmounts = samples
+    .map((sample) => sample.amount)
+    .filter((value) => value > 0)
+    .sort((a, b) => a - b);
+  if (positiveAmounts.length === 0) return amount;
+
+  const median = positiveAmounts[Math.floor(positiveAmounts.length / 2)];
+  if (!median || median <= 0) return amount;
+  return Math.min(amount, median * OUTLIER_CAP_MULTIPLIER);
+}
+
+function weightedAverage(samples: readonly { amount: number; weight: number }[]): Decimal {
+  const totals = samples.reduce(
+    (acc, sample) => {
+      const weight = new Decimal(sample.weight);
+      return {
+        weightedSum: acc.weightedSum.plus(new Decimal(sample.amount).times(weight)),
+        weightSum: acc.weightSum.plus(weight),
+      };
+    },
+    { weightedSum: new Decimal(0), weightSum: new Decimal(0) },
+  );
+
+  if (totals.weightSum.isZero()) return new Decimal(0);
+  return totals.weightedSum.dividedBy(totals.weightSum);
+}
+
+/**
  * 오늘부터 하루씩 시뮬레이션. 정기휴무는 소비 0.
  * 1년 내 소진 안 하면 null (충분히 여유).
  *
- * 데이터 없는 요일은 영업일 평균으로 대체. 그렇지 않으면 가입 직후·드문 영업
- * 요일에 over-forecast (실제보다 오래 버틴다고 잘못 안내) 위험.
+ * 데이터 없는 영업일 타입은 전체 영업일 평균으로 대체. 그렇지 않으면 가입 직후·
+ * 드문 영업 타입에 over-forecast (실제보다 오래 버틴다고 잘못 안내) 위험.
  */
 export function predictDepletionDate({
   currentStock,
-  weekdayAvg,
+  usageModel,
+  trendFactor = 1,
   today,
   daysOff,
 }: {
   currentStock: number;
-  weekdayAvg: ReadonlyMap<Weekday, Decimal>;
+  usageModel: UsageForecastModel;
+  trendFactor?: number;
   today: Date;
   daysOff: readonly Weekday[];
 }): Date | null {
   let stock = new Decimal(currentStock);
-  const fallback = overallWeekdayAverage(weekdayAvg);
+  const trendMultiplier = new Decimal(clamp(trendFactor, TREND_FACTOR_MIN, TREND_FACTOR_MAX));
 
   for (let offset = 1; offset <= MAX_FORECAST_DAYS; offset++) {
     const day = new Date(today.getTime() + offset * ONE_DAY_MS);
-    if (isRegularDayOff(day, daysOff)) continue;
+    const dayType = businessDayTypeOf(day, daysOff);
+    if (!dayType) continue;
 
-    const usage = weekdayAvg.get(weekdayOf(day)) ?? fallback;
+    const usage = (usageModel.usageByDayType.get(dayType) ?? usageModel.fallbackDailyUsage).times(
+      trendMultiplier,
+    );
     if (usage.isZero()) continue; // 전체 데이터가 0 → 소비 미정, 패스
 
     stock = stock.minus(usage);
@@ -109,11 +245,8 @@ export function predictDepletionDate({
   return null;
 }
 
-function overallWeekdayAverage(weekdayAvg: ReadonlyMap<Weekday, Decimal>): Decimal {
-  if (weekdayAvg.size === 0) return new Decimal(0);
-  let sum = new Decimal(0);
-  for (const v of weekdayAvg.values()) sum = sum.plus(v);
-  return sum.dividedBy(weekdayAvg.size);
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
 }
 
 /**
@@ -164,6 +297,14 @@ export function detectTrend(samples: readonly DailyConsumption[], today: Date): 
   return "normal";
 }
 
+export function computeTrendFactor(samples: readonly DailyConsumption[], today: Date): number {
+  const last7Avg = averageOverDays(samples, today, 7);
+  const last30Avg = averageOverDays(samples, today, 30);
+
+  if (last30Avg.isZero()) return 1;
+  return clamp(last7Avg.dividedBy(last30Avg).toNumber(), TREND_FACTOR_MIN, TREND_FACTOR_MAX);
+}
+
 function averageOverDays(
   samples: readonly DailyConsumption[],
   today: Date,
@@ -189,10 +330,16 @@ export function forecastIngredient(input: ForecastInput): ForecastResult {
     };
   }
 
-  const weekdayAvg = computeWeekdayUsageAverage(input.consumptionSamples, input.daysOff);
+  const trend = detectTrend(input.consumptionSamples, input.today);
+  const usageModel = computeBusinessDayUsageModel(
+    input.consumptionSamples,
+    input.daysOff,
+    input.today,
+  );
   const depletionDate = predictDepletionDate({
     currentStock: input.currentStock,
-    weekdayAvg,
+    usageModel,
+    trendFactor: computeTrendFactor(input.consumptionSamples, input.today),
     today: input.today,
     daysOff: input.daysOff,
   });
@@ -200,7 +347,7 @@ export function forecastIngredient(input: ForecastInput): ForecastResult {
   return {
     expectedDepletionDate: depletionDate,
     status: classifyStatus(depletionDate, input.leadTimeDays, input.safetyBufferDays, input.today),
-    trend: detectTrend(input.consumptionSamples, input.today),
+    trend,
     isColdStart: false,
   };
 }

--- a/supabase/migrations/039_extend_depletion_forecast_lookback.sql
+++ b/supabase/migrations/039_extend_depletion_forecast_lookback.sql
@@ -1,0 +1,91 @@
+-- Migration: 소진 예측 raw consumption_samples lookback을 30일에서 90일로 확장
+-- 클라이언트 도메인 로직이 최근가중 평균을 적용하므로, 더 긴 이력으로 표본 안정성을 확보한다.
+
+create or replace function public.get_depletion_forecast()
+returns table (
+  ingredient_id uuid,
+  name text,
+  unit public.ingredient_unit,
+  current_stock numeric,
+  lead_time_days integer,
+  lead_time_vendor_name text,
+  is_default_lead_time boolean,
+  safety_buffer_days integer,
+  consumption_samples jsonb,
+  signed_up_at timestamptz,
+  regular_days_off public.weekday[]
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  return query
+  with vendor_choice as (
+    select
+      i.id as ingredient_id,
+      choice.vendor_name,
+      choice.lead_time_days
+    from public.ingredients i
+    left join lateral (
+      select
+        v.name as vendor_name,
+        v.lead_time_days
+      from public.purchase_orders po
+      join public.vendors v on v.id = po.vendor_id
+      join public.purchase_order_items poi on poi.purchase_order_id = po.id
+      where poi.ingredient_id = i.id
+        and po.user_id = v_user_id
+      group by v.id, v.name, v.lead_time_days
+      order by count(*) desc, max(po.purchased_at) desc, v.name asc
+      limit 1
+    ) choice on true
+    where i.user_id = v_user_id
+      and i.is_active = true
+  )
+  select
+    i.id,
+    i.name,
+    i.unit,
+    i.current_stock,
+    coalesce(vc.lead_time_days, 1) as lead_time_days,
+    vc.vendor_name as lead_time_vendor_name,
+    (vc.lead_time_days is null) as is_default_lead_time,
+    u.safety_buffer_days,
+    coalesce(
+      (select jsonb_agg(jsonb_build_object('date', day, 'amount', total))
+       from (
+         select
+           s.sold_at as day,
+           sum(si.quantity * ri.quantity_per_serving) as total
+         from public.sales s
+         join public.sale_items si on si.sale_id = s.id
+         join public.recipe_items ri on ri.menu_id = si.menu_id
+         where ri.ingredient_id = i.id
+           and s.user_id = v_user_id
+           and s.sold_at >= current_date - interval '90 days'
+         group by s.sold_at
+       ) daily),
+      '[]'::jsonb
+    ) as consumption_samples,
+    u.signed_up_at,
+    u.regular_days_off
+  from public.ingredients i
+  join public.users u on u.id = i.user_id
+  left join vendor_choice vc on vc.ingredient_id = i.id
+  where i.user_id = v_user_id
+    and i.is_active = true
+  order by i.name;
+end;
+$$;
+
+comment on function public.get_depletion_forecast() is
+  '재고 예측 raw 데이터 반환. 최근 90일 소비 sample, 리드타임 출처, 설정값을 포함하며 최종 예측은 src/lib/domain/forecast.ts가 담당.';

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Decimal } from "@/lib/domain/_decimal";
 import {
+  businessDayTypeOf,
   classifyStatus,
+  computeBusinessDayUsageModel,
+  computeTrendFactor,
   computeWeekdayUsageAverage,
   detectTrend,
   forecastIngredient,
@@ -17,6 +20,18 @@ function daysAgo(days: number): Date {
   return new Date(today.getTime() - days * ONE_DAY);
 }
 
+function usageModel(amount: number) {
+  const usageByDayType = new Map([
+    ["weekday", new Decimal(amount)],
+    ["friday", new Decimal(amount)],
+    ["weekend", new Decimal(amount)],
+  ] as const);
+  return {
+    usageByDayType,
+    fallbackDailyUsage: new Decimal(amount),
+  };
+}
+
 describe("isColdStart (FR-018)", () => {
   it("가입 후 7일 미만은 콜드스타트", () => {
     expect(isColdStart(daysAgo(6), today)).toBe(true);
@@ -28,6 +43,48 @@ describe("isColdStart (FR-018)", () => {
 
   it("가입 30일 후는 일반", () => {
     expect(isColdStart(daysAgo(30), today)).toBe(false);
+  });
+});
+
+describe("business day usage model", () => {
+  it("월~목은 weekday, 금요일은 friday, 토/일은 weekend로 분류", () => {
+    expect(businessDayTypeOf(new Date("2026-04-27"), [])).toBe("weekday");
+    expect(businessDayTypeOf(new Date("2026-05-01"), [])).toBe("friday");
+    expect(businessDayTypeOf(new Date("2026-05-02"), [])).toBe("weekend");
+  });
+
+  it("정기휴무는 예측 소비일에서 제외", () => {
+    expect(businessDayTypeOf(new Date("2026-04-27"), ["MON"])).toBeNull();
+  });
+
+  it("최근 sample에 더 큰 가중치를 준다", () => {
+    const model = computeBusinessDayUsageModel(
+      [
+        { date: daysAgo(80), amount: 10 },
+        { date: daysAgo(60), amount: 10 },
+        { date: daysAgo(3), amount: 100 },
+        { date: daysAgo(1), amount: 100 },
+      ],
+      [],
+      today,
+    );
+
+    expect(model.fallbackDailyUsage.toNumber()).toBeGreaterThan(80);
+  });
+
+  it("그룹 표본이 적으면 전체 영업일 평균과 섞어 안정화한다", () => {
+    const samples: DailyConsumption[] = [
+      { date: new Date("2026-04-03"), amount: 100 },
+      { date: new Date("2026-04-06"), amount: 10 },
+      { date: new Date("2026-04-07"), amount: 10 },
+      { date: new Date("2026-04-08"), amount: 10 },
+      { date: new Date("2026-04-09"), amount: 10 },
+    ];
+
+    const model = computeBusinessDayUsageModel(samples, [], today);
+
+    expect(model.usageByDayType.get("friday")?.toNumber()).toBeLessThan(100);
+    expect(model.usageByDayType.get("friday")?.toNumber()).toBeGreaterThan(10);
   });
 });
 
@@ -62,18 +119,9 @@ describe("computeWeekdayUsageAverage", () => {
 
 describe("predictDepletionDate", () => {
   it("재고 100, 매일 10g 소비 → 11일 뒤 소진", () => {
-    const weekdayAvg = new Map([
-      ["MON", new Decimal(10)],
-      ["TUE", new Decimal(10)],
-      ["WED", new Decimal(10)],
-      ["THU", new Decimal(10)],
-      ["FRI", new Decimal(10)],
-      ["SAT", new Decimal(10)],
-      ["SUN", new Decimal(10)],
-    ] as const);
     const result = predictDepletionDate({
       currentStock: 100,
-      weekdayAvg,
+      usageModel: usageModel(10),
       today,
       daysOff: [],
     });
@@ -84,27 +132,18 @@ describe("predictDepletionDate", () => {
   });
 
   it("정기휴무는 소비 0 (재고 보존)", () => {
-    const weekdayAvg = new Map([
-      ["MON", new Decimal(50)],
-      ["TUE", new Decimal(50)],
-      ["WED", new Decimal(50)],
-      ["THU", new Decimal(50)],
-      ["FRI", new Decimal(50)],
-      ["SAT", new Decimal(50)],
-      ["SUN", new Decimal(50)],
-    ] as const);
     // 오늘 목(2026-04-30), 매일 50g, stock 250g.
     // daysOff 없음: 금(200) → 토(150) → 일(100) → 월(50) → 화(0) = 5일째 화요일 소진
     // SUN off: 금(200) → 토(150) → 일(skip) → 월(100) → 화(50) → 수(0) = 6일째 수요일 소진
     const noSundayResult = predictDepletionDate({
       currentStock: 250,
-      weekdayAvg,
+      usageModel: usageModel(50),
       today,
       daysOff: ["SUN"],
     });
     const allDaysResult = predictDepletionDate({
       currentStock: 250,
-      weekdayAvg,
+      usageModel: usageModel(50),
       today,
       daysOff: [],
     });
@@ -112,27 +151,25 @@ describe("predictDepletionDate", () => {
   });
 
   it("예측 1년 내 소진 안 하면 null", () => {
-    const weekdayAvg = new Map([["MON", new Decimal(0.001)]] as const);
     const result = predictDepletionDate({
       currentStock: 1_000_000,
-      weekdayAvg,
+      usageModel: {
+        usageByDayType: new Map([["weekday", new Decimal(0.001)]] as const),
+        fallbackDailyUsage: new Decimal(0.001),
+      },
       today,
       daysOff: [],
     });
     expect(result).toBeNull();
   });
 
-  it("데이터 없는 요일은 영업일 평균으로 대체 — over-forecast 방지", () => {
-    // 월·화만 데이터 (둘 다 10g/일). 영업일 평균 = 10g.
-    // fallback 없이는: 월·화만 소진 → 100/(10×2/7일) ≈ 35일 (실제보다 오래 버틴다고 잘못 안내).
-    // fallback 적용: 매일 10g → 10일 뒤 소진.
-    const weekdayAvg = new Map([
-      ["MON", new Decimal(10)],
-      ["TUE", new Decimal(10)],
-    ] as const);
+  it("데이터 없는 영업일 타입은 전체 영업일 평균으로 대체 — over-forecast 방지", () => {
     const withFallback = predictDepletionDate({
       currentStock: 100,
-      weekdayAvg,
+      usageModel: {
+        usageByDayType: new Map([["weekday", new Decimal(10)]] as const),
+        fallbackDailyUsage: new Decimal(10),
+      },
       today,
       daysOff: [],
     });
@@ -141,14 +178,36 @@ describe("predictDepletionDate", () => {
     expect(daysUntilDepletion).toBeLessThanOrEqual(11);
   });
 
-  it("weekdayAvg 비어있으면 소진 예측 불가 (null)", () => {
+  it("usageModel 비어있으면 소진 예측 불가 (null)", () => {
     const result = predictDepletionDate({
       currentStock: 100,
-      weekdayAvg: new Map(),
+      usageModel: {
+        usageByDayType: new Map(),
+        fallbackDailyUsage: new Decimal(0),
+      },
       today,
       daysOff: [],
     });
     expect(result).toBeNull();
+  });
+
+  it("최근 추세 계수를 소진일 계산에 반영한다", () => {
+    const normal = predictDepletionDate({
+      currentStock: 100,
+      usageModel: usageModel(10),
+      trendFactor: 1,
+      today,
+      daysOff: [],
+    });
+    const rising = predictDepletionDate({
+      currentStock: 100,
+      usageModel: usageModel(10),
+      trendFactor: 1.25,
+      today,
+      daysOff: [],
+    });
+
+    expect(rising!.getTime()).toBeLessThan(normal!.getTime());
   });
 });
 
@@ -222,6 +281,24 @@ describe("detectTrend (FR-025)", () => {
 
   it("데이터 부족(빈 배열) → normal", () => {
     expect(detectTrend([], today)).toBe("normal");
+  });
+});
+
+describe("computeTrendFactor", () => {
+  it("최근 급증 추세는 상한 1.25로 제한", () => {
+    const samples: DailyConsumption[] = Array.from({ length: 30 }, (_, i) => ({
+      date: daysAgo(i + 1),
+      amount: i < 7 ? 500 : 10,
+    }));
+    expect(computeTrendFactor(samples, today)).toBe(1.25);
+  });
+
+  it("최근 급감 추세는 하한 0.85로 제한", () => {
+    const samples: DailyConsumption[] = Array.from({ length: 30 }, (_, i) => ({
+      date: daysAgo(i + 1),
+      amount: i < 7 ? 1 : 100,
+    }));
+    expect(computeTrendFactor(samples, today)).toBe(0.85);
   });
 });
 


### PR DESCRIPTION
## Summary
- extend depletion forecast raw consumption sample lookback from 30 days to 90 days
- replace day-of-week-only depletion forecasting with business-day-type demand groups: weekday, friday, weekend
- add recency-weighted demand, outlier capping, low-sample shrinkage, and bounded trend factor for depletion simulation
- update forecast unit tests and README algorithm documentation to match the new implementation

## Validation
- npm run lint
- npm run typecheck
- npm run format:check
- npx vitest run tests/unit/forecast.test.ts
- npx vitest run

## Notes
- This keeps Supabase RPC as raw-data provider and leaves final forecast classification in src/lib/domain/forecast.ts.
- Public holiday/weather integration is intentionally left as a later enhancement; this PR adds the stable statistical baseline first.