### PR TITLE
feat: add menu option foundation

### DIFF
--- a/src/lib/domain/menu-options.ts
+++ b/src/lib/domain/menu-options.ts
@@ -1,0 +1,105 @@
+export type MenuOptionSelectionType = "single" | "add_on";
+
+export interface MenuOptionGroupPolicy {
+  groupId: string;
+  selectionType: MenuOptionSelectionType;
+  isRequired: boolean;
+  minSelect: number;
+  maxSelect: number | null;
+}
+
+export interface MenuOptionSelection {
+  optionValueId: string;
+  groupId: string;
+  quantity: number;
+}
+
+export interface OptionRecipeItem {
+  optionValueId: string;
+  ingredientId: string;
+  quantityPerSelection: number;
+}
+
+export interface OptionIngredientRequirement {
+  ingredientId: string;
+  quantity: number;
+}
+
+export function validateMenuOptionSelections({
+  menuQuantity,
+  groups,
+  selections,
+}: {
+  menuQuantity: number;
+  groups: readonly MenuOptionGroupPolicy[];
+  selections: readonly MenuOptionSelection[];
+}): string[] {
+  const errors: string[] = [];
+  const quantitiesByGroup = new Map<string, number>();
+
+  for (const selection of selections) {
+    if (!Number.isInteger(selection.quantity) || selection.quantity <= 0) {
+      errors.push(`invalid_option_quantity:${selection.optionValueId}`);
+      continue;
+    }
+    quantitiesByGroup.set(
+      selection.groupId,
+      (quantitiesByGroup.get(selection.groupId) ?? 0) + selection.quantity,
+    );
+  }
+
+  for (const group of groups) {
+    const selectedQuantity = quantitiesByGroup.get(group.groupId) ?? 0;
+
+    if (group.isRequired && selectedQuantity < menuQuantity) {
+      errors.push(`required_option_missing:${group.groupId}`);
+    }
+    if (selectedQuantity < group.minSelect) {
+      errors.push(`option_min_not_met:${group.groupId}`);
+    }
+    if (group.maxSelect !== null && selectedQuantity > group.maxSelect * menuQuantity) {
+      errors.push(`option_max_exceeded:${group.groupId}`);
+    }
+    if (
+      group.selectionType === "single" &&
+      selectedQuantity !== 0 &&
+      selectedQuantity !== menuQuantity
+    ) {
+      errors.push(`single_option_must_match_menu_quantity:${group.groupId}`);
+    }
+  }
+
+  return errors;
+}
+
+export function computeOptionIngredientRequirements({
+  selections,
+  recipeItems,
+}: {
+  selections: readonly MenuOptionSelection[];
+  recipeItems: readonly OptionRecipeItem[];
+}): OptionIngredientRequirement[] {
+  const selectionQuantityByValue = new Map<string, number>();
+  for (const selection of selections) {
+    selectionQuantityByValue.set(
+      selection.optionValueId,
+      (selectionQuantityByValue.get(selection.optionValueId) ?? 0) + selection.quantity,
+    );
+  }
+
+  const requiredByIngredient = new Map<string, number>();
+  for (const recipeItem of recipeItems) {
+    const selectionQuantity = selectionQuantityByValue.get(recipeItem.optionValueId) ?? 0;
+    if (selectionQuantity <= 0) continue;
+
+    requiredByIngredient.set(
+      recipeItem.ingredientId,
+      (requiredByIngredient.get(recipeItem.ingredientId) ?? 0) +
+        recipeItem.quantityPerSelection * selectionQuantity,
+    );
+  }
+
+  return [...requiredByIngredient.entries()]
+    .map(([ingredientId, quantity]) => ({ ingredientId, quantity }))
+    .sort((a, b) => a.ingredientId.localeCompare(b.ingredientId));
+}

