### PR TITLE
Add option-aware ingredient demand forecast

### DIFF
--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -1,11 +1,16 @@
 import {
+  forecastIngredientDemandFromMenus,
   forecastIngredient,
+  forecastMenuDemand,
   type DailyConsumption,
+  type DailyMenuDemand,
   type ForecastResult,
+  type IngredientDemandForecast,
 } from "@/lib/domain/forecast";
 import {
   applyInventoryReplay as applyInventoryReplayRpc,
   getDepletionForecast,
+  getMenuDemandForecast,
   type ApplyInventoryReplayResult,
 } from "@/lib/supabase/rpc";
 
@@ -56,6 +61,38 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       ...forecast,
     };
   });
+}
+
+export async function loadMenuBasedIngredientDemandForecast(
+  client: RpcClient,
+  horizonDays: number = 7,
+): Promise<IngredientDemandForecast[]> {
+  const { data, error } = await getMenuDemandForecast(client);
+  if (error) throw new Error(error.message);
+
+  const today = new Date();
+  return forecastIngredientDemandFromMenus(
+    (data ?? []).map((row) => {
+      const demandSamples: DailyMenuDemand[] = row.demandSamples.map((sample) => ({
+        date: new Date(sample.date),
+        quantity: Number(sample.quantity),
+      }));
+
+      return {
+        menuId: row.menuId,
+        name: row.name,
+        baseRecipe: row.baseRecipe,
+        optionGroups: row.optionGroups,
+        demandForecast: forecastMenuDemand({
+          demandSamples,
+          daysOff: row.regularDaysOff,
+          signupDate: new Date(row.signedUpAt),
+          today,
+          horizonDays,
+        }),
+      };
+    }),
+  );
 }
 
 export interface ApplyInventoryReplayInput {

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -44,6 +44,50 @@ export interface DailyMenuDemand {
   quantity: number;
 }
 
+export interface MenuRecipeIngredient {
+  ingredientId: string;
+  quantityPerServing: number;
+}
+
+export interface MenuOptionRecipeIngredient {
+  ingredientId: string;
+  quantityPerSelection: number;
+}
+
+export interface MenuOptionValueForecastInput {
+  optionValueId: string;
+  name: string;
+  isDefault: boolean;
+  selectionRate: number;
+  recipe: readonly MenuOptionRecipeIngredient[];
+}
+
+export interface MenuOptionGroupForecastInput {
+  optionGroupId: string;
+  name: string;
+  selectionType: "single" | "add_on";
+  isRequired: boolean;
+  values: readonly MenuOptionValueForecastInput[];
+}
+
+export interface MenuIngredientDemandForecastInput {
+  menuId: string;
+  name: string;
+  baseRecipe: readonly MenuRecipeIngredient[];
+  optionGroups: readonly MenuOptionGroupForecastInput[];
+  demandForecast: MenuDemandForecastResult;
+}
+
+export interface IngredientDemandForecastDay {
+  date: Date;
+  amount: number;
+}
+
+export interface IngredientDemandForecast {
+  ingredientId: string;
+  dailyPredictions: IngredientDemandForecastDay[];
+}
+
 export interface ForecastInput {
   currentStock: number;
   leadTimeDays: number;
@@ -441,4 +485,106 @@ function buildZeroMenuDemandDays(
       predictedQuantity: 0,
     };
   });
