### PR TITLE
Add sale option selection UI

### DIFF
--- a/src/app/(main)/menu/[id]/edit/page.tsx
+++ b/src/app/(main)/menu/[id]/edit/page.tsx
@@ -66,5 +66,21 @@ function toInitialValues(
       ingredientId: item.ingredient.id,
       quantityPerServing: item.quantity_per_serving,
     })),
+    optionGroups: menu.option_groups.map((group) => ({
+      name: group.name,
+      selectionType: group.selection_type,
+      isRequired: group.is_required,
+      minSelect: group.min_select,
+      maxSelect: group.max_select,
+      values: group.values.map((value) => ({
+        name: value.name,
+        priceDelta: value.price_delta,
+        isDefault: value.is_default,
+        recipe: value.recipe_items.map((item) => ({
+          ingredientId: item.ingredient.id,
+          quantityPerSelection: item.quantity_per_selection,
+        })),
+      })),
+    })),
   };
 }

--- a/src/features/menu/components/MenuDetailCard.tsx
+++ b/src/features/menu/components/MenuDetailCard.tsx
@@ -46,6 +46,39 @@ export function MenuDetailCard({ menu }: MenuDetailCardProps): React.ReactElemen
         </ul>
       )}
 
+      {menu.option_groups.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h3 className="text-caption font-semibold text-ink-2">옵션 구성</h3>
+          <ul className="flex flex-col gap-3">
+            {menu.option_groups.map((group) => (
+              <li key={group.id} className="rounded-3xl bg-slate-50/85 px-4 py-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-body-regular text-ink-1">{group.name}</span>
+                    <span className="text-caption text-ink-3">
+                      {group.selection_type === "single" ? "택1형" : "추가형"} ·{" "}
+                      {group.is_required ? "필수" : "선택"} · 최소 {group.min_select}
+                      {group.max_select !== null ? ` / 최대 ${group.max_select}` : ""}
+                    </span>
+                  </div>
+                </div>
+                <ul className="mt-3 flex flex-col gap-2">
+                  {group.values.map((value) => (
+                    <li
+                      key={value.id}
+                      className="flex items-center justify-between rounded-2xl bg-white px-3 py-2 text-caption text-ink-2"
+                    >
+                      <span>{value.name}</span>
+                      <span className="tabular-nums">+{formatWon(value.price_delta)}원</span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       {hasRecipe && (
         <footer className="rounded-3xl bg-slate-50/90 px-4 py-4">
           <div className="flex items-baseline justify-between">

--- a/src/features/menu/components/MenuForm.tsx
+++ b/src/features/menu/components/MenuForm.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { useForm, useFieldArray } from "react-hook-form";
+import { useForm, useFieldArray, type Control, type UseFormRegister } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { Field } from "@/components/ui/field";
@@ -38,10 +38,18 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
     formState: { errors, isSubmitting },
   } = useForm<MenuInput>({
     resolver: zodResolver(menuSchema),
-    defaultValues: mode.kind === "edit" ? mode.initialValues : { name: "", price: 0, recipe: [] },
+    defaultValues:
+      mode.kind === "edit"
+        ? mode.initialValues
+        : { name: "", price: 0, recipe: [], optionGroups: [] },
   });
 
   const { fields, append, remove } = useFieldArray({ control, name: "recipe" });
+  const {
+    fields: optionGroupFields,
+    append: appendOptionGroup,
+    remove: removeOptionGroup,
+  } = useFieldArray({ control, name: "optionGroups" });
 
   async function onSubmit(values: MenuInput): Promise<void> {
     setSubmitError(null);
@@ -99,7 +107,7 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
           <button
             type="button"
             onClick={() =>
-              append({ ingredientId: ingredients[0]?.id ?? "", quantityPerServing: 0 })
+              append({ ingredientId: ingredients[0]?.id ?? "", quantityPerServing: 1 })
             }
             className="rounded-md border border-border px-stack py-1 text-label text-ink-2 hover:bg-card-hover"
             disabled={ingredients.length === 0}
@@ -126,6 +134,50 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
         ))}
       </section>
 
+      <section className="flex flex-col gap-stack-tight">
+        <header className="flex items-center justify-between">
+          <div className="flex flex-col gap-1">
+            <span className="text-label text-ink-2">옵션 / 커스터마이징</span>
+            <span className="text-caption text-ink-3">
+              예: 빵 선택, 연유 추가, 샷 추가처럼 추가금과 추가 재료를 관리합니다.
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() =>
+              appendOptionGroup({
+                name: "",
+                selectionType: "add_on",
+                isRequired: false,
+                minSelect: 0,
+                maxSelect: null,
+                values: [],
+              })
+            }
+            className="rounded-md border border-border px-stack py-1 text-label text-ink-2 hover:bg-card-hover"
+          >
+            + 옵션 그룹
+          </button>
+        </header>
+
+        {optionGroupFields.length === 0 && (
+          <p className="rounded-3xl bg-slate-50 px-4 py-3 text-caption text-ink-3">
+            옵션이 없는 메뉴면 비워두면 됩니다.
+          </p>
+        )}
+
+        {optionGroupFields.map((field, idx) => (
+          <OptionGroupEditor
+            key={field.id}
+            groupIdx={idx}
+            control={control}
+            register={register}
+            ingredients={ingredients}
+            onRemove={() => removeOptionGroup(idx)}
+          />
+        ))}
+      </section>
+
       {submitError && (
         <p role="alert" className="text-body-regular text-red">
           {submitError}
@@ -141,10 +193,209 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
 
 interface RecipeRowProps {
   idx: number;
-  register: ReturnType<typeof useForm<MenuInput>>["register"];
+  register: UseFormRegister<MenuInput>;
   ingredients: readonly IngredientOption[];
   onRemove: () => void;
   error?: string;
+}
+
+interface OptionGroupEditorProps {
+  groupIdx: number;
+  control: Control<MenuInput>;
+  register: UseFormRegister<MenuInput>;
+  ingredients: readonly IngredientOption[];
+  onRemove: () => void;
+}
+
+function OptionGroupEditor({
+  groupIdx,
+  control,
+  register,
+  ingredients,
+  onRemove,
+}: OptionGroupEditorProps): React.ReactElement {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `optionGroups.${groupIdx}.values` as const,
+  });
+
+  return (
+    <article className="flex flex-col gap-stack rounded-[28px] border border-border bg-card p-stack shadow-soft">
+      <div className="grid gap-stack-tight md:grid-cols-[1fr_150px_auto_auto] md:items-end">
+        <Field label="그룹명">
+          <input
+            {...register(`optionGroups.${groupIdx}.name`)}
+            placeholder="예: 토핑 추가"
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+          />
+        </Field>
+        <Field label="방식">
+          <select
+            {...register(`optionGroups.${groupIdx}.selectionType`)}
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+          >
+            <option value="add_on">추가형</option>
+            <option value="single">택1형</option>
+          </select>
+        </Field>
+        <label className="flex items-center gap-2 rounded-md border border-border px-stack py-stack-tight text-caption text-ink-2">
+          <input type="checkbox" {...register(`optionGroups.${groupIdx}.isRequired`)} />
+          필수
+        </label>
+        <button type="button" onClick={onRemove} className="text-caption text-ink-3 hover:text-red">
+          그룹 삭제
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-stack-tight">
+        <Field label="최소 선택">
+          <input
+            {...register(`optionGroups.${groupIdx}.minSelect`, { valueAsNumber: true })}
+            type="number"
+            min={0}
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+          />
+        </Field>
+        <Field label="최대 선택 (비우면 제한 없음)">
+          <input
+            {...register(`optionGroups.${groupIdx}.maxSelect`, {
+              setValueAs: (value) => (value === "" ? null : Number(value)),
+            })}
+            type="number"
+            min={1}
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+          />
+        </Field>
+      </div>
+
+      <div className="flex flex-col gap-stack-tight">
+        <header className="flex items-center justify-between">
+          <span className="text-caption font-semibold text-ink-2">선택지</span>
+          <button
+            type="button"
+            onClick={() => append({ name: "", priceDelta: 0, isDefault: false, recipe: [] })}
+            className="rounded-md border border-border px-stack py-1 text-caption text-ink-2 hover:bg-card-hover"
+          >
+            + 선택지
+          </button>
+        </header>
+        {fields.map((field, valueIdx) => (
+          <OptionValueEditor
+            key={field.id}
+            groupIdx={groupIdx}
+            valueIdx={valueIdx}
+            control={control}
+            register={register}
+            ingredients={ingredients}
+            onRemove={() => remove(valueIdx)}
+          />
+        ))}
+      </div>
+    </article>
+  );
+}
+
+interface OptionValueEditorProps extends Omit<OptionGroupEditorProps, "groupIdx" | "onRemove"> {
+  groupIdx: number;
+  valueIdx: number;
+  onRemove: () => void;
+}
+
+function OptionValueEditor({
+  groupIdx,
+  valueIdx,
+  control,
+  register,
+  ingredients,
+  onRemove,
+}: OptionValueEditorProps): React.ReactElement {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `optionGroups.${groupIdx}.values.${valueIdx}.recipe` as const,
+  });
+
+  return (
+    <div className="flex flex-col gap-stack-tight rounded-3xl bg-slate-50/90 p-stack-tight">
+      <div className="grid gap-stack-tight md:grid-cols-[1fr_120px_auto_auto] md:items-end">
+        <Field label="옵션명">
+          <input
+            {...register(`optionGroups.${groupIdx}.values.${valueIdx}.name`)}
+            placeholder="예: 연유 추가"
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+          />
+        </Field>
+        <Field label="추가금">
+          <input
+            {...register(`optionGroups.${groupIdx}.values.${valueIdx}.priceDelta`, {
+              valueAsNumber: true,
+            })}
+            type="number"
+            min={0}
+            className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+          />
+        </Field>
+        <label className="flex items-center gap-2 rounded-md border border-border bg-white px-stack py-stack-tight text-caption text-ink-2">
+          <input
+            type="checkbox"
+            {...register(`optionGroups.${groupIdx}.values.${valueIdx}.isDefault`)}
+          />
+          기본
+        </label>
+        <button type="button" onClick={onRemove} className="text-caption text-ink-3 hover:text-red">
+          삭제
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={() =>
+            append({ ingredientId: ingredients[0]?.id ?? "", quantityPerSelection: 1 })
+          }
+          disabled={ingredients.length === 0}
+          className="self-start rounded-md border border-border px-stack py-1 text-caption text-ink-2 hover:bg-card-hover disabled:opacity-50"
+        >
+          + 옵션 재료
+        </button>
+        {fields.map((field, recipeIdx) => (
+          <div
+            key={field.id}
+            className="grid grid-cols-[1fr_100px_auto] items-center gap-stack-tight"
+          >
+            <select
+              {...register(
+                `optionGroups.${groupIdx}.values.${valueIdx}.recipe.${recipeIdx}.ingredientId`,
+              )}
+              className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1"
+            >
+              {ingredients.map((ing) => (
+                <option key={ing.id} value={ing.id}>
+                  {ing.name} ({ing.unit})
+                </option>
+              ))}
+            </select>
+            <input
+              {...register(
+                `optionGroups.${groupIdx}.values.${valueIdx}.recipe.${recipeIdx}.quantityPerSelection`,
+                { valueAsNumber: true },
+              )}
+              type="number"
+              min={0}
+              step="0.001"
+              className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
+            />
+            <button
+              type="button"
+              onClick={() => remove(recipeIdx)}
+              className="text-caption text-ink-3 hover:text-red"
+            >
+              삭제
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function RecipeRow({

--- a/src/features/menu/components/MenuForm.tsx
+++ b/src/features/menu/components/MenuForm.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { useForm, useFieldArray, type Control, type UseFormRegister } from "react-hook-form";
+import { useEffect, useState } from "react";
+import {
+  useForm,
+  useFieldArray,
+  type Control,
+  type UseFormRegister,
+  type UseFormSetValue,
+  type UseFormWatch,
+} from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { Field } from "@/components/ui/field";
@@ -35,6 +42,8 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
     register,
     handleSubmit,
     control,
+    watch,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm<MenuInput>({
     resolver: zodResolver(menuSchema),
@@ -103,39 +112,6 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
 
       <section className="flex flex-col gap-stack-tight">
         <header className="flex items-center justify-between">
-          <span className="text-label text-ink-2">레시피 (1회 제공량)</span>
-          <button
-            type="button"
-            onClick={() =>
-              append({ ingredientId: ingredients[0]?.id ?? "", quantityPerServing: 1 })
-            }
-            className="rounded-md border border-border px-stack py-1 text-label text-ink-2 hover:bg-card-hover"
-            disabled={ingredients.length === 0}
-          >
-            + 재료 추가
-          </button>
-        </header>
-
-        {ingredients.length === 0 && (
-          <p className="text-caption text-ink-3">
-            재료를 먼저 등록해주세요. (템플릿 불러오면 재료/메뉴가 함께 만들어집니다.)
-          </p>
-        )}
-
-        {fields.map((field, idx) => (
-          <RecipeRow
-            key={field.id}
-            idx={idx}
-            register={register}
-            ingredients={ingredients}
-            onRemove={() => remove(idx)}
-            error={errors.recipe?.[idx]?.quantityPerServing?.message}
-          />
-        ))}
-      </section>
-
-      <section className="flex flex-col gap-stack-tight">
-        <header className="flex items-center justify-between">
           <div className="flex flex-col gap-1">
             <span className="text-label text-ink-2">옵션 / 커스터마이징</span>
             <span className="text-caption text-ink-3">
@@ -171,9 +147,44 @@ export function MenuForm({ ingredients, mode }: MenuFormProps): React.ReactEleme
             key={field.id}
             groupIdx={idx}
             control={control}
+            watch={watch}
+            setValue={setValue}
             register={register}
             ingredients={ingredients}
             onRemove={() => removeOptionGroup(idx)}
+          />
+        ))}
+      </section>
+
+      <section className="flex flex-col gap-stack-tight">
+        <header className="flex items-center justify-between">
+          <span className="text-label text-ink-2">레시피 (1회 제공량)</span>
+          <button
+            type="button"
+            onClick={() =>
+              append({ ingredientId: ingredients[0]?.id ?? "", quantityPerServing: 1 })
+            }
+            className="rounded-md border border-border px-stack py-1 text-label text-ink-2 hover:bg-card-hover"
+            disabled={ingredients.length === 0}
+          >
+            + 재료 추가
+          </button>
+        </header>
+
+        {ingredients.length === 0 && (
+          <p className="text-caption text-ink-3">
+            재료를 먼저 등록해주세요. (템플릿 불러오면 재료/메뉴가 함께 만들어집니다.)
+          </p>
+        )}
+
+        {fields.map((field, idx) => (
+          <RecipeRow
+            key={field.id}
+            idx={idx}
+            register={register}
+            ingredients={ingredients}
+            onRemove={() => remove(idx)}
+            error={errors.recipe?.[idx]?.quantityPerServing?.message}
           />
         ))}
       </section>
@@ -202,6 +213,8 @@ interface RecipeRowProps {
 interface OptionGroupEditorProps {
   groupIdx: number;
   control: Control<MenuInput>;
+  watch: UseFormWatch<MenuInput>;
+  setValue: UseFormSetValue<MenuInput>;
   register: UseFormRegister<MenuInput>;
   ingredients: readonly IngredientOption[];
   onRemove: () => void;
@@ -210,10 +223,24 @@ interface OptionGroupEditorProps {
 function OptionGroupEditor({
   groupIdx,
   control,
+  watch,
+  setValue,
   register,
   ingredients,
   onRemove,
 }: OptionGroupEditorProps): React.ReactElement {
+  const selectionType = watch(`optionGroups.${groupIdx}.selectionType`);
+  const minSelect = watch(`optionGroups.${groupIdx}.minSelect`);
+  const maxSelect = watch(`optionGroups.${groupIdx}.maxSelect`);
+  const isRequired = watch(`optionGroups.${groupIdx}.isRequired`);
+
+  useEffect(() => {
+    if (selectionType !== "single") return;
+    if (minSelect !== 1) setValue(`optionGroups.${groupIdx}.minSelect`, 1, { shouldDirty: true });
+    if (maxSelect !== 1) setValue(`optionGroups.${groupIdx}.maxSelect`, 1, { shouldDirty: true });
+    if (!isRequired) setValue(`optionGroups.${groupIdx}.isRequired`, true, { shouldDirty: true });
+  }, [groupIdx, isRequired, maxSelect, minSelect, selectionType, setValue]);
+
   const { fields, append, remove } = useFieldArray({
     control,
     name: `optionGroups.${groupIdx}.values` as const,
@@ -247,12 +274,19 @@ function OptionGroupEditor({
         </button>
       </div>
 
+      <p className="rounded-2xl bg-slate-50 px-3 py-2 text-caption text-ink-3">
+        {selectionType === "single"
+          ? "택1형은 판매할 때 메뉴 수량만큼 정확히 하나씩 선택하게 됩니다. 최소/최대 선택은 1로 고정됩니다."
+          : "추가형은 여러 개를 더하거나 0개로 비워둘 수 있습니다."}
+      </p>
+
       <div className="grid grid-cols-2 gap-stack-tight">
         <Field label="최소 선택">
           <input
             {...register(`optionGroups.${groupIdx}.minSelect`, { valueAsNumber: true })}
             type="number"
             min={0}
+            disabled={selectionType === "single"}
             className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
           />
         </Field>
@@ -263,6 +297,7 @@ function OptionGroupEditor({
             })}
             type="number"
             min={1}
+            disabled={selectionType === "single"}
             className="rounded-md border border-border bg-card px-stack py-stack-tight text-body-regular text-ink-1 tabular-nums"
           />
         </Field>
@@ -295,7 +330,10 @@ function OptionGroupEditor({
   );
 }
 
-interface OptionValueEditorProps extends Omit<OptionGroupEditorProps, "groupIdx" | "onRemove"> {
+interface OptionValueEditorProps extends Omit<
+  OptionGroupEditorProps,
+  "groupIdx" | "onRemove" | "watch" | "setValue"
+> {
   groupIdx: number;
   valueIdx: number;
   onRemove: () => void;

--- a/src/features/menu/hooks/useMenuMutations.ts
+++ b/src/features/menu/hooks/useMenuMutations.ts
@@ -34,6 +34,7 @@ export function useEditMenu(): UseMutationResult<string, Error, EditMenuVariable
         name: values.name,
         price: values.price,
         recipe: values.recipe,
+        optionGroups: values.optionGroups,
       };
       return updateMenu(supabase, payload);
     },

--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -2,7 +2,7 @@
 
 import { useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
-import { loadMenus, type MenuRowWithRecipe } from "@/lib/application/lookups";
+import { loadMenus, type LookupClient, type MenuRowWithRecipe } from "@/lib/application/lookups";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 
 /**
@@ -19,9 +19,8 @@ export type { MenuRowWithRecipe } from "@/lib/application/lookups";
 export const menuListQueryKey = ["menus", "list"] as const;
 
 async function fetchMenus(): Promise<MenuRowWithRecipe[]> {
-  const supabase = createClient();
-  await (supabase as never as { auth: { getSession: () => Promise<unknown> } }).auth.getSession();
-  return loadMenus(supabase as unknown as import("@/lib/application/lookups").LookupClient);
+  const supabase = createClient() as unknown as LookupClient;
+  return loadMenus(supabase);
 }
 
 export function useMenus(): UseQueryResult<MenuRowWithRecipe[]> {

--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -19,14 +19,18 @@ export type { MenuRowWithRecipe } from "@/lib/application/lookups";
 export const menuListQueryKey = ["menus", "list"] as const;
 
 async function fetchMenus(): Promise<MenuRowWithRecipe[]> {
-  const supabase = createClient() as unknown as import("@/lib/application/lookups").LookupClient;
-  return loadMenus(supabase);
+  const supabase = createClient();
+  await (supabase as never as { auth: { getSession: () => Promise<unknown> } }).auth.getSession();
+  return loadMenus(supabase as unknown as import("@/lib/application/lookups").LookupClient);
 }
 
 export function useMenus(): UseQueryResult<MenuRowWithRecipe[]> {
   return useQuery({
     queryKey: menuListQueryKey,
     queryFn: fetchMenus,
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/src/features/menu/schemas.ts
+++ b/src/features/menu/schemas.ts
@@ -13,10 +13,32 @@ export const recipeItemSchema = z.object({
 
 export type RecipeItemInput = z.infer<typeof recipeItemSchema>;
 
+export const optionRecipeItemSchema = z.object({
+  ingredientId: z.string().uuid(),
+  quantityPerSelection: z.number().positive(),
+});
+
+export const optionValueSchema = z.object({
+  name: z.string().min(1, "옵션명을 입력해주세요").max(50, "50자 이내로 입력해주세요"),
+  priceDelta: z.number().nonnegative("추가금은 0원 이상이어야 합니다"),
+  isDefault: z.boolean().default(false),
+  recipe: z.array(optionRecipeItemSchema).default([]),
+});
+
+export const optionGroupSchema = z.object({
+  name: z.string().min(1, "옵션 그룹명을 입력해주세요").max(50, "50자 이내로 입력해주세요"),
+  selectionType: z.enum(["single", "add_on"]).default("add_on"),
+  isRequired: z.boolean().default(false),
+  minSelect: z.number().int().nonnegative().default(0),
+  maxSelect: z.number().int().positive().nullable().optional(),
+  values: z.array(optionValueSchema).default([]),
+});
+
 export const menuSchema = z.object({
   name: z.string().min(1, "메뉴 이름을 입력해주세요").max(50, "50자 이내로 입력해주세요"),
   price: z.number().nonnegative("가격은 0원 이상이어야 합니다"),
   recipe: z.array(recipeItemSchema).default([]),
+  optionGroups: z.array(optionGroupSchema).default([]),
 });
 
 export type MenuInput = z.infer<typeof menuSchema>;

--- a/src/features/sale/components/MenuRow.tsx
+++ b/src/features/sale/components/MenuRow.tsx
@@ -24,7 +24,7 @@ export function MenuRow({
   const isActive = quantity > 0;
   const hasOptionControls = menu.option_groups.length > 0 && onOptionChange !== undefined;
   const selectedOptionByValue = new Map(optionSelections.map((item) => [item.optionValueId, item]));
-  const showOptions = hasOptionControls && (isActive || optionSelections.length > 0);
+  const showOptions = hasOptionControls;
   const [open, setOpen] = useState(showOptions);
 
   useEffect(() => {
@@ -52,7 +52,7 @@ export function MenuRow({
                 onClick={() => setOpen((prev) => !prev)}
                 className="rounded-full border border-border bg-white px-2 py-1 text-[11px] text-ink-3 hover:text-ink-2"
               >
-                {open ? "옵션 닫기" : "옵션"}
+                {open ? "옵션 닫기" : "옵션 보기"}
               </button>
             )}
           </div>
@@ -96,6 +96,10 @@ export function MenuRow({
 
       {showOptions && open && (
         <div className="mt-4 flex flex-col gap-3 rounded-3xl bg-slate-50/90 p-4">
+          <p className="text-[11px] text-ink-3">
+            판매 수량을 입력하면 아래 옵션을 같이 고를 수 있어요. 택1형은 메뉴 수량만큼 정확히
+            맞춰야 합니다.
+          </p>
           {menu.option_groups.map((group) => (
             <div key={group.id} className="flex flex-col gap-2">
               <div className="flex items-center justify-between gap-3">

--- a/src/features/sale/components/MenuRow.tsx
+++ b/src/features/sale/components/MenuRow.tsx
@@ -116,6 +116,12 @@ export function MenuRow({
               </div>
 
               <div className="flex flex-col gap-2">
+                {group.values.length === 0 && (
+                  <p className="rounded-2xl border border-dashed border-border bg-white/70 px-3 py-3 text-[11px] text-ink-3">
+                    이 그룹에는 아직 선택지가 없어요. 메뉴 수정에서 옵션값을 추가해야 판매 입력에
+                    선택 버튼이 생깁니다.
+                  </p>
+                )}
                 {group.values.map((value) => {
                   const current = selectedOptionByValue.get(value.id)?.quantity ?? 0;
                   return (

--- a/src/features/sale/components/MenuRow.tsx
+++ b/src/features/sale/components/MenuRow.tsx
@@ -1,67 +1,179 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/lib/utils/format";
 import type { MenuRowWithRecipe } from "@/features/menu/hooks/useMenus";
+import type { SaleDraftOptionItem } from "@/stores/sale-draft";
 
 interface MenuRowProps {
   menu: MenuRowWithRecipe;
   quantity: number;
   onChange: (next: number) => void;
+  optionSelections?: readonly SaleDraftOptionItem[];
+  onOptionChange?: (groupId: string, optionValueId: string, quantity: number) => void;
 }
 
-export function MenuRow({ menu, quantity, onChange }: MenuRowProps): React.ReactElement {
+export function MenuRow({
+  menu,
+  quantity,
+  onChange,
+  optionSelections = [],
+  onOptionChange,
+}: MenuRowProps): React.ReactElement {
   const isActive = quantity > 0;
+  const hasOptionControls = menu.option_groups.length > 0 && onOptionChange !== undefined;
+  const selectedOptionByValue = new Map(optionSelections.map((item) => [item.optionValueId, item]));
+  const showOptions = hasOptionControls && (isActive || optionSelections.length > 0);
+  const [open, setOpen] = useState(showOptions);
+
+  useEffect(() => {
+    if (showOptions) setOpen(true);
+  }, [showOptions]);
 
   return (
     <li
       className={cn(
-        "glow-panel flex items-center justify-between rounded-[28px] border px-5 py-4 shadow-soft transition",
+        "glow-panel flex flex-col gap-4 rounded-[28px] border px-5 py-4 shadow-soft transition",
         isActive
           ? "border-brand-primary/25 bg-white shadow-card ring-1 ring-brand-primary/10"
           : "border-white/70 bg-white/92",
       )}
     >
-      <div className="flex flex-col gap-1">
-        <span className={cn("text-body font-semibold", isActive ? "text-ink-1" : "text-ink-2")}>
-          {menu.name}
-        </span>
-        <span className="text-caption text-ink-3 tabular-nums">{formatNumber(menu.price)}원</span>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className={cn("text-body font-semibold", isActive ? "text-ink-1" : "text-ink-2")}>
+              {menu.name}
+            </span>
+            {hasOptionControls && (
+              <button
+                type="button"
+                onClick={() => setOpen((prev) => !prev)}
+                className="rounded-full border border-border bg-white px-2 py-1 text-[11px] text-ink-3 hover:text-ink-2"
+              >
+                {open ? "옵션 닫기" : "옵션"}
+              </button>
+            )}
+          </div>
+          <span className="text-caption text-ink-3 tabular-nums">{formatNumber(menu.price)}원</span>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-2xl border border-border bg-white p-1.5 shadow-soft">
+          <button
+            type="button"
+            onClick={() => onChange(Math.max(0, quantity - 1))}
+            disabled={quantity === 0}
+            aria-label={`${menu.name} 수량 -1`}
+            className="h-11 w-11 rounded-2xl border border-border bg-slate-100 text-title-md font-semibold text-ink-2 shadow-soft transition hover:bg-slate-200 disabled:text-ink-4 disabled:shadow-none"
+          >
+            −
+          </button>
+
+          <input
+            type="number"
+            min={0}
+            inputMode="numeric"
+            aria-label={`${menu.name} 수량`}
+            value={quantity}
+            onChange={(e) => {
+              const n = Number(e.target.value);
+              onChange(Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0);
+            }}
+            className="w-16 rounded-2xl border border-border bg-white py-2 text-center text-body-regular font-semibold text-ink-1 tabular-nums shadow-soft"
+          />
+
+          <button
+            type="button"
+            onClick={() => onChange(quantity + 1)}
+            aria-label={`${menu.name} 수량 +1`}
+            className="h-11 w-11 rounded-2xl bg-blue text-title-md font-semibold text-white shadow-soft transition hover:bg-blue-deep"
+          >
+            +
+          </button>
+        </div>
       </div>
 
-      <div className="flex items-center gap-2 rounded-2xl border border-border bg-white p-1.5 shadow-soft">
-        <button
-          type="button"
-          onClick={() => onChange(Math.max(0, quantity - 1))}
-          disabled={quantity === 0}
-          aria-label={`${menu.name} 수량 -1`}
-          className="h-11 w-11 rounded-2xl border border-border bg-slate-100 text-title-md font-semibold text-ink-2 shadow-soft transition hover:bg-slate-200 disabled:text-ink-4 disabled:shadow-none"
-        >
-          −
-        </button>
+      {showOptions && open && (
+        <div className="mt-4 flex flex-col gap-3 rounded-3xl bg-slate-50/90 p-4">
+          {menu.option_groups.map((group) => (
+            <div key={group.id} className="flex flex-col gap-2">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex flex-col gap-1">
+                  <span className="text-caption font-semibold text-ink-2">{group.name}</span>
+                  <span className="text-[11px] text-ink-3">
+                    {group.selection_type === "single" ? "택1형" : "추가형"} ·{" "}
+                    {group.is_required ? "필수" : "선택"} · 선택 수량은 판매 수량 기준
+                  </span>
+                </div>
+                <span className="text-[11px] text-ink-3">
+                  {quantity > 0 ? `판매 ${quantity}개` : "수량을 먼저 입력"}
+                </span>
+              </div>
 
-        <input
-          type="number"
-          min={0}
-          inputMode="numeric"
-          aria-label={`${menu.name} 수량`}
-          value={quantity}
-          onChange={(e) => {
-            const n = Number(e.target.value);
-            onChange(Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0);
-          }}
-          className="w-16 rounded-2xl border border-border bg-white py-2 text-center text-body-regular font-semibold text-ink-1 tabular-nums shadow-soft"
-        />
+              <div className="flex flex-col gap-2">
+                {group.values.map((value) => {
+                  const current = selectedOptionByValue.get(value.id)?.quantity ?? 0;
+                  return (
+                    <div
+                      key={value.id}
+                      className={cn(
+                        "grid grid-cols-[1fr_auto] items-center gap-3 rounded-2xl border px-3 py-2",
+                        current > 0
+                          ? "border-brand-primary/20 bg-white"
+                          : "border-white bg-white/80",
+                      )}
+                    >
+                      <div className="flex min-w-0 flex-col gap-0.5">
+                        <span className="truncate text-body-regular text-ink-1">{value.name}</span>
+                        <span className="text-[11px] text-ink-3 tabular-nums">
+                          +{formatNumber(value.price_delta)}원
+                        </span>
+                      </div>
 
-        <button
-          type="button"
-          onClick={() => onChange(quantity + 1)}
-          aria-label={`${menu.name} 수량 +1`}
-          className="h-11 w-11 rounded-2xl bg-blue text-title-md font-semibold text-white shadow-soft transition hover:bg-blue-deep"
-        >
-          +
-        </button>
-      </div>
+                      <div className="flex items-center gap-1 rounded-2xl border border-border bg-white p-1">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            onOptionChange?.(group.id, value.id, Math.max(0, current - 1))
+                          }
+                          disabled={current === 0 || quantity === 0}
+                          className="h-9 w-9 rounded-xl border border-border bg-slate-100 text-ink-2 disabled:opacity-40"
+                        >
+                          −
+                        </button>
+                        <input
+                          type="number"
+                          min={0}
+                          max={quantity > 0 ? quantity : undefined}
+                          value={current}
+                          onChange={(event) => {
+                            const next = Number(event.target.value);
+                            onOptionChange?.(
+                              group.id,
+                              value.id,
+                              Number.isFinite(next) && next >= 0 ? Math.floor(next) : 0,
+                            );
+                          }}
+                          className="w-14 rounded-xl border border-border bg-white py-2 text-center text-caption font-semibold text-ink-1 tabular-nums"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => onOptionChange?.(group.id, value.id, current + 1)}
+                          disabled={quantity === 0}
+                          className="h-9 w-9 rounded-xl bg-blue text-white disabled:opacity-40"
+                        >
+                          +
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </li>
   );
 }

--- a/src/features/sale/components/SaleEditForm.tsx
+++ b/src/features/sale/components/SaleEditForm.tsx
@@ -14,6 +14,9 @@ import type { SaleWithItems } from "../hooks/useSaleByDate";
 import { MenuRow } from "./MenuRow";
 import { StickyTotalCard } from "./StickyTotalCard";
 import { SaleSaveBar } from "./SaleSaveBar";
+import type { SaleDraftOptionItem } from "@/stores/sale-draft";
+import { SaleErrorNotice } from "./SaleErrorNotice";
+import { formatSaleErrorMessage } from "@/lib/application/sale";
 
 interface SaleEditFormProps {
   sale: SaleWithItems;
@@ -30,23 +33,29 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
   const [quantities, setQuantities] = useState<Map<string, number>>(
     () => new Map(sale.items.map((it) => [it.menu_id, it.quantity])),
   );
+  const [optionSelections, setOptionSelections] = useState<Map<string, SaleDraftOptionItem[]>>(
+    () =>
+      new Map(
+        sale.items.map((it) => [
+          it.menu_id,
+          it.options.map((option) => ({
+            groupId: option.option_group_id,
+            optionValueId: option.option_value_id,
+            quantity: option.quantity,
+          })),
+        ]),
+      ),
+  );
   const [reason, setReason] = useState("");
 
   // quantities Map identity가 매번 새로워서 useMemo가 skip 못 함 → inline derive.
   const items = Array.from(quantities.entries())
     .filter(([, qty]) => qty > 0)
     .map(([menuId, quantity]) => {
-      const saleItem = sale.items.find((item) => item.menu_id === menuId);
       return {
         menuId,
         quantity,
-        options: saleItem
-          ? saleItem.options.map((option) => ({
-              groupId: option.option_group_id,
-              optionValueId: option.option_value_id,
-              quantity: option.quantity,
-            }))
-          : undefined,
+        options: optionSelections.get(menuId) ?? [],
       };
     });
   const activeMenuIds = menus ? new Set(menus.map((menu) => menu.id)) : null;
@@ -94,9 +103,34 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
       const updated = new Map(prev);
       if (next <= 0) {
         updated.delete(menuId);
+        setOptionSelections((prevOptions) => {
+          const updatedOptions = new Map(prevOptions);
+          updatedOptions.delete(menuId);
+          return updatedOptions;
+        });
       } else {
         updated.set(menuId, next);
       }
+      return updated;
+    });
+  }
+
+  function setOptionQuantity(
+    menuId: string,
+    groupId: string,
+    optionValueId: string,
+    quantity: number,
+  ): void {
+    setOptionSelections((prev) => {
+      const updated = new Map(prev);
+      const current = updated.get(menuId) ?? [];
+      const nextOptions = current.filter(
+        (opt) => opt.groupId !== groupId || opt.optionValueId !== optionValueId,
+      );
+      if (quantity > 0) {
+        nextOptions.push({ groupId, optionValueId, quantity });
+      }
+      updated.set(menuId, nextOptions);
       return updated;
     });
   }
@@ -138,6 +172,10 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
           "메뉴를 다시 활성화한 뒤 수정하거나, 필요하면 이 판매 기록을 삭제 후 다시 입력해 주세요.",
         ].join("\n")
       : null;
+  const saleErrorMessage =
+    editMutation.error?.message || deleteMutation.error?.message
+      ? formatSaleErrorMessage(editMutation.error?.message || deleteMutation.error?.message || "")
+      : "";
 
   return (
     <div className="flex flex-col gap-stack pb-36">
@@ -151,6 +189,10 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
             menu={menu}
             quantity={quantities.get(menu.id) ?? 0}
             onChange={(next) => setQuantity(menu.id, next)}
+            optionSelections={optionSelections.get(menu.id) ?? []}
+            onOptionChange={(groupId, optionValueId, next) =>
+              setOptionQuantity(menu.id, groupId, optionValueId, next)
+            }
           />
         ))}
       </ul>
@@ -165,16 +207,11 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
         />
       </Field>
 
-      {(missingMenuMessage || stockGuardMessage || editMutation.error || deleteMutation.error) && (
-        <p
-          role="alert"
-          className="whitespace-pre-line rounded-[24px] bg-rose-50 px-4 py-3 text-caption text-rose-700"
-        >
-          {missingMenuMessage ??
-            stockGuardMessage ??
-            editMutation.error?.message ??
-            deleteMutation.error?.message}
-        </p>
+      {(missingMenuMessage || stockGuardMessage || saleErrorMessage) && (
+        <SaleErrorNotice
+          title={missingMenuMessage ? "수정 불가" : stockGuardMessage ? "재고 부족" : "수정 실패"}
+          message={missingMenuMessage ?? stockGuardMessage ?? saleErrorMessage}
+        />
       )}
 
       {preview && totalQuantity > 0 && <StickyTotalCard preview={preview} />}

--- a/src/features/sale/components/SaleEditForm.tsx
+++ b/src/features/sale/components/SaleEditForm.tsx
@@ -9,7 +9,7 @@ import { PrimaryButton } from "@/components/ui/primary-button";
 import { cn } from "@/lib/utils";
 import { useSaleEdit, useSaleDelete } from "../hooks/useSaleEdit";
 import { findSaleStockShortages, formatStockShortageMessage } from "../lib/stock-guard";
-import { toSnapshotMenu } from "../lib/to-snapshot-menu";
+import { toSnapshotMenuWithOptions } from "../lib/to-snapshot-menu-with-options";
 import type { SaleWithItems } from "../hooks/useSaleByDate";
 import { MenuRow } from "./MenuRow";
 import { StickyTotalCard } from "./StickyTotalCard";
@@ -35,8 +35,22 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
   // quantities Map identity가 매번 새로워서 useMemo가 skip 못 함 → inline derive.
   const items = Array.from(quantities.entries())
     .filter(([, qty]) => qty > 0)
-    .map(([menuId, quantity]) => ({ menuId, quantity }));
+    .map(([menuId, quantity]) => {
+      const saleItem = sale.items.find((item) => item.menu_id === menuId);
+      return {
+        menuId,
+        quantity,
+        options: saleItem
+          ? saleItem.options.map((option) => ({
+              groupId: option.option_group_id,
+              optionValueId: option.option_value_id,
+              quantity: option.quantity,
+            }))
+          : undefined,
+      };
+    });
   const activeMenuIds = menus ? new Set(menus.map((menu) => menu.id)) : null;
+  const menuById = new Map((menus ?? []).map((menu) => [menu.id, menu]));
   const editableItems = activeMenuIds
     ? items.filter((item) => activeMenuIds.has(item.menuId))
     : items;
@@ -46,7 +60,16 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
 
   const preview =
     menus && menus.length > 0 && editableItems.length > 0
-      ? computeSnapshotPreview(editableItems, menus.map(toSnapshotMenu))
+      ? computeSnapshotPreview(
+          editableItems,
+          editableItems.map((item) =>
+            toSnapshotMenuWithOptions(
+              menuById.get(item.menuId)!,
+              item.quantity,
+              item.options ?? [],
+            ),
+          ),
+        )
       : null;
   const shortages =
     menus && menus.length > 0
@@ -56,6 +79,11 @@ export function SaleEditForm({ sale, createdAt }: SaleEditFormProps): React.Reac
           existingItems: sale.items.map((item) => ({
             menu_id: item.menu_id,
             quantity: item.quantity,
+            options: item.options.map((option) => ({
+              groupId: option.option_group_id,
+              optionValueId: option.option_value_id,
+              quantity: option.quantity,
+            })),
           })),
         })
       : [];

--- a/src/features/sale/components/SaleErrorNotice.tsx
+++ b/src/features/sale/components/SaleErrorNotice.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+interface SaleErrorNoticeProps {
+  title: string;
+  message: string;
+}
+
+export function SaleErrorNotice({ title, message }: SaleErrorNoticeProps): React.ReactElement {
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="rounded-[24px] border border-rose-200 bg-rose-50/90 px-4 py-3 shadow-soft"
+    >
+      <p className="text-caption font-semibold text-rose-800">{title}</p>
+      <p className="mt-1 text-caption text-rose-700 whitespace-pre-line">{message}</p>
+    </div>
+  );
+}

--- a/src/features/sale/components/SaleInputForm.tsx
+++ b/src/features/sale/components/SaleInputForm.tsx
@@ -10,6 +10,7 @@ import { PrimaryButton } from "@/components/ui/primary-button";
 import { MenuRow } from "./MenuRow";
 import { StickyTotalCard } from "./StickyTotalCard";
 import { SaleSaveBar } from "./SaleSaveBar";
+import { SaleErrorNotice } from "./SaleErrorNotice";
 import { useSaleSubmit } from "../hooks/useSaleSubmit";
 import { useFavoriteMenus } from "../hooks/useFavoriteMenus";
 import {
@@ -18,6 +19,7 @@ import {
   formatStockShortageMessage,
 } from "../lib/stock-guard";
 import { toSnapshotMenuWithOptions } from "../lib/to-snapshot-menu-with-options";
+import { formatSaleErrorMessage } from "@/lib/application/sale";
 
 interface SaleInputFormProps {
   soldAt: string; // YYYY-MM-DD
@@ -78,6 +80,7 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
         optionErrors.map((error) => `- ${error.message}`).join("\n") +
         "\n판매 수량과 옵션 수량을 다시 확인해주세요."
       : "";
+  const saleErrorMessage = submit.error ? formatSaleErrorMessage(submit.error.message) : "";
 
   function handleSubmit(): void {
     if (shortages.length > 0 || optionErrors.length > 0) return;
@@ -149,13 +152,17 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
 
       <SaleSaveBar
         left={
-          (stockGuardMessage || optionGuardMessage || submit.isError) && (
-            <p
-              role="alert"
-              className="flex-1 whitespace-pre-line rounded-2xl bg-rose-50 px-3 py-2 text-caption text-rose-700"
-            >
-              {stockGuardMessage || optionGuardMessage || submit.error?.message}
-            </p>
+          (stockGuardMessage || optionGuardMessage || saleErrorMessage) && (
+            <SaleErrorNotice
+              title={
+                stockGuardMessage
+                  ? "재고 부족"
+                  : optionGuardMessage
+                    ? "옵션 확인 필요"
+                    : "저장 실패"
+              }
+              message={stockGuardMessage || optionGuardMessage || saleErrorMessage}
+            />
           )
         }
         right={

--- a/src/features/sale/components/SaleInputForm.tsx
+++ b/src/features/sale/components/SaleInputForm.tsx
@@ -12,8 +12,12 @@ import { StickyTotalCard } from "./StickyTotalCard";
 import { SaleSaveBar } from "./SaleSaveBar";
 import { useSaleSubmit } from "../hooks/useSaleSubmit";
 import { useFavoriteMenus } from "../hooks/useFavoriteMenus";
-import { findSaleStockShortages, formatStockShortageMessage } from "../lib/stock-guard";
-import { toSnapshotMenu } from "../lib/to-snapshot-menu";
+import {
+  findSaleOptionErrors,
+  findSaleStockShortages,
+  formatStockShortageMessage,
+} from "../lib/stock-guard";
+import { toSnapshotMenuWithOptions } from "../lib/to-snapshot-menu-with-options";
 
 interface SaleInputFormProps {
   soldAt: string; // YYYY-MM-DD
@@ -26,6 +30,7 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
   const { data: favorites } = useFavoriteMenus();
   const draftItems = useSaleDraft((s) => s.draftsByDate[soldAt] ?? EMPTY_SALE_DRAFT_ITEMS);
   const setQuantity = useSaleDraft((s) => s.setQuantity);
+  const setOptionQuantity = useSaleDraft((s) => s.setOptionQuantity);
   const clearDraftDate = useSaleDraft((s) => s.clearDate);
   const replaceDraftItems = useSaleDraft((s) => s.replaceDateItems);
   const submit = useSaleSubmit();
@@ -44,26 +49,49 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
   // ~20개 메뉴 sort + Map 구성은 trivial, useMemo 오버헤드만 더함 → inline.
   const sortedMenus = sortByFavorites(menus ?? [], favorites ?? []);
   const validMenuIds = menus ? new Set(menus.map((menu) => menu.id)) : null;
+  const menuById = new Map((menus ?? []).map((menu) => [menu.id, menu]));
   const items = validMenuIds ? sanitizeSaleDraftItems(draftItems, validMenuIds) : draftItems;
   const draftMap = new Map(items.map((it) => [it.menuId, it.quantity]));
+  const draftOptionMap = new Map(items.map((it) => [it.menuId, it.options ?? []]));
 
   const preview =
     menus && menus.length > 0
       ? computeSnapshotPreview(
           items.filter((it) => it.quantity > 0),
-          menus.map(toSnapshotMenu),
+          items
+            .filter((it) => it.quantity > 0)
+            .map((item) =>
+              toSnapshotMenuWithOptions(
+                menuById.get(item.menuId)!,
+                item.quantity,
+                item.options ?? [],
+              ),
+            ),
         )
       : null;
+  const optionErrors = menus && menus.length > 0 ? findSaleOptionErrors({ items, menus }) : [];
   const shortages = menus && menus.length > 0 ? findSaleStockShortages({ items, menus }) : [];
   const stockGuardMessage = formatStockShortageMessage(shortages);
+  const optionGuardMessage =
+    optionErrors.length > 0
+      ? "옵션 선택이 맞지 않아요.\n" +
+        optionErrors.map((error) => `- ${error.message}`).join("\n") +
+        "\n판매 수량과 옵션 수량을 다시 확인해주세요."
+      : "";
 
   function handleSubmit(): void {
-    if (shortages.length > 0) return;
+    if (shortages.length > 0 || optionErrors.length > 0) return;
 
     submit.mutate(
       {
         soldAt,
-        items: items.filter((it) => it.quantity > 0),
+        items: items
+          .filter((it) => it.quantity > 0)
+          .map((item) => ({
+            menuId: item.menuId,
+            quantity: item.quantity,
+            options: item.options?.filter((option) => option.quantity > 0),
+          })),
         isFirstSale,
       },
       {
@@ -109,6 +137,10 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
             menu={menu}
             quantity={draftMap.get(menu.id) ?? 0}
             onChange={(next) => setQuantity(soldAt, menu.id, next)}
+            optionSelections={draftOptionMap.get(menu.id) ?? []}
+            onOptionChange={(groupId, optionValueId, next) =>
+              setOptionQuantity(soldAt, menu.id, groupId, optionValueId, next)
+            }
           />
         ))}
       </ul>
@@ -117,12 +149,12 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
 
       <SaleSaveBar
         left={
-          (stockGuardMessage || submit.isError) && (
+          (stockGuardMessage || optionGuardMessage || submit.isError) && (
             <p
               role="alert"
               className="flex-1 whitespace-pre-line rounded-2xl bg-rose-50 px-3 py-2 text-caption text-rose-700"
             >
-              {stockGuardMessage || submit.error?.message}
+              {stockGuardMessage || optionGuardMessage || submit.error?.message}
             </p>
           )
         }
@@ -130,7 +162,9 @@ export function SaleInputForm({ soldAt, isFirstSale }: SaleInputFormProps): Reac
           <PrimaryButton
             type="button"
             onClick={handleSubmit}
-            disabled={totalQuantity === 0 || submit.isPending || isBlockedByStock}
+            disabled={
+              totalQuantity === 0 || submit.isPending || isBlockedByStock || optionErrors.length > 0
+            }
             className="halo-cta"
           >
             {submit.isPending ? "저장 중…" : `${totalQuantity}개 저장`}

--- a/src/features/sale/components/SaleLockedView.tsx
+++ b/src/features/sale/components/SaleLockedView.tsx
@@ -29,6 +29,33 @@ export function SaleLockedView({ sale }: SaleLockedViewProps): React.ReactElemen
           <span>{formatWon(sale.total_revenue - sale.total_cost_snapshot)}원</span>
         </li>
       </ul>
+      <section className="flex flex-col gap-2">
+        <h3 className="text-caption font-semibold text-ink-2">판매 항목</h3>
+        <ul className="flex flex-col gap-3">
+          {sale.items.map((item) => (
+            <li key={item.id} className="rounded-2xl bg-slate-50 px-4 py-3">
+              <div className="flex items-center justify-between gap-3 text-body-regular text-ink-1">
+                <span>{item.menu_name ?? "알 수 없는 메뉴"}</span>
+                <span className="tabular-nums">{item.quantity}개</span>
+              </div>
+              {item.options.length > 0 && (
+                <ul className="mt-2 flex flex-col gap-1 text-caption text-ink-3">
+                  {item.options.map((option) => (
+                    <li key={option.id} className="flex justify-between gap-3">
+                      <span>
+                        {option.group_name_snapshot} · {option.value_name_snapshot}
+                      </span>
+                      <span className="tabular-nums">
+                        +{formatWon(option.price_delta_snapshot)}원
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
       <p className="text-micro text-ink-3">{MARGIN_LABEL}</p>
     </article>
   );

--- a/src/features/sale/lib/stock-guard.ts
+++ b/src/features/sale/lib/stock-guard.ts
@@ -1,14 +1,29 @@
 import type { MenuRowWithRecipe } from "@/features/menu/hooks/useMenus";
+import {
+  computeOptionIngredientRequirements,
+  validateMenuOptionSelections,
+  type MenuOptionGroupPolicy,
+  type MenuOptionSelection,
+  type OptionRecipeItem,
+} from "@/lib/domain/menu-options";
 import { formatNumber } from "@/lib/utils/format";
+
+interface SaleItemOptionLike {
+  groupId: string;
+  optionValueId: string;
+  quantity: number;
+}
 
 interface SaleItemLike {
   menuId: string;
   quantity: number;
+  options?: readonly SaleItemOptionLike[];
 }
 
 interface ExistingSaleItemLike {
   menu_id: string;
   quantity: number;
+  options?: readonly SaleItemOptionLike[];
 }
 
 export interface StockShortage {
@@ -20,10 +35,56 @@ export interface StockShortage {
   shortage: number;
 }
 
+export interface SaleOptionError {
+  menuId: string;
+  message: string;
+}
+
 interface FindSaleStockShortagesInput {
   items: readonly SaleItemLike[];
   menus: readonly MenuRowWithRecipe[];
   existingItems?: readonly ExistingSaleItemLike[];
+}
+
+export function findSaleOptionErrors({
+  items,
+  menus,
+}: {
+  items: readonly SaleItemLike[];
+  menus: readonly MenuRowWithRecipe[];
+}): SaleOptionError[] {
+  const menuById = new Map(menus.map((menu) => [menu.id, menu]));
+  const errors: SaleOptionError[] = [];
+
+  for (const item of items) {
+    if (item.quantity <= 0) continue;
+    const menu = menuById.get(item.menuId);
+    if (!menu || menu.option_groups.length === 0) continue;
+
+    const groups: MenuOptionGroupPolicy[] = menu.option_groups.map((group) => ({
+      groupId: group.id,
+      selectionType: group.selection_type,
+      isRequired: group.is_required,
+      minSelect: group.min_select,
+      maxSelect: group.max_select,
+    }));
+
+    const selections: MenuOptionSelection[] = (item.options ?? []).map((option) => ({
+      groupId: option.groupId,
+      optionValueId: option.optionValueId,
+      quantity: option.quantity,
+    }));
+
+    for (const message of validateMenuOptionSelections({
+      menuQuantity: item.quantity,
+      groups,
+      selections,
+    })) {
+      errors.push({ menuId: item.menuId, message });
+    }
+  }
+
+  return errors;
 }
 
 export function findSaleStockShortages({
@@ -44,6 +105,18 @@ export function findSaleStockShortages({
         currentStock: recipeItem.ingredient.current_stock,
       });
     }
+
+    for (const group of menu.option_groups) {
+      for (const value of group.values) {
+        for (const recipeItem of value.recipe_items) {
+          ingredientStock.set(recipeItem.ingredient.id, {
+            name: recipeItem.ingredient.name,
+            unit: recipeItem.ingredient.unit,
+            currentStock: recipeItem.ingredient.current_stock,
+          });
+        }
+      }
+    }
   }
 
   for (const item of items) {
@@ -57,6 +130,13 @@ export function findSaleStockShortages({
         (required.get(recipeItem.ingredient.id) ?? 0) + consumed,
       );
     }
+
+    for (const requirement of computeMenuOptionRequirements(menu, item.options ?? [])) {
+      required.set(
+        requirement.ingredientId,
+        (required.get(requirement.ingredientId) ?? 0) + requirement.quantity,
+      );
+    }
   }
 
   for (const item of existingItems) {
@@ -68,6 +148,13 @@ export function findSaleStockShortages({
       restored.set(
         recipeItem.ingredient.id,
         (restored.get(recipeItem.ingredient.id) ?? 0) + consumed,
+      );
+    }
+
+    for (const requirement of computeMenuOptionRequirements(menu, item.options ?? [])) {
+      restored.set(
+        requirement.ingredientId,
+        (restored.get(requirement.ingredientId) ?? 0) + requirement.quantity,
       );
     }
   }
@@ -92,6 +179,45 @@ export function findSaleStockShortages({
     })
     .filter((item): item is StockShortage => item !== null)
     .sort((a, b) => b.shortage - a.shortage || a.name.localeCompare(b.name, "ko-KR"));
+}
+
+function computeMenuOptionRequirements(
+  menu: MenuRowWithRecipe,
+  selections: readonly SaleItemOptionLike[],
+): Array<{ ingredientId: string; quantity: number }> {
+  if (menu.option_groups.length === 0 || selections.length === 0) return [];
+
+  const selectionByValue = new Map(
+    selections.map((selection) => [selection.optionValueId, selection]),
+  );
+  const normalizedSelections: MenuOptionSelection[] = [];
+  const recipeItems: OptionRecipeItem[] = [];
+
+  for (const group of menu.option_groups) {
+    for (const value of group.values) {
+      const selection = selectionByValue.get(value.id);
+      if (!selection || selection.quantity <= 0) continue;
+
+      normalizedSelections.push({
+        groupId: group.id,
+        optionValueId: value.id,
+        quantity: selection.quantity,
+      });
+
+      for (const recipeItem of value.recipe_items) {
+        recipeItems.push({
+          optionValueId: value.id,
+          ingredientId: recipeItem.ingredient.id,
+          quantityPerSelection: recipeItem.quantity_per_selection,
+        });
+      }
+    }
+  }
+
+  return computeOptionIngredientRequirements({
+    selections: normalizedSelections,
+    recipeItems,
+  });
 }
 
 export function formatStockShortageMessage(shortages: readonly StockShortage[]): string {

--- a/src/features/sale/lib/to-snapshot-menu-with-options.ts
+++ b/src/features/sale/lib/to-snapshot-menu-with-options.ts
@@ -1,0 +1,58 @@
+import type { MenuRowWithRecipe } from "@/features/menu/hooks/useMenus";
+import type { MenuForSnapshot } from "@/lib/domain/snapshot";
+
+interface OptionSelectionLike {
+  optionValueId: string;
+  quantity: number;
+}
+
+/**
+ * 메뉴 1행의 판매 수량과 옵션 선택을 합친 스냅샷 입력.
+ * 옵션 가격/재료는 판매 수량으로 나눈 per-serving 평균으로 환산한다.
+ */
+export function toSnapshotMenuWithOptions(
+  row: MenuRowWithRecipe,
+  quantity: number,
+  selections: readonly OptionSelectionLike[],
+): MenuForSnapshot {
+  const baseByIngredient = new Map(
+    row.recipe_items.map((item) => [
+      item.ingredient.id,
+      { quantity: item.quantity_per_serving, avgPrice: item.ingredient.current_avg_price },
+    ]),
+  );
+  const selectionByValueId = new Map(
+    selections.map((selection) => [selection.optionValueId, selection.quantity]),
+  );
+  let totalPriceDelta = 0;
+
+  for (const group of row.option_groups) {
+    for (const value of group.values) {
+      const selectedQuantity = selectionByValueId.get(value.id) ?? 0;
+      if (selectedQuantity <= 0) continue;
+
+      totalPriceDelta += value.price_delta * selectedQuantity;
+
+      for (const recipeItem of value.recipe_items) {
+        const current = baseByIngredient.get(recipeItem.ingredient.id);
+        const extraPerServing = (recipeItem.quantity_per_selection * selectedQuantity) / quantity;
+        baseByIngredient.set(recipeItem.ingredient.id, {
+          quantity: (current?.quantity ?? 0) + extraPerServing,
+          avgPrice: recipeItem.ingredient.current_avg_price,
+        });
+      }
+    }
+  }
+
+  return {
+    id: row.id,
+    name: row.name,
+    price: row.price + totalPriceDelta / quantity,
+    recipeItems: [...baseByIngredient.entries()]
+      .map(([ingredientId, item]) => ({
+        quantity: item.quantity,
+        avgPrice: item.avgPrice,
+      }))
+      .sort((a, b) => a.avgPrice - b.avgPrice || a.quantity - b.quantity),
+  };
+}

--- a/src/features/sale/lib/to-snapshot-menu-with-options.ts
+++ b/src/features/sale/lib/to-snapshot-menu-with-options.ts
@@ -49,10 +49,7 @@ export function toSnapshotMenuWithOptions(
     name: row.name,
     price: row.price + totalPriceDelta / quantity,
     recipeItems: [...baseByIngredient.entries()]
-      .map(([ingredientId, item]) => ({
-        quantity: item.quantity,
-        avgPrice: item.avgPrice,
-      }))
+      .map(([, item]) => ({ quantity: item.quantity, avgPrice: item.avgPrice }))
       .sort((a, b) => a.avgPrice - b.avgPrice || a.quantity - b.quantity),
   };
 }

--- a/src/lib/application/lookups.ts
+++ b/src/lib/application/lookups.ts
@@ -309,10 +309,9 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
                 current_stock: Number(item.ingredient.current_stock),
                 current_avg_price: Number(item.ingredient.current_avg_price),
               },
-            })),
-        })),
-      }))
-      .filter((group) => group.values.length > 0),
+              })),
+          })),
+      })),
   }));
 }
 