--- a/supabase/migrations/040_menu_options_foundation.sql
+++ b/supabase/migrations/040_menu_options_foundation.sql
@@ -1,0 +1,147 @@
+-- Migration: menu options / modifiers foundation
+--
+-- POS-style customization model:
+-- - option groups belong to a menu (e.g. "빵 선택", "토핑 추가")
+-- - option values can carry price deltas and their own ingredient recipe
+-- - sale_item_options stores sale-time snapshots so past sales stay immutable
+
+create table public.menu_option_groups (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  menu_id uuid not null references public.menus (id) on delete cascade,
+  name text not null,
+  selection_type text not null default 'add_on',
+  is_required boolean not null default false,
+  min_select integer not null default 0,
+  max_select integer,
+  sort_order integer not null default 0,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint menu_option_groups_name_len check (char_length(name) between 1 and 50),
+  constraint menu_option_groups_selection_type check (selection_type in ('single', 'add_on')),
+  constraint menu_option_groups_min_nonneg check (min_select >= 0),
+  constraint menu_option_groups_max_valid check (max_select is null or max_select >= min_select),
+  constraint menu_option_groups_unique_name unique (menu_id, name)
+);
+
+comment on table public.menu_option_groups is
+  '메뉴 옵션 그룹. single=택1/분배형, add_on=추가 토핑형.';
+
+create index menu_option_groups_menu_idx on public.menu_option_groups (menu_id, is_active, sort_order);
+create index menu_option_groups_user_idx on public.menu_option_groups (user_id);
+
+create trigger menu_option_groups_set_updated_at
+before update on public.menu_option_groups
+for each row
+execute function public.set_updated_at();
+
+create table public.menu_option_values (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  option_group_id uuid not null references public.menu_option_groups (id) on delete cascade,
+  name text not null,
+  price_delta numeric(10, 2) not null default 0,
+  is_default boolean not null default false,
+  is_active boolean not null default true,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint menu_option_values_name_len check (char_length(name) between 1 and 50),
+  constraint menu_option_values_price_delta_nonneg check (price_delta >= 0),
+  constraint menu_option_values_unique_name unique (option_group_id, name)
+);
+
+comment on table public.menu_option_values is
+  '옵션 선택지. 판매 시 price_delta와 재료 레시피가 sale_item_options로 스냅샷된다.';
+
+create index menu_option_values_group_idx on public.menu_option_values (option_group_id, is_active, sort_order);
+create index menu_option_values_user_idx on public.menu_option_values (user_id);
+
+create trigger menu_option_values_set_updated_at
+before update on public.menu_option_values
+for each row
+execute function public.set_updated_at();
+
+create table public.menu_option_value_recipe_items (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  option_value_id uuid not null references public.menu_option_values (id) on delete cascade,
+  ingredient_id uuid not null references public.ingredients (id) on delete restrict,
+  quantity_per_selection numeric(12, 3) not null,
+  created_at timestamptz not null default now(),
+
+  constraint menu_option_value_recipe_unique unique (option_value_id, ingredient_id),
+  constraint menu_option_value_recipe_quantity_positive check (quantity_per_selection > 0)
+);
+
+comment on table public.menu_option_value_recipe_items is
+  '옵션 선택 1회당 추가/대체 재료 소모량.';
+
+create index menu_option_value_recipe_option_idx
+on public.menu_option_value_recipe_items (option_value_id);
+
+create index menu_option_value_recipe_ingredient_idx
+on public.menu_option_value_recipe_items (ingredient_id);
+
+create table public.sale_item_options (
+  id uuid primary key default gen_random_uuid(),
+  sale_item_id uuid not null references public.sale_items (id) on delete cascade,
+  user_id uuid not null references public.users (id) on delete cascade,
+  option_group_id uuid not null references public.menu_option_groups (id) on delete restrict,
+  option_value_id uuid not null references public.menu_option_values (id) on delete restrict,
+  quantity integer not null,
+  group_name_snapshot text not null,
+  value_name_snapshot text not null,
+  price_delta_snapshot numeric(10, 2) not null,
+  option_cost_snapshot numeric(14, 4) not null default 0,
+  recipe_items_snapshot jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+
+  constraint sale_item_options_quantity_positive check (quantity > 0),
+  constraint sale_item_options_price_delta_nonneg check (price_delta_snapshot >= 0),
+  constraint sale_item_options_cost_nonneg check (option_cost_snapshot >= 0),
+  constraint sale_item_options_unique_value_per_item unique (sale_item_id, option_value_id)
+);
+
+comment on table public.sale_item_options is
+  '판매 시점 옵션 스냅샷. 옵션명/가격/재료가 나중에 바뀌어도 과거 판매는 불변.';
+
+create index sale_item_options_sale_item_idx on public.sale_item_options (sale_item_id);
+create index sale_item_options_value_idx on public.sale_item_options (option_value_id);
+create index sale_item_options_user_idx on public.sale_item_options (user_id);
+
+alter table public.menu_option_groups enable row level security;
+alter table public.menu_option_values enable row level security;
+alter table public.menu_option_value_recipe_items enable row level security;
+alter table public.sale_item_options enable row level security;
+
+create policy menu_option_groups_isolated
+on public.menu_option_groups
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy menu_option_values_isolated
+on public.menu_option_values
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy menu_option_value_recipe_items_isolated
+on public.menu_option_value_recipe_items
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy sale_item_options_isolated
+on public.sale_item_options
+for select
+using (auth.uid() = user_id);
+
+grant select, insert, update, delete on public.menu_option_groups to authenticated;
+grant select, insert, update, delete on public.menu_option_values to authenticated;
+grant select, insert, update, delete on public.menu_option_value_recipe_items to authenticated;
+grant select on public.sale_item_options to authenticated;