+}
+
+export function forecastIngredientDemandFromMenus(
+  menus: readonly MenuIngredientDemandForecastInput[],
+): IngredientDemandForecast[] {
+  const byIngredient = new Map<string, Map<number, { date: Date; amount: Decimal }>>();
+
+  for (const menu of menus) {
+    const normalizedGroups = menu.optionGroups.map((group) => ({
+      ...group,
+      values: withEffectiveOptionRates(group),
+    }));
+
+    for (const day of menu.demandForecast.dailyPredictions) {
+      const menuQuantity = new Decimal(Math.max(0, day.predictedQuantity));
+      if (menuQuantity.isZero()) continue;
+
+      for (const recipeItem of menu.baseRecipe) {
+        addIngredientDemand(
+          byIngredient,
+          recipeItem.ingredientId,
+          day.date,
+          menuQuantity.times(recipeItem.quantityPerServing),
+        );
+      }
+
+      for (const group of normalizedGroups) {
+        for (const value of group.values) {
+          const optionQuantity = menuQuantity.times(value.effectiveRate);
+          if (optionQuantity.isZero()) continue;
+
+          for (const recipeItem of value.recipe) {
+            addIngredientDemand(
+              byIngredient,
+              recipeItem.ingredientId,
+              day.date,
+              optionQuantity.times(recipeItem.quantityPerSelection),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return Array.from(byIngredient.entries())
+    .map(([ingredientId, daily]) => ({
+      ingredientId,
+      dailyPredictions: Array.from(daily.values())
+        .sort((a, b) => a.date.getTime() - b.date.getTime())
+        .map((day) => ({ date: day.date, amount: day.amount.toNumber() })),
+    }))
+    .sort((a, b) => a.ingredientId.localeCompare(b.ingredientId));
+}
+
+function withEffectiveOptionRates(
+  group: MenuOptionGroupForecastInput,
+): Array<MenuOptionValueForecastInput & { effectiveRate: number }> {
+  if (group.selectionType === "add_on") {
+    return group.values.map((value) => ({
+      ...value,
+      effectiveRate: Math.max(0, value.selectionRate),
+    }));
+  }
+
+  const positiveTotal = group.values.reduce(
+    (sum, value) => sum + Math.max(0, value.selectionRate),
+    0,
+  );
+  if (positiveTotal > 0) {
+    return group.values.map((value) => ({
+      ...value,
+      effectiveRate: Math.max(0, value.selectionRate) / positiveTotal,
+    }));
+  }
+
+  const defaults = group.values.filter((value) => value.isDefault);
+  return group.values.map((value) => ({
+    ...value,
+    effectiveRate:
+      defaults.length > 0 && value.isDefault ? 1 / defaults.length : group.isRequired ? 0 : 0,
+  }));
+}
+
+function addIngredientDemand(
+  byIngredient: Map<string, Map<number, { date: Date; amount: Decimal }>>,
+  ingredientId: string,
+  date: Date,
+  amount: Decimal,
+): void {
+  const dateKey = startOfForecastDay(date).getTime();
+  const daily =
+    byIngredient.get(ingredientId) ?? new Map<number, { date: Date; amount: Decimal }>();
+  const existing = daily.get(dateKey);
+  daily.set(dateKey, {
+    date: existing?.date ?? new Date(dateKey),
+    amount: (existing?.amount ?? new Decimal(0)).plus(amount),
+  });
+  byIngredient.set(ingredientId, daily);
+}
+
+function startOfForecastDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }

--- a/src/lib/supabase/rpc-queries.ts
+++ b/src/lib/supabase/rpc-queries.ts
@@ -19,6 +19,20 @@ export interface MenuDemandForecastRow {
   name: string;
   price: number;
   isActive: boolean;
+  baseRecipe: Array<{ ingredientId: string; quantityPerServing: number }>;
+  optionGroups: Array<{
+    optionGroupId: string;
+    name: string;
+    selectionType: "single" | "add_on";
+    isRequired: boolean;
+    values: Array<{
+      optionValueId: string;
+      name: string;
+      isDefault: boolean;
+      selectionRate: number;
+      recipe: Array<{ ingredientId: string; quantityPerSelection: number }>;
+    }>;
+  }>;
   demandSamples: Array<{ date: string; quantity: number }>;
   signedUpAt: string;
   regularDaysOff: ReadonlyArray<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -43,6 +57,20 @@ interface MenuDemandForecastRawRow {
   name: string;
   price: number;
   is_active: boolean;
+  base_recipe?: Array<{ ingredient_id: string; quantity_per_serving: number }> | null;
+  option_groups?: Array<{
+    option_group_id: string;
+    name: string;
+    selection_type: "single" | "add_on";
+    is_required: boolean;
+    values?: Array<{
+      option_value_id: string;
+      name: string;
+      is_default: boolean;
+      selection_rate: number;
+      recipe?: Array<{ ingredient_id: string; quantity_per_selection: number }> | null;
+    }> | null;
+  }> | null;
   demand_samples: Array<{ date: string; quantity: number }>;
   signed_up_at: string;
   regular_days_off: Array<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -299,6 +327,26 @@ export async function getMenuDemandForecast(
       name: row.name,
       price: numeric(row.price),
       isActive: row.is_active,
+      baseRecipe: (row.base_recipe ?? []).map((item) => ({
+        ingredientId: item.ingredient_id,
+        quantityPerServing: numeric(item.quantity_per_serving),
+      })),
+      optionGroups: (row.option_groups ?? []).map((group) => ({
+        optionGroupId: group.option_group_id,
+        name: group.name,
+        selectionType: group.selection_type,
+        isRequired: group.is_required,
+        values: (group.values ?? []).map((value) => ({
+          optionValueId: value.option_value_id,
+          name: value.name,
+          isDefault: value.is_default,
+          selectionRate: numeric(value.selection_rate),
+          recipe: (value.recipe ?? []).map((item) => ({
+            ingredientId: item.ingredient_id,
+            quantityPerSelection: numeric(item.quantity_per_selection),
+          })),
+        })),
+      })),
       demandSamples: row.demand_samples ?? [],
       signedUpAt: row.signed_up_at,
       regularDaysOff: row.regular_days_off ?? [],

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -768,10 +768,12 @@ export type Database = {
       get_menu_demand_forecast: {
         Args: never
         Returns: {
+          base_recipe: Json
           demand_samples: Json
           is_active: boolean
           menu_id: string
           name: string
+          option_groups: Json
           price: number
           regular_days_off: Database["public"]["Enums"]["weekday"][]
           signed_up_at: string

--- a/supabase/migrations/045_extend_menu_demand_forecast_inputs.sql
+++ b/supabase/migrations/045_extend_menu_demand_forecast_inputs.sql
@@ -4,6 +4,8 @@
 -- menu demand forecast RPC. The client combines these with menu demand
 -- predictions to produce ingredient demand forecasts.
 
+drop function if exists public.get_menu_demand_forecast();
+
 create or replace function public.get_menu_demand_forecast()
 returns table (
   menu_id uuid,

--- a/supabase/migrations/045_extend_menu_demand_forecast_inputs.sql
+++ b/supabase/migrations/045_extend_menu_demand_forecast_inputs.sql
@@ -1,0 +1,145 @@
+-- Migration: extend menu demand forecast inputs
+--
+-- Adds base recipe, option recipe, and option selection/attach rates to the
+-- menu demand forecast RPC. The client combines these with menu demand
+-- predictions to produce ingredient demand forecasts.
+
+create or replace function public.get_menu_demand_forecast()
+returns table (
+  menu_id uuid,
+  name text,
+  price numeric,
+  is_active boolean,
+  base_recipe jsonb,
+  option_groups jsonb,
+  demand_samples jsonb,
+  signed_up_at timestamptz,
+  regular_days_off public.weekday[]
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  return query
+  with menu_sales as (
+    select
+      si.menu_id,
+      sum(si.quantity)::numeric as total_quantity
+    from public.sales s
+    join public.sale_items si on si.sale_id = s.id
+    where s.user_id = v_user_id
+      and s.sold_at >= current_date - interval '90 days'
+    group by si.menu_id
+  ),
+  option_sales as (
+    select
+      si.menu_id,
+      sio.option_value_id,
+      sum(sio.quantity)::numeric as selected_quantity
+    from public.sales s
+    join public.sale_items si on si.sale_id = s.id
+    join public.sale_item_options sio on sio.sale_item_id = si.id
+    where s.user_id = v_user_id
+      and s.sold_at >= current_date - interval '90 days'
+    group by si.menu_id, sio.option_value_id
+  )
+  select
+    m.id,
+    m.name,
+    m.price,
+    m.is_active,
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object(
+          'ingredient_id', ri.ingredient_id,
+          'quantity_per_serving', ri.quantity_per_serving
+        ) order by ri.ingredient_id)
+        from public.recipe_items ri
+        where ri.menu_id = m.id
+      ),
+      '[]'::jsonb
+    ) as base_recipe,
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object(
+          'option_group_id', og.id,
+          'name', og.name,
+          'selection_type', og.selection_type,
+          'is_required', og.is_required,
+          'values', coalesce(values_json.values, '[]'::jsonb)
+        ) order by og.sort_order, og.name)
+        from public.menu_option_groups og
+        left join menu_sales ms on ms.menu_id = m.id
+        left join lateral (
+          select jsonb_agg(jsonb_build_object(
+            'option_value_id', ov.id,
+            'name', ov.name,
+            'is_default', ov.is_default,
+            'selection_rate', case
+              when coalesce(ms.total_quantity, 0) > 0
+                then coalesce(os.selected_quantity, 0) / ms.total_quantity
+              else 0
+            end,
+            'recipe', coalesce(recipe_json.recipe, '[]'::jsonb)
+          ) order by ov.sort_order, ov.name) as values
+          from public.menu_option_values ov
+          left join option_sales os on os.option_value_id = ov.id and os.menu_id = m.id
+          left join lateral (
+            select jsonb_agg(jsonb_build_object(
+              'ingredient_id', ovr.ingredient_id,
+              'quantity_per_selection', ovr.quantity_per_selection
+            ) order by ovr.ingredient_id) as recipe
+            from public.menu_option_value_recipe_items ovr
+            where ovr.option_value_id = ov.id
+              and ovr.user_id = v_user_id
+          ) recipe_json on true
+          where ov.option_group_id = og.id
+            and ov.user_id = v_user_id
+            and ov.is_active = true
+        ) values_json on true
+        where og.menu_id = m.id
+          and og.user_id = v_user_id
+          and og.is_active = true
+      ),
+      '[]'::jsonb
+    ) as option_groups,
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('date', sold_at, 'quantity', quantity) order by sold_at)
+        from (
+          select
+            s.sold_at,
+            sum(si.quantity)::integer as quantity
+          from public.sales s
+          join public.sale_items si on si.sale_id = s.id
+          where s.user_id = v_user_id
+            and si.menu_id = m.id
+            and s.sold_at >= current_date - interval '90 days'
+          group by s.sold_at
+        ) daily
+      ),
+      '[]'::jsonb
+    ) as demand_samples,
+    u.signed_up_at,
+    u.regular_days_off
+  from public.menus m
+  join public.users u on u.id = m.user_id
+  where m.user_id = v_user_id
+    and m.is_active = true
+  order by m.name;
+end;
+$$;
+
+comment on function public.get_menu_demand_forecast() is
+  '메뉴별 수요 예측 raw 데이터 반환. 일별 판매 수량, 기본 레시피, 옵션 레시피, 옵션 선택률/부착률을 반환한다.';
+
+revoke all on function public.get_menu_demand_forecast() from public;
+grant execute on function public.get_menu_demand_forecast() to authenticated;

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -4,6 +4,7 @@ const rpcMocks = vi.hoisted(() => ({
   getCalendarMonth: vi.fn(),
   getTodayDashboard: vi.fn(),
   getDepletionForecast: vi.fn(),
+  getMenuDemandForecast: vi.fn(),
   applyInventoryReplay: vi.fn(),
   applySaleSnapshotRewrite: vi.fn(),
   savePurchase: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("@/lib/supabase/rpc", () => ({
   getCalendarMonth: rpcMocks.getCalendarMonth,
   getTodayDashboard: rpcMocks.getTodayDashboard,
   getDepletionForecast: rpcMocks.getDepletionForecast,
+  getMenuDemandForecast: rpcMocks.getMenuDemandForecast,
   applyInventoryReplay: rpcMocks.applyInventoryReplay,
   applySaleSnapshotRewrite: rpcMocks.applySaleSnapshotRewrite,
   savePurchase: rpcMocks.savePurchase,
@@ -48,7 +50,11 @@ vi.mock("@/lib/domain/forecast", async () => {
 import { createMenu, removeMenu, updateMenu } from "@/lib/application/menu";
 import { loadTodayDashboard } from "@/lib/application/dashboard";
 import { loadCalendarMonth, withConsecutiveMissingDays } from "@/lib/application/calendar";
-import { applyInventoryReplay, loadDepletionForecast } from "@/lib/application/inventory";
+import {
+  applyInventoryReplay,
+  loadDepletionForecast,
+  loadMenuBasedIngredientDemandForecast,
+} from "@/lib/application/inventory";
 import { submitPurchase } from "@/lib/application/purchase";
 import {
   applySaleSnapshotRewrite,
@@ -354,6 +360,53 @@ describe("application layer", () => {
         stockDeltaTotal: -120,
         avgPriceDeltaTotal: 15.5,
       });
+    });
+
+    it("loadMenuBasedIngredientDemandForecast converts menu demand and options into ingredient demand", async () => {
+      rpcMocks.getMenuDemandForecast.mockResolvedValue({
+        data: [
+          {
+            menuId: "menu-1",
+            name: "과일빙수",
+            price: 12000,
+            isActive: true,
+            baseRecipe: [{ ingredientId: "ice", quantityPerServing: 100 }],
+            optionGroups: [
+              {
+                optionGroupId: "topping",
+                name: "토핑",
+                selectionType: "add_on",
+                isRequired: false,
+                values: [
+                  {
+                    optionValueId: "condensed",
+                    name: "연유",
+                    isDefault: false,
+                    selectionRate: 0.5,
+                    recipe: [{ ingredientId: "condensed", quantityPerSelection: 20 }],
+                  },
+                ],
+              },
+            ],
+            demandSamples: Array.from({ length: 30 }, (_, index) => ({
+              date: `2026-05-${String(index + 1).padStart(2, "0")}`,
+              quantity: 10,
+            })),
+            signedUpAt: "2026-04-01T00:00:00.000Z",
+            regularDaysOff: [],
+          },
+        ],
+        error: null,
+      });
+
+      const result = await loadMenuBasedIngredientDemandForecast({ rpc: {} }, 1);
+
+      expect(result.map((row) => row.ingredientId).sort()).toEqual(["condensed", "ice"]);
+      const ice = result.find((row) => row.ingredientId === "ice")?.dailyPredictions[0]?.amount;
+      const condensed = result.find((row) => row.ingredientId === "condensed")?.dailyPredictions[0]
+        ?.amount;
+      expect(ice).toBeGreaterThan(0);
+      expect(condensed).toBeCloseTo((ice ?? 0) * 0.1);
     });
   });
 

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -7,6 +7,7 @@ import {
   computeTrendFactor,
   computeWeekdayUsageAverage,
   detectTrend,
+  forecastIngredientDemandFromMenus,
   forecastIngredient,
   forecastMenuDemand,
   isColdStart,
@@ -431,5 +432,181 @@ describe("forecastMenuDemand", () => {
       (day) => day.dayType === "weekday" && day.date.toISOString().slice(0, 10) === "2026-05-04",
     );
     expect(friday?.predictedQuantity).toBeGreaterThan(weekday?.predictedQuantity ?? 0);
+  });
+});
+
+describe("forecastIngredientDemandFromMenus", () => {
+  it("메뉴 기본 레시피와 옵션 선택률/부착률을 재료 소요량으로 합산한다", () => {
+    const demand = forecastIngredientDemandFromMenus([
+      {
+        menuId: "menu-bingsu",
+        name: "과일빙수",
+        baseRecipe: [{ ingredientId: "milk-ice", quantityPerServing: 100 }],
+        optionGroups: [
+          {
+            optionGroupId: "ice-type",
+            name: "얼음 선택",
+            selectionType: "single",
+            isRequired: true,
+            values: [
+              {
+                optionValueId: "milk",
+                name: "우유얼음",
+                isDefault: true,
+                selectionRate: 0.7,
+                recipe: [{ ingredientId: "milk", quantityPerSelection: 50 }],
+              },
+              {
+                optionValueId: "green-tea",
+                name: "녹차얼음",
+                isDefault: false,
+                selectionRate: 0.3,
+                recipe: [{ ingredientId: "green-tea-powder", quantityPerSelection: 10 }],
+              },
+            ],
+          },
+          {
+            optionGroupId: "toppings",
+            name: "토핑 추가",
+            selectionType: "add_on",
+            isRequired: false,
+            values: [
+              {
+                optionValueId: "condensed-milk",
+                name: "연유 추가",
+                isDefault: false,
+                selectionRate: 0.4,
+                recipe: [{ ingredientId: "condensed-milk", quantityPerSelection: 20 }],
+              },
+            ],
+          },
+        ],
+        demandForecast: {
+          dailyPredictions: [
+            {
+              date: new Date("2026-05-01T00:00:00"),
+              dayType: "friday",
+              predictedQuantity: 100,
+            },
+          ],
+          fallbackDailyQuantity: 100,
+          trend: "normal",
+          isColdStart: false,
+        },
+      },
+    ]);
+
+    const byIngredient = new Map(
+      demand.map((item) => [item.ingredientId, item.dailyPredictions[0]?.amount]),
+    );
+    expect(byIngredient.get("milk-ice")).toBe(10_000);
+    expect(byIngredient.get("milk")).toBe(3_500);
+    expect(byIngredient.get("green-tea-powder")).toBe(300);
+    expect(byIngredient.get("condensed-milk")).toBe(800);
+  });
+
+  it("택1 옵션 이력 비율 합이 1이 아니면 정규화한다", () => {
+    const demand = forecastIngredientDemandFromMenus([
+      {
+        menuId: "menu-1",
+        name: "테스트메뉴",
+        baseRecipe: [],
+        optionGroups: [
+          {
+            optionGroupId: "single",
+            name: "택1",
+            selectionType: "single",
+            isRequired: true,
+            values: [
+              {
+                optionValueId: "a",
+                name: "A",
+                isDefault: false,
+                selectionRate: 2,
+                recipe: [{ ingredientId: "a-ing", quantityPerSelection: 10 }],
+              },
+              {
+                optionValueId: "b",
+                name: "B",
+                isDefault: false,
+                selectionRate: 1,
+                recipe: [{ ingredientId: "b-ing", quantityPerSelection: 10 }],
+              },
+            ],
+          },
+        ],
+        demandForecast: {
+          dailyPredictions: [
+            {
+              date: new Date("2026-05-01T00:00:00"),
+              dayType: "friday",
+              predictedQuantity: 90,
+            },
+          ],
+          fallbackDailyQuantity: 90,
+          trend: "normal",
+          isColdStart: false,
+        },
+      },
+    ]);
+
+    const byIngredient = new Map(
+      demand.map((item) => [item.ingredientId, item.dailyPredictions[0]?.amount]),
+    );
+    expect(byIngredient.get("a-ing")).toBeCloseTo(600);
+    expect(byIngredient.get("b-ing")).toBeCloseTo(300);
+  });
+
+  it("택1 옵션 이력이 없으면 기본값으로 fallback한다", () => {
+    const demand = forecastIngredientDemandFromMenus([
+      {
+        menuId: "menu-1",
+        name: "테스트메뉴",
+        baseRecipe: [],
+        optionGroups: [
+          {
+            optionGroupId: "single",
+            name: "택1",
+            selectionType: "single",
+            isRequired: true,
+            values: [
+              {
+                optionValueId: "default",
+                name: "기본",
+                isDefault: true,
+                selectionRate: 0,
+                recipe: [{ ingredientId: "default-ing", quantityPerSelection: 5 }],
+              },
+              {
+                optionValueId: "other",
+                name: "기타",
+                isDefault: false,
+                selectionRate: 0,
+                recipe: [{ ingredientId: "other-ing", quantityPerSelection: 5 }],
+              },
+            ],
+          },
+        ],
+        demandForecast: {
+          dailyPredictions: [
+            {
+              date: new Date("2026-05-01T00:00:00"),
+              dayType: "friday",
+              predictedQuantity: 10,
+            },
+          ],
+          fallbackDailyQuantity: 10,
+          trend: "normal",
+          isColdStart: false,
+        },
+      },
+    ]);
+
+    expect(demand).toEqual([
+      {
+        ingredientId: "default-ing",
+        dailyPredictions: [{ date: new Date("2026-05-01T00:00:00"), amount: 50 }],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- extend menu demand forecast RPC with base recipe, option recipes, and option selection/attach rates
- add domain conversion from menu demand forecasts to ingredient demand forecasts
- add application loader for menu-based ingredient demand forecasts
- cover base recipe, single-option normalization/default fallback, add-on attach rates, and application mapping

## Test
- npm run lint
- npm run typecheck
- npm run format:check
- npx vitest run tests/unit/forecast.test.ts tests/unit/application.test.ts