--- a/src/lib/application/lookups.ts
+++ b/src/lib/application/lookups.ts
@@ -309,8 +309,8 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
                 current_stock: Number(item.ingredient.current_stock),
                 current_avg_price: Number(item.ingredient.current_avg_price),
               },
-              })),
-          })),
+            })),
+        })),
       })),
   }));
 }

--- a/src/lib/application/lookups.ts
+++ b/src/lib/application/lookups.ts
@@ -36,6 +36,31 @@ export interface MenuRowWithRecipe {
       current_avg_price: number;
     };
   }>;
+  option_groups: Array<{
+    id: string;
+    name: string;
+    selection_type: "single" | "add_on";
+    is_required: boolean;
+    min_select: number;
+    max_select: number | null;
+    values: Array<{
+      id: string;
+      name: string;
+      price_delta: number;
+      is_default: boolean;
+      recipe_items: Array<{
+        id: string;
+        quantity_per_selection: number;
+        ingredient: {
+          id: string;
+          name: string;
+          unit: string;
+          current_stock: number;
+          current_avg_price: number;
+        };
+      }>;
+    }>;
+  }>;
 }
 
 interface RawIngredient {
@@ -52,12 +77,39 @@ interface RawRecipeItem {
   ingredient: RawIngredient | null;
 }
 
+interface RawOptionRecipeItem {
+  id: string;
+  quantity_per_selection: string | number;
+  ingredient: RawIngredient | null;
+}
+
+interface RawOptionValue {
+  id: string;
+  name: string;
+  price_delta: string | number;
+  is_default: boolean;
+  is_active: boolean;
+  menu_option_value_recipe_items: RawOptionRecipeItem[];
+}
+
+interface RawOptionGroup {
+  id: string;
+  name: string;
+  selection_type: "single" | "add_on";
+  is_required: boolean;
+  min_select: number;
+  max_select: number | null;
+  is_active: boolean;
+  menu_option_values: RawOptionValue[];
+}
+
 interface RawMenuRow {
   id: string;
   name: string;
   price: string | number;
   is_active: boolean;
   recipe_items: RawRecipeItem[];
+  menu_option_groups?: RawOptionGroup[];
 }
 
 export interface VendorRow {
@@ -86,6 +138,16 @@ export interface SaleWithItems {
     quantity: number;
     unit_price: number;
     menu_cost_snapshot: number;
+    options: Array<{
+      id: string;
+      option_group_id: string;
+      option_value_id: string;
+      quantity: number;
+      group_name_snapshot: string;
+      value_name_snapshot: string;
+      price_delta_snapshot: number;
+      option_cost_snapshot: number;
+    }>;
   }>;
 }
 
@@ -102,6 +164,16 @@ interface RawSaleRow {
     quantity: number;
     unit_price: string | number;
     menu_cost_snapshot: string | number;
+    sale_item_options?: Array<{
+      id: string;
+      option_group_id: string;
+      option_value_id: string;
+      quantity: number;
+      group_name_snapshot: string;
+      value_name_snapshot: string;
+      price_delta_snapshot: string | number;
+      option_cost_snapshot: string | number;
+    }>;
   }>;
 }
 