--- a/tests/unit/menu-options.test.ts
+++ b/tests/unit/menu-options.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeOptionIngredientRequirements,
+  validateMenuOptionSelections,
+  type MenuOptionGroupPolicy,
+} from "@/lib/domain/menu-options";
+
+describe("menu option domain", () => {
+  const breadGroup: MenuOptionGroupPolicy = {
+    groupId: "bread",
+    selectionType: "single",
+    isRequired: true,
+    minSelect: 0,
+    maxSelect: 1,
+  };
+
+  const toppingGroup: MenuOptionGroupPolicy = {
+    groupId: "topping",
+    selectionType: "add_on",
+    isRequired: false,
+    minSelect: 0,
+    maxSelect: 2,
+  };
+
+  it("single 옵션은 메뉴 수량과 선택 합계가 같아야 한다", () => {
+    expect(
+      validateMenuOptionSelections({
+        menuQuantity: 10,
+        groups: [breadGroup],
+        selections: [
+          { groupId: "bread", optionValueId: "milk-bread", quantity: 7 },
+          { groupId: "bread", optionValueId: "wheat-bread", quantity: 3 },
+        ],
+      }),
+    ).toEqual([]);
+
+    expect(
+      validateMenuOptionSelections({
+        menuQuantity: 10,
+        groups: [breadGroup],
+        selections: [{ groupId: "bread", optionValueId: "milk-bread", quantity: 8 }],
+      }),
+    ).toContain("required_option_missing:bread");
+  });
+
+  it("add_on 옵션은 메뉴 수량 대비 maxSelect 배수까지 허용한다", () => {
+    expect(
+      validateMenuOptionSelections({
+        menuQuantity: 5,
+        groups: [toppingGroup],
+        selections: [{ groupId: "topping", optionValueId: "condensed-milk", quantity: 10 }],
+      }),
+    ).toEqual([]);
+
+    expect(
+      validateMenuOptionSelections({
+        menuQuantity: 5,
+        groups: [toppingGroup],
+        selections: [{ groupId: "topping", optionValueId: "condensed-milk", quantity: 11 }],
+      }),
+    ).toContain("option_max_exceeded:topping");
+  });
+
+  it("옵션 선택량과 옵션 레시피로 재료 소요량을 합산한다", () => {
+    expect(
+      computeOptionIngredientRequirements({
+        selections: [
+          { groupId: "bread", optionValueId: "wheat-bread", quantity: 6 },
+          { groupId: "topping", optionValueId: "condensed-milk", quantity: 4 },
+        ],
+        recipeItems: [
+          { optionValueId: "wheat-bread", ingredientId: "whole-wheat", quantityPerSelection: 2 },
+          { optionValueId: "condensed-milk", ingredientId: "milk", quantityPerSelection: 30 },
+        ],
+      }),
+    ).toEqual([
+      { ingredientId: "milk", quantity: 120 },
+      { ingredientId: "whole-wheat", quantity: 12 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add menu option/modifier tables for option groups, option values, option recipes, and sale-time option snapshots
- add RLS, indexes, constraints, and grants for the option foundation
- add pure domain helpers for option selection validation and option ingredient requirement expansion
- add unit tests for single-option quantity matching, add-on max limits, and option recipe ingredient rollups

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/menu-options.test.ts
- npx vitest run

## Notes
- This PR intentionally does not wire option payloads into save_sale/edit_sale yet.
- Keeping the write path separate avoids accepting option selections before backend stock/cost replay can apply them safely.