@@ -116,6 +188,18 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
         quantity_per_serving,
         ingredient:ingredients (
           id, name, unit, current_stock, current_avg_price
+        )
+      ),
+      menu_option_groups (
+        id, name, selection_type, is_required, min_select, max_select, is_active, sort_order,
+        menu_option_values (
+          id, name, price_delta, is_default, is_active, sort_order,
+          menu_option_value_recipe_items (
+            id, quantity_per_selection,
+            ingredient:ingredients (
+              id, name, unit, current_stock, current_avg_price
+            )
+          )
         )
       )
     `,
@@ -145,6 +229,41 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
           current_avg_price: Number(item.ingredient.current_avg_price),
         },
       })),
+    option_groups: (menu.menu_option_groups ?? [])
+      .filter((group) => group.is_active)
+      .map((group) => ({
+        id: group.id,
+        name: group.name,
+        selection_type: group.selection_type,
+        is_required: group.is_required,
+        min_select: group.min_select,
+        max_select: group.max_select,
+        values: group.menu_option_values
+          .filter((value) => value.is_active)
+          .map((value) => ({
+            id: value.id,
+            name: value.name,
+            price_delta: Number(value.price_delta),
+            is_default: value.is_default,
+            recipe_items: value.menu_option_value_recipe_items
+              .filter(
+                (item): item is RawOptionRecipeItem & { ingredient: RawIngredient } =>
+                  item.ingredient !== null,
+              )
+              .map((item) => ({
+                id: item.id,
+                quantity_per_selection: Number(item.quantity_per_selection),
+                ingredient: {
+                  id: item.ingredient.id,
+                  name: item.ingredient.name,
+                  unit: item.ingredient.unit,
+                  current_stock: Number(item.ingredient.current_stock),
+                  current_avg_price: Number(item.ingredient.current_avg_price),
+                },
+              })),
+          })),
+      }))
+      .filter((group) => group.values.length > 0),
   }));
 }
 
@@ -196,7 +315,12 @@ export async function loadSaleByDate(
       id, sold_at, created_at, total_revenue, total_cost_snapshot,
       sale_items (
         id, menu_id, quantity, unit_price, menu_cost_snapshot,
-        menu:menus (name)
+        menu:menus (name),
+        sale_item_options (
+          id, option_group_id, option_value_id, quantity,
+          group_name_snapshot, value_name_snapshot,
+          price_delta_snapshot, option_cost_snapshot
+        )
       )
     `,
     )
@@ -219,6 +343,16 @@ export async function loadSaleByDate(
       quantity: si.quantity,
       unit_price: Number(si.unit_price),
       menu_cost_snapshot: Number(si.menu_cost_snapshot),
+      options: (si.sale_item_options ?? []).map((option) => ({
+        id: option.id,
+        option_group_id: option.option_group_id,
+        option_value_id: option.option_value_id,
+        quantity: option.quantity,
+        group_name_snapshot: option.group_name_snapshot,
+        value_name_snapshot: option.value_name_snapshot,
+        price_delta_snapshot: Number(option.price_delta_snapshot),
+        option_cost_snapshot: Number(option.option_cost_snapshot),
+      })),
     })),
   };
 }

--- a/src/lib/application/lookups.ts
+++ b/src/lib/application/lookups.ts
@@ -194,7 +194,7 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
         ingredient:ingredients (
           id, name, unit, current_stock, current_avg_price
         )
-      ),
+      )
     `,
     )
     .eq("is_active", true)

--- a/src/lib/application/lookups.ts
+++ b/src/lib/application/lookups.ts
@@ -4,6 +4,9 @@ export type LookupClient = SupabaseLike;
 interface SupabaseLike {
   from: (table: string) => {
     select: (query: string) => {
+      order: (
+        column: string,
+      ) => PromiseLike<{ data: LookupRow[] | null; error: { message: string } | null }>;
       eq: (
         column: string,
         value: unknown,
@@ -77,39 +80,41 @@ interface RawRecipeItem {
   ingredient: RawIngredient | null;
 }
 
-interface RawOptionRecipeItem {
-  id: string;
-  quantity_per_selection: string | number;
-  ingredient: RawIngredient | null;
-}
-
-interface RawOptionValue {
-  id: string;
-  name: string;
-  price_delta: string | number;
-  is_default: boolean;
-  is_active: boolean;
-  menu_option_value_recipe_items: RawOptionRecipeItem[];
-}
-
-interface RawOptionGroup {
-  id: string;
-  name: string;
-  selection_type: "single" | "add_on";
-  is_required: boolean;
-  min_select: number;
-  max_select: number | null;
-  is_active: boolean;
-  menu_option_values: RawOptionValue[];
-}
-
 interface RawMenuRow {
   id: string;
   name: string;
   price: string | number;
   is_active: boolean;
   recipe_items: RawRecipeItem[];
-  menu_option_groups?: RawOptionGroup[];
+}
+
+interface RawOptionGroupRow {
+  id: string;
+  menu_id: string;
+  name: string;
+  selection_type: "single" | "add_on";
+  is_required: boolean;
+  min_select: number;
+  max_select: number | null;
+  is_active: boolean;
+  sort_order: number;
+}
+
+interface RawOptionValueRow {
+  id: string;
+  option_group_id: string;
+  name: string;
+  price_delta: string | number;
+  is_default: boolean;
+  is_active: boolean;
+  sort_order: number;
+}
+
+interface RawOptionRecipeItem {
+  id: string;
+  option_value_id: string;
+  quantity_per_selection: string | number;
+  ingredient: RawIngredient | null;
 }
 
 export interface VendorRow {
@@ -178,7 +183,7 @@ interface RawSaleRow {
 }
 
 export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe[]> {
-  const { data, error } = await client
+  const menusQuery = client
     .from("menus")
     .select(
       `
@@ -190,25 +195,71 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
           id, name, unit, current_stock, current_avg_price
         )
       ),
-      menu_option_groups (
-        id, name, selection_type, is_required, min_select, max_select, is_active, sort_order,
-        menu_option_values (
-          id, name, price_delta, is_default, is_active, sort_order,
-          menu_option_value_recipe_items (
-            id, quantity_per_selection,
-            ingredient:ingredients (
-              id, name, unit, current_stock, current_avg_price
-            )
-          )
-        )
-      )
     `,
     )
     .eq("is_active", true)
     .order("name");
+  const groupsQuery = client
+    .from("menu_option_groups")
+    .select(
+      "id, menu_id, name, selection_type, is_required, min_select, max_select, is_active, sort_order",
+    )
+    .eq("is_active", true)
+    .order("sort_order");
+  const valuesQuery = client
+    .from("menu_option_values")
+    .select("id, option_group_id, name, price_delta, is_default, is_active, sort_order")
+    .eq("is_active", true)
+    .order("sort_order");
+  const recipeQuery = client
+    .from("menu_option_value_recipe_items")
+    .select(
+      `
+        id, option_value_id, quantity_per_selection,
+        ingredient:ingredients (
+          id, name, unit, current_stock, current_avg_price
+        )
+      `,
+    )
+    .order("id");
 
-  if (error) throw new Error(error.message);
-  const rows = (data ?? []) as unknown as RawMenuRow[];
+  const [menusResult, groupsResult, valuesResult, recipeResult] = await Promise.all([
+    menusQuery,
+    groupsQuery,
+    valuesQuery,
+    recipeQuery,
+  ]);
+
+  const { data: menus, error: menusError } = menusResult;
+  const { data: groups, error: groupsError } = groupsResult;
+  const { data: values, error: valuesError } = valuesResult;
+  const { data: recipeItems, error: recipeError } = recipeResult;
+  const firstError = menusError ?? groupsError ?? valuesError ?? recipeError;
+  if (firstError) throw new Error(firstError.message);
+
+  const rows = (menus ?? []) as unknown as RawMenuRow[];
+  const groupRows = ((groups ?? []) as unknown as RawOptionGroupRow[]).filter(
+    (group) => group.is_active,
+  );
+  const valueRows = ((values ?? []) as unknown as RawOptionValueRow[]).filter(
+    (value) => value.is_active,
+  );
+  const recipeRows = (recipeItems ?? []) as unknown as RawOptionRecipeItem[];
+  const valuesByGroup = new Map<string, RawOptionValueRow[]>();
+  const recipesByValue = new Map<string, RawOptionRecipeItem[]>();
+
+  for (const value of valueRows) {
+    const list = valuesByGroup.get(value.option_group_id) ?? [];
+    list.push(value);
+    valuesByGroup.set(value.option_group_id, list);
+  }
+
+  for (const item of recipeRows) {
+    const list = recipesByValue.get(item.option_value_id) ?? [];
+    list.push(item);
+    recipesByValue.set(item.option_value_id, list);
+  }
+
   return rows.map((menu) => ({
     id: menu.id,
     name: menu.name,
@@ -229,8 +280,8 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
           current_avg_price: Number(item.ingredient.current_avg_price),
         },
       })),
-    option_groups: (menu.menu_option_groups ?? [])
-      .filter((group) => group.is_active)
+    option_groups: groupRows
+      .filter((group) => group.menu_id === menu.id)
       .map((group) => ({
         id: group.id,
         name: group.name,
@@ -238,30 +289,28 @@ export async function loadMenus(client: SupabaseLike): Promise<MenuRowWithRecipe
         is_required: group.is_required,
         min_select: group.min_select,
         max_select: group.max_select,
-        values: group.menu_option_values
-          .filter((value) => value.is_active)
-          .map((value) => ({
-            id: value.id,
-            name: value.name,
-            price_delta: Number(value.price_delta),
-            is_default: value.is_default,
-            recipe_items: value.menu_option_value_recipe_items
-              .filter(
-                (item): item is RawOptionRecipeItem & { ingredient: RawIngredient } =>
-                  item.ingredient !== null,
-              )
-              .map((item) => ({
-                id: item.id,
-                quantity_per_selection: Number(item.quantity_per_selection),
-                ingredient: {
-                  id: item.ingredient.id,
-                  name: item.ingredient.name,
-                  unit: item.ingredient.unit,
-                  current_stock: Number(item.ingredient.current_stock),
-                  current_avg_price: Number(item.ingredient.current_avg_price),
-                },
-              })),
-          })),
+        values: (valuesByGroup.get(group.id) ?? []).map((value) => ({
+          id: value.id,
+          name: value.name,
+          price_delta: Number(value.price_delta),
+          is_default: value.is_default,
+          recipe_items: (recipesByValue.get(value.id) ?? [])
+            .filter(
+              (item): item is RawOptionRecipeItem & { ingredient: RawIngredient } =>
+                item.ingredient !== null,
+            )
+            .map((item) => ({
+              id: item.id,
+              quantity_per_selection: Number(item.quantity_per_selection),
+              ingredient: {
+                id: item.ingredient.id,
+                name: item.ingredient.name,
+                unit: item.ingredient.unit,
+                current_stock: Number(item.ingredient.current_stock),
+                current_avg_price: Number(item.ingredient.current_avg_price),
+              },
+            })),
+        })),
       }))
       .filter((group) => group.values.length > 0),
   }));

--- a/src/lib/application/menu.ts
+++ b/src/lib/application/menu.ts
@@ -1,6 +1,7 @@
 import {
   deleteMenu as deleteMenuRpc,
   editMenu as editMenuRpc,
+  saveMenuOptions as saveMenuOptionsRpc,
   saveMenu as saveMenuRpc,
 } from "@/lib/supabase/rpc";
 
@@ -12,6 +13,19 @@ export interface SaveMenuInput {
   name: string;
   price: number;
   recipe: ReadonlyArray<{ ingredientId: string; quantityPerServing: number }>;
+  optionGroups?: ReadonlyArray<{
+    name: string;
+    selectionType: "single" | "add_on";
+    isRequired: boolean;
+    minSelect: number;
+    maxSelect?: number | null;
+    values: ReadonlyArray<{
+      name: string;
+      priceDelta: number;
+      isDefault: boolean;
+      recipe: ReadonlyArray<{ ingredientId: string; quantityPerSelection: number }>;
+    }>;
+  }>;
 }
 
 export interface EditMenuInput extends SaveMenuInput {
@@ -23,6 +37,7 @@ export async function createMenu(client: RpcClient, input: SaveMenuInput): Promi
   if (error) throw new Error(error.message);
   const row = data?.[0];
   if (!row) throw new Error("save_menu returned empty");
+  await saveMenuOptions(client, row.menu_id, input.optionGroups ?? []);
   return row.menu_id;
 }
 
@@ -31,10 +46,20 @@ export async function updateMenu(client: RpcClient, input: EditMenuInput): Promi
   if (error) throw new Error(error.message);
   const row = data?.[0];
   if (!row) throw new Error("edit_menu returned empty");
+  await saveMenuOptions(client, input.menuId, input.optionGroups ?? []);
   return row.menu_id;
 }
 
 export async function removeMenu(client: RpcClient, menuId: string): Promise<void> {
   const { error } = await deleteMenuRpc(client, menuId);
+  if (error) throw new Error(error.message);
+}
+
+async function saveMenuOptions(
+  client: RpcClient,
+  menuId: string,
+  optionGroups: NonNullable<SaveMenuInput["optionGroups"]>,
+): Promise<void> {
+  const { error } = await saveMenuOptionsRpc(client, { menuId, optionGroups });
   if (error) throw new Error(error.message);
 }

--- a/src/lib/application/sale.ts
+++ b/src/lib/application/sale.ts
@@ -142,6 +142,10 @@ export async function applySaleSnapshotRewrite(
   return data;
 }
 
+export function formatSaleErrorMessage(message: string): string {
+  return toBasicSaleErrorMessage(message);
+}
+
 async function toSaleErrorMessage(client: SaleClient, message: string): Promise<string> {
   const ingredientId = parseNegativeStockIngredientId(message);
   if (!ingredientId) return toBasicSaleErrorMessage(message);
@@ -168,6 +172,24 @@ function toBasicSaleErrorMessage(message: string): string {
   }
   if (message.includes("menu_no_recipe")) {
     return "레시피가 없는 메뉴가 포함되어 있어 저장할 수 없어요.";
+  }
+  if (message.includes("menu not found")) {
+    return "메뉴를 다시 불러오지 못했어요. 새로고침 후 다시 시도해주세요.";
+  }
+  if (
+    message.includes("Could not find a relationship between 'menus' and 'menu_option_groups'") ||
+    message.includes("Could not find the table 'public.menu_option_groups' in the schema cache")
+  ) {
+    return "메뉴 옵션 데이터를 아직 불러오지 못했어요. 데이터베이스 마이그레이션 반영 후 다시 시도해주세요.";
+  }
+  if (message.includes("failed to parse select parameter")) {
+    return "메뉴 데이터를 읽는 중 오류가 발생했어요. 최신 마이그레이션 반영 후 다시 시도해주세요.";
+  }
+  if (message.includes("duplicate key value violates unique constraint")) {
+    return "이미 같은 내용이 저장되어 있어요. 입력 값을 다시 확인해주세요.";
+  }
+  if (message.includes("permission denied")) {
+    return "권한 문제로 저장할 수 없어요. 로그인 상태와 접근 권한을 확인해주세요.";
   }
   return message;
 }

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -52,6 +52,23 @@ interface SaveMenuRow {
   menu_id: string;
 }
 
+interface SaveMenuOptionsArgs {
+  menuId: string;
+  optionGroups: ReadonlyArray<{
+    name: string;
+    selectionType: "single" | "add_on";
+    isRequired: boolean;
+    minSelect: number;
+    maxSelect?: number | null;
+    values: ReadonlyArray<{
+      name: string;
+      priceDelta: number;
+      isDefault: boolean;
+      recipe: ReadonlyArray<{ ingredientId: string; quantityPerSelection: number }>;
+    }>;
+  }>;
+}
+
 // 도메인 타입 → RPC payload 변환 어댑터 — saveMenu / editMenu / saveSale / editSale 4곳 공유.
 function mapRecipePayload(
   recipe: SaveMenuArgs["recipe"],
@@ -141,6 +158,35 @@ export function saveMenu(
     p_name: args.name,
     p_price: args.price,
     p_recipe: mapRecipePayload(args.recipe),
+  });
+}
+
+export function saveMenuOptions(
+  client: ClientLike,
+  args: SaveMenuOptionsArgs,
+): Promise<
+  RpcResult<Array<{ menu_id: string; option_group_count: number; option_value_count: number }>>
+> {
+  return callRpc(client, "save_menu_options", {
+    p_menu_id: args.menuId,
+    p_option_groups: args.optionGroups.map((group, groupIdx) => ({
+      name: group.name,
+      selection_type: group.selectionType,
+      is_required: group.isRequired,
+      min_select: group.minSelect,
+      max_select: group.maxSelect ?? null,
+      sort_order: groupIdx,
+      values: group.values.map((value, valueIdx) => ({
+        name: value.name,
+        price_delta: value.priceDelta,
+        is_default: value.isDefault,
+        sort_order: valueIdx,
+        recipe: value.recipe.map((item) => ({
+          ingredient_id: item.ingredientId,
+          quantity_per_selection: item.quantityPerSelection,
+        })),
+      })),
+    })),
   });
 }
 

--- a/src/stores/sale-draft.ts
+++ b/src/stores/sale-draft.ts
@@ -6,6 +6,13 @@ import { persist } from "zustand/middleware";
 export interface SaleDraftItem {
   menuId: string;
   quantity: number;
+  options: SaleDraftOptionItem[];
+}
+
+export interface SaleDraftOptionItem {
+  groupId: string;
+  optionValueId: string;
+  quantity: number;
 }
 
 export type SaleDraftsByDate = Record<string, SaleDraftItem[]>;
@@ -33,7 +40,7 @@ export function upsertSaleDraftItems(
     const existing = current.find((item) => item.menuId === menuId);
     nextItems = existing
       ? current.map((item) => (item.menuId === menuId ? { ...item, quantity } : item))
-      : [...current, { menuId, quantity }];
+      : [...current, { menuId, quantity, options: [] }];
   }
 
   return {
@@ -60,9 +67,43 @@ export function replaceSaleDraftDateItems(
   };
 }
 
+export function setSaleDraftOptionQuantity(
+  draftsByDate: SaleDraftsByDate,
+  date: string,
+  menuId: string,
+  groupId: string,
+  optionValueId: string,
+  quantity: number,
+): SaleDraftsByDate {
+  const current = draftsByDate[date] ?? [];
+  const nextItems = current.map((item) => {
+    if (item.menuId !== menuId) return item;
+    const options = item.options ?? [];
+    const nextOptions = options.filter(
+      (opt) => opt.groupId !== groupId || opt.optionValueId !== optionValueId,
+    );
+    if (quantity > 0) {
+      nextOptions.push({ groupId, optionValueId, quantity });
+    }
+    return { ...item, options: nextOptions };
+  });
+
+  return {
+    ...draftsByDate,
+    [date]: nextItems,
+  };
+}
+
 interface SaleDraftState {
   draftsByDate: SaleDraftsByDate;
   setQuantity: (date: string, menuId: string, quantity: number) => void;
+  setOptionQuantity: (
+    date: string,
+    menuId: string,
+    groupId: string,
+    optionValueId: string,
+    quantity: number,
+  ) => void;
   clearDate: (date: string) => void;
   replaceDateItems: (date: string, items: readonly SaleDraftItem[]) => void;
 }
@@ -80,6 +121,18 @@ export const useSaleDraft = create<SaleDraftState>()(
       setQuantity: (date, menuId, quantity) =>
         set((state) => ({
           draftsByDate: upsertSaleDraftItems(state.draftsByDate, date, menuId, quantity),
+        })),
+
+      setOptionQuantity: (date, menuId, groupId, optionValueId, quantity) =>
+        set((state) => ({
+          draftsByDate: setSaleDraftOptionQuantity(
+            state.draftsByDate,
+            date,
+            menuId,
+            groupId,
+            optionValueId,
+            quantity,
+          ),
         })),
 
       clearDate: (date) =>

--- a/supabase/migrations/042_save_menu_options_rpc.sql
+++ b/supabase/migrations/042_save_menu_options_rpc.sql
@@ -1,0 +1,185 @@
+-- Migration: menu option management RPC
+
+create or replace function public.save_menu_options(
+  p_menu_id uuid,
+  p_option_groups jsonb
+)
+returns table (
+  menu_id uuid,
+  option_group_count integer,
+  option_value_count integer
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+  v_group jsonb;
+  v_value jsonb;
+  v_recipe jsonb;
+  v_group_id uuid;
+  v_value_id uuid;
+  v_group_count integer := 0;
+  v_value_count integer := 0;
+  v_existing_group record;
+  v_existing_value record;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if p_option_groups is null then
+    p_option_groups := '[]'::jsonb;
+  end if;
+
+  if jsonb_typeof(p_option_groups) <> 'array' then
+    raise exception 'invalid_input: option_groups must be array' using errcode = '22023';
+  end if;
+
+  if not exists (
+    select 1 from public.menus m where m.id = p_menu_id and m.user_id = v_user_id
+  ) then
+    raise exception 'menu_not_found' using errcode = '22023';
+  end if;
+
+  -- Past sale snapshots may reference old option rows, so deactivate instead of deleting.
+  update public.menu_option_groups
+  set is_active = false
+  where menu_id = p_menu_id
+    and user_id = v_user_id;
+
+  update public.menu_option_values ov
+  set is_active = false
+  from public.menu_option_groups og
+  where ov.option_group_id = og.id
+    and og.menu_id = p_menu_id
+    and ov.user_id = v_user_id;
+
+  for v_group in select * from jsonb_array_elements(p_option_groups)
+  loop
+    if nullif(btrim(v_group ->> 'name'), '') is null then
+      raise exception 'invalid_input: option group name is required' using errcode = '22023';
+    end if;
+
+    select *
+    into v_existing_group
+    from public.menu_option_groups
+    where menu_id = p_menu_id
+      and user_id = v_user_id
+      and name = btrim(v_group ->> 'name')
+    limit 1;
+
+    if found then
+      update public.menu_option_groups
+      set selection_type = coalesce(nullif(v_group ->> 'selection_type', ''), selection_type),
+          is_required = coalesce((v_group ->> 'is_required')::boolean, is_required),
+          min_select = coalesce((v_group ->> 'min_select')::integer, min_select),
+          max_select = nullif(v_group ->> 'max_select', '')::integer,
+          sort_order = coalesce((v_group ->> 'sort_order')::integer, sort_order),
+          is_active = true
+      where id = v_existing_group.id
+      returning id into v_group_id;
+    else
+      insert into public.menu_option_groups (
+        user_id,
+        menu_id,
+        name,
+        selection_type,
+        is_required,
+        min_select,
+        max_select,
+        sort_order,
+        is_active
+      ) values (
+        v_user_id,
+        p_menu_id,
+        btrim(v_group ->> 'name'),
+        coalesce(nullif(v_group ->> 'selection_type', ''), 'add_on'),
+        coalesce((v_group ->> 'is_required')::boolean, false),
+        coalesce((v_group ->> 'min_select')::integer, 0),
+        nullif(v_group ->> 'max_select', '')::integer,
+        coalesce((v_group ->> 'sort_order')::integer, v_group_count),
+        true
+      )
+      returning id into v_group_id;
+    end if;
+
+    v_group_count := v_group_count + 1;
+
+    for v_value in select * from jsonb_array_elements(coalesce(v_group -> 'values', '[]'::jsonb))
+    loop
+      if nullif(btrim(v_value ->> 'name'), '') is null then
+        raise exception 'invalid_input: option value name is required' using errcode = '22023';
+      end if;
+
+      select *
+      into v_existing_value
+      from public.menu_option_values
+      where option_group_id = v_group_id
+        and user_id = v_user_id
+        and name = btrim(v_value ->> 'name')
+      limit 1;
+
+      if found then
+        update public.menu_option_values
+        set price_delta = coalesce((v_value ->> 'price_delta')::numeric, price_delta),
+            is_default = coalesce((v_value ->> 'is_default')::boolean, is_default),
+            sort_order = coalesce((v_value ->> 'sort_order')::integer, sort_order),
+            is_active = true
+        where id = v_existing_value.id
+        returning id into v_value_id;
+      else
+        insert into public.menu_option_values (
+          user_id,
+          option_group_id,
+          name,
+          price_delta,
+          is_default,
+          sort_order,
+          is_active
+        ) values (
+          v_user_id,
+          v_group_id,
+          btrim(v_value ->> 'name'),
+          coalesce((v_value ->> 'price_delta')::numeric, 0),
+          coalesce((v_value ->> 'is_default')::boolean, false),
+          coalesce((v_value ->> 'sort_order')::integer, v_value_count),
+          true
+        )
+        returning id into v_value_id;
+      end if;
+
+      v_value_count := v_value_count + 1;
+
+      delete from public.menu_option_value_recipe_items
+      where option_value_id = v_value_id
+        and user_id = v_user_id;
+
+      for v_recipe in select * from jsonb_array_elements(coalesce(v_value -> 'recipe', '[]'::jsonb))
+      loop
+        insert into public.menu_option_value_recipe_items (
+          user_id,
+          option_value_id,
+          ingredient_id,
+          quantity_per_selection
+        ) values (
+          v_user_id,
+          v_value_id,
+          (v_recipe ->> 'ingredient_id')::uuid,
+          (v_recipe ->> 'quantity_per_selection')::numeric
+        );
+      end loop;
+    end loop;
+  end loop;
+
+  return query select p_menu_id, v_group_count, v_value_count;
+end;
+$$;
+
+comment on function public.save_menu_options(uuid, jsonb) is
+  'Replaces active menu option groups/values/recipes for a menu. Old rows are deactivated for sale snapshot compatibility.';
+
+revoke all on function public.save_menu_options(uuid, jsonb) from public;
+grant execute on function public.save_menu_options(uuid, jsonb) to authenticated;

--- a/supabase/migrations/043_fix_sale_snapshot_replay_fallback.sql
+++ b/supabase/migrations/043_fix_sale_snapshot_replay_fallback.sql
@@ -1,0 +1,232 @@
+-- Migration: fix sale snapshot replay fallback
+--
+-- When a sale has no prior inventory event for an ingredient, replay should
+-- fall back to the ingredient's current average price instead of zero.
+
+create or replace function public.apply_sale_snapshot_rewrite(
+  p_from_date date,
+  p_note text default null
+)
+returns table (
+  replay_run_id uuid,
+  affected_sale_count integer,
+  affected_item_count integer,
+  total_cost_delta numeric
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_run_id uuid;
+  v_sale_count integer := 0;
+  v_item_count integer := 0;
+  v_total_cost_delta numeric(14, 4) := 0;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if p_from_date is null then
+    raise exception 'invalid_input: from_date is required' using errcode = '22023';
+  end if;
+
+  create temporary table if not exists sale_snapshot_replay_rows (
+    sale_id uuid not null,
+    sale_item_id uuid not null,
+    menu_id uuid not null,
+    quantity integer not null,
+    previous_menu_cost_snapshot numeric(14, 4) not null,
+    applied_menu_cost_snapshot numeric(14, 4) not null,
+    previous_total_cost_snapshot numeric(14, 4) not null,
+    applied_total_cost_snapshot numeric(14, 4) not null,
+    cost_delta numeric(14, 4) not null
+  ) on commit drop;
+
+  truncate table sale_snapshot_replay_rows;
+
+  insert into sale_snapshot_replay_rows (
+    sale_id,
+    sale_item_id,
+    menu_id,
+    quantity,
+    previous_menu_cost_snapshot,
+    applied_menu_cost_snapshot,
+    previous_total_cost_snapshot,
+    applied_total_cost_snapshot,
+    cost_delta
+  )
+  select
+    s.id as sale_id,
+    si.id as sale_item_id,
+    si.menu_id,
+    si.quantity,
+    si.menu_cost_snapshot as previous_menu_cost_snapshot,
+    (
+      (
+        coalesce(base_cost.base_cost, 0) * si.quantity
+        + coalesce(option_cost.option_cost_total, 0)
+      ) / si.quantity
+    )::numeric(14, 4) as applied_menu_cost_snapshot,
+    s.total_cost_snapshot as previous_total_cost_snapshot,
+    0::numeric(14, 4) as applied_total_cost_snapshot,
+    0::numeric(14, 4) as cost_delta
+  from public.sales s
+  join public.sale_items si on si.sale_id = s.id
+  left join lateral (
+    select coalesce(sum(ri.quantity_per_serving * coalesce(last_event.avg_price_after, i.current_avg_price, 0)), 0)::numeric(14, 4) as base_cost
+    from public.recipe_items ri
+    join public.ingredients i on i.id = ri.ingredient_id
+    left join lateral (
+      select ie.avg_price_after
+      from public.inventory_events ie
+      where ie.user_id = s.user_id
+        and ie.ingredient_id = ri.ingredient_id
+        and ie.occurred_at < s.created_at
+      order by ie.occurred_at desc, ie.event_seq desc
+      limit 1
+    ) last_event on true
+    where ri.menu_id = si.menu_id
+  ) base_cost on true
+  left join lateral (
+    select coalesce(sum(
+      ((recipe_item ->> 'quantity_per_selection')::numeric)
+      * sio.quantity
+      * coalesce(last_event.avg_price_after, i.current_avg_price, 0)
+    ), 0)::numeric(14, 4) as option_cost_total
+    from public.sale_item_options sio
+    cross join lateral jsonb_array_elements(sio.recipe_items_snapshot) as recipe_item
+    join public.ingredients i on i.id = (recipe_item ->> 'ingredient_id')::uuid
+    left join lateral (
+      select ie.avg_price_after
+      from public.inventory_events ie
+      where ie.user_id = s.user_id
+        and ie.ingredient_id = (recipe_item ->> 'ingredient_id')::uuid
+        and ie.occurred_at < s.created_at
+      order by ie.occurred_at desc, ie.event_seq desc
+      limit 1
+    ) last_event on true
+    where sio.sale_item_id = si.id
+  ) option_cost on true
+  where s.user_id = v_user_id
+    and s.sold_at >= p_from_date;
+
+  update sale_snapshot_replay_rows as row
+  set applied_total_cost_snapshot = totals.applied_total_cost_snapshot,
+      cost_delta = (row.applied_menu_cost_snapshot - row.previous_menu_cost_snapshot) * row.quantity
+  from (
+    select
+      sale_id,
+      sum(applied_menu_cost_snapshot * quantity)::numeric(14, 4) as applied_total_cost_snapshot
+    from sale_snapshot_replay_rows
+    group by sale_id
+  ) totals
+  where totals.sale_id = row.sale_id;
+
+  insert into public.sale_snapshot_replay_runs (
+    user_id,
+    from_date,
+    note,
+    affected_sale_count,
+    affected_item_count,
+    total_cost_delta
+  )
+  select
+    v_user_id,
+    p_from_date,
+    nullif(btrim(p_note), ''),
+    count(distinct sale_id)::integer,
+    count(*)::integer,
+    coalesce(sum(cost_delta), 0)::numeric(14, 4)
+  from sale_snapshot_replay_rows
+  returning id into v_run_id;
+
+  update public.sale_item_options sio
+  set option_cost_snapshot = coalesce((
+    select coalesce(sum(
+      ((recipe_item ->> 'quantity_per_selection')::numeric)
+      * coalesce(last_event.avg_price_after, i.current_avg_price, 0)
+    ), 0)::numeric(14, 4) as option_cost_snapshot
+    from jsonb_array_elements(sio.recipe_items_snapshot) as recipe_item
+    join public.ingredients i on i.id = (recipe_item ->> 'ingredient_id')::uuid
+    left join lateral (
+      select ie.avg_price_after
+      from public.inventory_events ie
+      where ie.user_id = s.user_id
+        and ie.ingredient_id = (recipe_item ->> 'ingredient_id')::uuid
+        and ie.occurred_at < s.created_at
+      order by ie.occurred_at desc, ie.event_seq desc
+      limit 1
+    ) last_event on true
+  ), 0)
+  from public.sale_items si
+  join public.sales s on s.id = si.sale_id
+  where sio.sale_item_id = si.id
+    and s.user_id = v_user_id
+    and s.sold_at >= p_from_date;
+
+  update public.sale_items si
+  set menu_cost_snapshot = row.applied_menu_cost_snapshot
+  from sale_snapshot_replay_rows row
+  where si.id = row.sale_item_id;
+
+  update public.sales s
+  set total_cost_snapshot = totals.applied_total_cost_snapshot,
+      updated_at = now()
+  from (
+    select
+      sale_id,
+      max(applied_total_cost_snapshot) as applied_total_cost_snapshot
+    from sale_snapshot_replay_rows
+    group by sale_id
+  ) totals
+  where s.id = totals.sale_id;
+
+  insert into public.sale_snapshot_replay_run_items (
+    run_id,
+    user_id,
+    sale_id,
+    sale_item_id,
+    menu_id,
+    quantity,
+    previous_menu_cost_snapshot,
+    applied_menu_cost_snapshot,
+    previous_total_cost_snapshot,
+    applied_total_cost_snapshot,
+    cost_delta
+  )
+  select
+    v_run_id,
+    v_user_id,
+    row.sale_id,
+    row.sale_item_id,
+    row.menu_id,
+    row.quantity,
+    row.previous_menu_cost_snapshot,
+    row.applied_menu_cost_snapshot,
+    row.previous_total_cost_snapshot,
+    row.applied_total_cost_snapshot,
+    row.cost_delta
+  from sale_snapshot_replay_rows row;
+
+  select count(distinct sale_id), count(*), coalesce(sum(cost_delta), 0)
+  into v_sale_count, v_item_count, v_total_cost_delta
+  from sale_snapshot_replay_rows;
+
+  update public.sale_snapshot_replay_runs
+  set affected_sale_count = v_sale_count,
+      affected_item_count = v_item_count,
+      total_cost_delta = v_total_cost_delta
+  where id = v_run_id;
+
+  return query select
+    v_run_id,
+    v_sale_count,
+    v_item_count,
+    v_total_cost_delta;
+end;
+$$;
+
+comment on function public.apply_sale_snapshot_rewrite(date, text) is
+  'Rewrites sale item cost snapshots including option recipe snapshots from inventory replay history, with fallback to current ingredient avg price when no prior event exists.';

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -32,35 +32,50 @@ export async function seedCafeWithBean(
     throw new Error(`cloneMenuTemplate failed: ${cloneResult.error.message}`);
   }
 
-  const menu = await client.from("menus").select("id").eq("name", menuName).single();
+  const clonedMenuIds = cloneResult.data?.[0]?.menu_ids ?? [];
+  if (clonedMenuIds.length === 0) {
+    throw new Error(`menu '${menuName}' lookup failed: no menu_id returned from clone`);
+  }
+
+  const menu = await client
+    .from("menus")
+    .select("id")
+    .in("id", clonedMenuIds)
+    .eq("name", menuName)
+    .single();
   if (menu.error || !menu.data) {
     throw new Error(`menu '${menuName}' lookup failed: ${menu.error?.message ?? "no row"}`);
   }
 
-  const admin = getServiceRoleClient();
-  const ing = await admin
-    .from("ingredients")
-    .select("id")
-    .eq("user_id", user.id)
-    .eq("name", ingredientName)
-    .single();
-  if (ing.error || !ing.data) {
-    throw new Error(
-      `ingredient '${ingredientName}' lookup failed: ${ing.error?.message ?? "no row"}`,
-    );
+  const recipeItems = await client
+    .from("recipe_items")
+    .select("ingredient:ingredients ( id, name )")
+    .eq("menu_id", menu.data.id);
+  if (recipeItems.error) {
+    throw new Error(`recipe_items lookup failed: ${recipeItems.error.message}`);
   }
+
+  const matchedIngredientId = recipeItems.data?.find(
+    (item: { ingredient: { id: string; name: string } | null }) =>
+      item.ingredient?.name === ingredientName,
+  )?.ingredient?.id;
+  if (!matchedIngredientId) {
+    throw new Error(`ingredient '${ingredientName}' lookup failed from menu '${menuName}' recipe`);
+  }
+
+  const admin = getServiceRoleClient();
 
   if (options.stock !== undefined && options.avgPrice !== undefined) {
     const update = await admin
       .from("ingredients")
       .update({ current_stock: options.stock, current_avg_price: options.avgPrice })
-      .eq("id", ing.data.id);
+      .eq("id", matchedIngredientId);
     if (update.error) {
       throw new Error(`ingredient stock update failed: ${update.error.message}`);
     }
   }
 
-  return { menuId: menu.data.id, ingredientId: ing.data.id };
+  return { menuId: menu.data.id, ingredientId: matchedIngredientId };
 }
 
 interface InsertResultLike<T> {

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -13,6 +13,7 @@ const rpcMocks = vi.hoisted(() => ({
   saveMenu: vi.fn(),
   editMenu: vi.fn(),
   deleteMenu: vi.fn(),
+  saveMenuOptions: vi.fn(),
 }));
 
 const forecastMocks = vi.hoisted(() => ({
@@ -32,6 +33,7 @@ vi.mock("@/lib/supabase/rpc", () => ({
   saveMenu: rpcMocks.saveMenu,
   editMenu: rpcMocks.editMenu,
   deleteMenu: rpcMocks.deleteMenu,
+  saveMenuOptions: rpcMocks.saveMenuOptions,
 }));
 
 vi.mock("@/lib/domain/forecast", async () => {
@@ -586,6 +588,10 @@ describe("application layer", () => {
       });
       rpcMocks.deleteMenu.mockResolvedValue({
         data: [{ menu_id: "menu-1", was_active: false }],
+        error: null,
+      });
+      rpcMocks.saveMenuOptions.mockResolvedValue({
+        data: [],
         error: null,
       });
 

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -50,7 +50,12 @@ import { loadTodayDashboard } from "@/lib/application/dashboard";
 import { loadCalendarMonth, withConsecutiveMissingDays } from "@/lib/application/calendar";
 import { applyInventoryReplay, loadDepletionForecast } from "@/lib/application/inventory";
 import { submitPurchase } from "@/lib/application/purchase";
-import { applySaleSnapshotRewrite, editSale, submitSale } from "@/lib/application/sale";
+import {
+  applySaleSnapshotRewrite,
+  editSale,
+  formatSaleErrorMessage,
+  submitSale,
+} from "@/lib/application/sale";
 
 describe("application layer", () => {
   beforeEach(() => {
@@ -545,6 +550,22 @@ describe("application layer", () => {
         ),
       ).rejects.toThrow(
         "이미 이 날짜의 판매가 입력되어 있어요. 캘린더 날짜 상세 또는 판매 수정 화면에서 기존 기록을 수정해주세요.",
+      );
+    });
+
+    it("formatSaleErrorMessage maps schema cache and query errors into friendly messages", () => {
+      expect(
+        formatSaleErrorMessage(
+          "Could not find the table 'public.menu_option_groups' in the schema cache",
+        ),
+      ).toBe(
+        "메뉴 옵션 데이터를 아직 불러오지 못했어요. 데이터베이스 마이그레이션 반영 후 다시 시도해주세요.",
+      );
+      expect(formatSaleErrorMessage("failed to parse select parameter")).toBe(
+        "메뉴 데이터를 읽는 중 오류가 발생했어요. 최신 마이그레이션 반영 후 다시 시도해주세요.",
+      );
+      expect(formatSaleErrorMessage("menu not found: abc")).toBe(
+        "메뉴를 다시 불러오지 못했어요. 새로고침 후 다시 시도해주세요.",
       );
     });
 

--- a/tests/unit/biz-lib.test.ts
+++ b/tests/unit/biz-lib.test.ts
@@ -22,6 +22,7 @@ const baseMenu = (overrides?: Partial<MenuRowWithRecipe>): MenuRowWithRecipe => 
     },
   ],
   ...overrides,
+  option_groups: overrides?.option_groups ?? [],
 });
 
 describe("computeMenuMarginFromRow", () => {

--- a/tests/unit/query-lookups.test.ts
+++ b/tests/unit/query-lookups.test.ts
@@ -9,7 +9,7 @@ type RpcResponse<T> = {
 function createClientMock(results: Record<string, RpcResponse<unknown>>) {
   return {
     from: vi.fn((table: string) => {
-      const response = results[table];
+      const response = results[table] ?? { data: [], error: null };
       const chain: any = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
@@ -54,6 +54,9 @@ describe("query lookups", () => {
         ],
         error: null,
       },
+      menu_option_groups: { data: [], error: null },
+      menu_option_values: { data: [], error: null },
+      menu_option_value_recipe_items: { data: [], error: null },
     });
 
     await expect(loadMenus(client)).resolves.toEqual([

--- a/tests/unit/query-lookups.test.ts
+++ b/tests/unit/query-lookups.test.ts
@@ -49,6 +49,7 @@ describe("query lookups", () => {
                 ingredient: null,
               },
             ],
+            option_groups: [],
           },
         ],
         error: null,
@@ -74,6 +75,7 @@ describe("query lookups", () => {
             },
           },
         ],
+        option_groups: [],
       },
     ]);
   });
@@ -164,6 +166,7 @@ describe("query lookups", () => {
           quantity: 3,
           unit_price: 15000,
           menu_cost_snapshot: 6000,
+          options: [],
         },
       ],
     });

--- a/tests/unit/rpc-menu-options.test.ts
+++ b/tests/unit/rpc-menu-options.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { saveMenuOptions } from "@/lib/supabase/rpc";
+
+describe("menu option RPC payload", () => {
+  it("saveMenuOptions maps nested option groups to snake_case payload", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+
+    await saveMenuOptions(
+      { rpc },
+      {
+        menuId: "menu-1",
+        optionGroups: [
+          {
+            name: "토핑 추가",
+            selectionType: "add_on",
+            isRequired: false,
+            minSelect: 0,
+            maxSelect: 2,
+            values: [
+              {
+                name: "연유 추가",
+                priceDelta: 500,
+                isDefault: false,
+                recipe: [{ ingredientId: "ing-1", quantityPerSelection: 10 }],
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(rpc).toHaveBeenCalledWith("save_menu_options", {
+      p_menu_id: "menu-1",
+      p_option_groups: [
+        {
+          name: "토핑 추가",
+          selection_type: "add_on",
+          is_required: false,
+          min_select: 0,
+          max_select: 2,
+          sort_order: 0,
+          values: [
+            {
+              name: "연유 추가",
+              price_delta: 500,
+              is_default: false,
+              sort_order: 0,
+              recipe: [{ ingredient_id: "ing-1", quantity_per_selection: 10 }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/sale-draft.test.ts
+++ b/tests/unit/sale-draft.test.ts
@@ -13,43 +13,45 @@ describe("sale draft helpers", () => {
     const second = upsertSaleDraftItems(first, "2026-06-02", "menu-b", 3);
 
     expect(second).toEqual({
-      "2026-06-01": [{ menuId: "menu-a", quantity: 2 }],
-      "2026-06-02": [{ menuId: "menu-b", quantity: 3 }],
+      "2026-06-01": [{ menuId: "menu-a", quantity: 2, options: [] }],
+      "2026-06-02": [{ menuId: "menu-b", quantity: 3, options: [] }],
     });
   });
 
   it("지정한 날짜의 드래프트만 지운다", () => {
     const drafts: SaleDraftsByDate = {
-      "2026-06-01": [{ menuId: "menu-a", quantity: 2 }],
-      "2026-06-02": [{ menuId: "menu-b", quantity: 3 }],
+      "2026-06-01": [{ menuId: "menu-a", quantity: 2, options: [] }],
+      "2026-06-02": [{ menuId: "menu-b", quantity: 3, options: [] }],
     };
 
     expect(clearSaleDraftDate(drafts, "2026-06-01")).toEqual({
-      "2026-06-02": [{ menuId: "menu-b", quantity: 3 }],
+      "2026-06-02": [{ menuId: "menu-b", quantity: 3, options: [] }],
     });
   });
 
   it("현재 메뉴에 없는 항목은 제거한다", () => {
     const filtered = sanitizeSaleDraftItems(
       [
-        { menuId: "menu-a", quantity: 2 },
-        { menuId: "menu-x", quantity: 1 },
+        { menuId: "menu-a", quantity: 2, options: [] },
+        { menuId: "menu-x", quantity: 1, options: [] },
       ],
       new Set(["menu-a", "menu-b"]),
     );
 
-    expect(filtered).toEqual([{ menuId: "menu-a", quantity: 2 }]);
+    expect(filtered).toEqual([{ menuId: "menu-a", quantity: 2, options: [] }]);
   });
 
   it("드래프트 항목을 날짜 단위로 통째로 교체한다", () => {
     const drafts: SaleDraftsByDate = {
-      "2026-06-01": [{ menuId: "menu-a", quantity: 2 }],
+      "2026-06-01": [{ menuId: "menu-a", quantity: 2, options: [] }],
     };
 
     expect(
-      replaceSaleDraftDateItems(drafts, "2026-06-01", [{ menuId: "menu-b", quantity: 4 }]),
+      replaceSaleDraftDateItems(drafts, "2026-06-01", [
+        { menuId: "menu-b", quantity: 4, options: [] },
+      ]),
     ).toEqual({
-      "2026-06-01": [{ menuId: "menu-b", quantity: 4 }],
+      "2026-06-01": [{ menuId: "menu-b", quantity: 4, options: [] }],
     });
   });
 });

--- a/tests/unit/sale-stock-guard.test.ts
+++ b/tests/unit/sale-stock-guard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   findSaleStockShortages,
   formatStockShortageMessage,
+  findSaleOptionErrors,
 } from "@/features/sale/lib/stock-guard";
 import type { MenuRowWithRecipe } from "@/features/menu/hooks/useMenus";
 
@@ -24,6 +25,7 @@ const menus: MenuRowWithRecipe[] = [
         },
       },
     ],
+    option_groups: [],
   },
   {
     id: "menu-2",
@@ -41,6 +43,57 @@ const menus: MenuRowWithRecipe[] = [
           current_stock: 200,
           current_avg_price: 20,
         },
+      },
+    ],
+    option_groups: [],
+  },
+  {
+    id: "menu-3",
+    name: "샷추가커피",
+    price: 5000,
+    is_active: true,
+    recipe_items: [
+      {
+        id: "recipe-3",
+        quantity_per_serving: 10,
+        ingredient: {
+          id: "ing-3",
+          name: "원두",
+          unit: "g",
+          current_stock: 100,
+          current_avg_price: 50,
+        },
+      },
+    ],
+    option_groups: [
+      {
+        id: "group-1",
+        name: "샷 추가",
+        selection_type: "add_on",
+        is_required: false,
+        min_select: 0,
+        max_select: 2,
+        values: [
+          {
+            id: "value-1",
+            name: "샷 추가",
+            price_delta: 500,
+            is_default: false,
+            recipe_items: [
+              {
+                id: "recipe-4",
+                quantity_per_selection: 20,
+                ingredient: {
+                  id: "ing-4",
+                  name: "원두",
+                  unit: "g",
+                  current_stock: 0,
+                  current_avg_price: 50,
+                },
+              },
+            ],
+          },
+        ],
       },
     ],
   },
@@ -115,5 +168,47 @@ describe("sale stock guard", () => {
     expect(message).toBe(
       "재고가 부족한 재료가 있어요.\n- 인절미: 사용 가능 0g, 필요 60g, 부족 60g\n- 팥: 사용 가능 10g, 필요 40g, 부족 30g\n먼저 매입 또는 재고실사로 재고를 채워주세요.",
     );
+  });
+
+  it("옵션 재료 부족도 shortage에 포함한다", () => {
+    const shortages = findSaleStockShortages({
+      items: [
+        {
+          menuId: "menu-3",
+          quantity: 2,
+          options: [{ groupId: "group-1", optionValueId: "value-1", quantity: 2 }],
+        },
+      ],
+      menus,
+    });
+
+    expect(shortages.some((item) => item.ingredientId === "ing-4")).toBe(true);
+  });
+
+  it("필수 옵션 미선택은 option error로 걸린다", () => {
+    const optionMenu = menus[2]!;
+    const requiredGroup = optionMenu.option_groups[0]!;
+    const errors = findSaleOptionErrors({
+      items: [
+        {
+          menuId: "menu-3",
+          quantity: 2,
+          options: [],
+        },
+      ],
+      menus: [
+        {
+          ...optionMenu,
+          option_groups: [
+            {
+              ...requiredGroup,
+              is_required: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(errors.some((error) => error.message.includes("required_option_missing"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- close #121
- Add menu option editing UI and persist option groups / values / recipes
- Let sale input/edit screens carry option selections through draft state and payloads
- Include option-aware stock guarding, edit preservation, and sale preview snapshots
- Show option snapshots in menu detail and locked sale views

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/sale-draft.test.ts tests/unit/rpc-menu-options.test.ts tests/unit/rpc-sale-options.test.ts tests/unit/application.test.ts tests/unit/biz-lib.test.ts tests/unit/sale-stock-guard.test.ts tests/unit/query-lookups.test.ts