### PR TITLE
Use menu demand for depletion forecast

### DIFF
--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -95,6 +95,7 @@ function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactE
             안전여유 {item.safetyBufferDays}일
           </span>
           <span className="text-caption text-ink-3">{formatLeadTimeSource(item)}</span>
+          <span className="text-caption text-ink-3">{formatForecastSource(item)}</span>
         </div>
         <div className="flex items-center gap-stack-tight">
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
@@ -128,6 +129,13 @@ function formatLeadTimeSource(item: IngredientForecastView): string {
   return item.leadTimeVendorName
     ? `${item.leadTimeVendorName} 거래처 이력 기준 리드타임 적용`
     : "최근 가장 자주 쓴 거래처 기준 리드타임 적용";
+}
+
+function formatForecastSource(item: IngredientForecastView): string {
+  if (item.forecastSource === "menu_demand") {
+    return "메뉴·옵션 판매 예측 기준";
+  }
+  return "최근 재료 사용량 기준";
 }
 
 const STATUS_TONE: Record<DepletionStatus, string> = {

--- a/src/features/inventory/hooks/useDepletionForecast.ts
+++ b/src/features/inventory/hooks/useDepletionForecast.ts
@@ -3,7 +3,6 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
 import { loadDepletionForecast, type IngredientForecastView } from "@/lib/application/inventory";
-import type { ForecastResult } from "@/lib/domain/forecast";
 
 /**
  * RPC `get_depletion_forecast`로 raw 데이터를 받아 클라이언트에서
@@ -14,20 +13,7 @@ export const depletionForecastQueryKey = ["inventory", "forecast"] as const;
 
 export type { IngredientForecastView } from "@/lib/application/inventory";
 
-async function fetchDepletionForecast(): Promise<
-  Array<
-    {
-      ingredientId: string;
-      name: string;
-      unit: "g" | "ml" | "piece";
-      currentStock: number;
-      leadTimeDays: number;
-      leadTimeVendorName: string | null;
-      isDefaultLeadTime: boolean;
-      safetyBufferDays: number;
-    } & ForecastResult
-  >
-> {
+async function fetchDepletionForecast(): Promise<IngredientForecastView[]> {
   const supabase = createClient();
   return loadDepletionForecast(supabase);
 }

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -1,4 +1,5 @@
 import {
+  classifyStatus,
   forecastIngredientDemandFromMenus,
   forecastIngredient,
   forecastMenuDemand,
@@ -18,6 +19,8 @@ interface RpcClient {
   rpc: unknown;
 }
 
+const MENU_DEMAND_DEPLETION_HORIZON_DAYS = 365;
+
 export interface IngredientForecastView extends ForecastResult {
   ingredientId: string;
   name: string;
@@ -27,6 +30,7 @@ export interface IngredientForecastView extends ForecastResult {
   leadTimeVendorName: string | null;
   isDefaultLeadTime: boolean;
   safetyBufferDays: number;
+  forecastSource: "menu_demand" | "consumption_history";
 }
 
 export async function loadDepletionForecast(client: RpcClient): Promise<IngredientForecastView[]> {
@@ -34,7 +38,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
   if (error) throw new Error(error.message);
 
   const today = new Date();
-  return (data ?? []).map((row) => {
+  const legacyForecasts = (data ?? []).map((row) => {
     const samples: DailyConsumption[] = row.consumptionSamples.map((s) => ({
       date: new Date(s.date),
       amount: Number(s.amount),
@@ -58,7 +62,33 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       leadTimeVendorName: row.leadTimeVendorName,
       isDefaultLeadTime: row.isDefaultLeadTime,
       safetyBufferDays,
+      forecastSource: "consumption_history" as const,
       ...forecast,
+    };
+  });
+
+  const menuDemandForecasts = await loadMenuBasedIngredientDemandForecastSafely(
+    client,
+    MENU_DEMAND_DEPLETION_HORIZON_DAYS,
+  );
+  if (menuDemandForecasts.length === 0) return legacyForecasts;
+
+  const demandByIngredient = new Map(
+    menuDemandForecasts.map((forecast) => [forecast.ingredientId, forecast]),
+  );
+
+  return legacyForecasts.map((legacy) => {
+    const demand = demandByIngredient.get(legacy.ingredientId);
+    const depletionDate = demand
+      ? predictDepletionDateFromDemand(legacy.currentStock, demand)
+      : null;
+    if (!depletionDate) return legacy;
+
+    return {
+      ...legacy,
+      expectedDepletionDate: depletionDate,
+      status: classifyStatus(depletionDate, legacy.leadTimeDays, legacy.safetyBufferDays, today),
+      forecastSource: "menu_demand",
     };
   });
 }
@@ -93,6 +123,35 @@ export async function loadMenuBasedIngredientDemandForecast(
       };
     }),
   );
+}
+
+async function loadMenuBasedIngredientDemandForecastSafely(
+  client: RpcClient,
+  horizonDays: number,
+): Promise<IngredientDemandForecast[]> {
+  try {
+    return await loadMenuBasedIngredientDemandForecast(client, horizonDays);
+  } catch {
+    return [];
+  }
+}
+
+function predictDepletionDateFromDemand(
+  currentStock: number,
+  demand: IngredientDemandForecast,
+): Date | null {
+  let stock = currentStock;
+
+  for (const day of demand.dailyPredictions) {
+    stock -= Math.max(0, day.amount);
+    if (stock <= 0) return startOfDay(day.date);
+  }
+
+  return null;
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
 export interface ApplyInventoryReplayInput {

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -66,6 +66,7 @@ import {
 describe("application layer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    rpcMocks.getMenuDemandForecast.mockResolvedValue({ data: [], error: null });
   });
 
   describe("calendar", () => {
@@ -282,6 +283,7 @@ describe("application layer", () => {
           status: "caution",
           trend: "rising",
           isColdStart: false,
+          forecastSource: "consumption_history",
         },
       ]);
 
@@ -294,6 +296,58 @@ describe("application layer", () => {
         signupDate: new Date("2026-05-20T00:00:00.000Z"),
         today: expect.any(Date),
       });
+    });
+
+    it("loadDepletionForecast prefers menu-based ingredient demand when available", async () => {
+      rpcMocks.getDepletionForecast.mockResolvedValue({
+        data: [
+          {
+            ingredientId: "ice",
+            name: "얼음",
+            unit: "g",
+            currentStock: 100,
+            leadTimeDays: 1,
+            leadTimeVendorName: "얼음상회",
+            isDefaultLeadTime: false,
+            safetyBufferDays: 1,
+            consumptionSamples: [{ date: "2026-06-01", amount: 1 }],
+            signedUpAt: "2026-05-01T00:00:00.000Z",
+            regularDaysOff: [],
+          },
+        ],
+        error: null,
+      });
+      rpcMocks.getMenuDemandForecast.mockResolvedValue({
+        data: [
+          {
+            menuId: "menu-1",
+            name: "과일빙수",
+            price: 12000,
+            isActive: true,
+            baseRecipe: [{ ingredientId: "ice", quantityPerServing: 100 }],
+            optionGroups: [],
+            demandSamples: Array.from({ length: 30 }, (_, index) => ({
+              date: `2026-05-${String(index + 1).padStart(2, "0")}`,
+              quantity: 10,
+            })),
+            signedUpAt: "2026-04-01T00:00:00.000Z",
+            regularDaysOff: [],
+          },
+        ],
+        error: null,
+      });
+      forecastMocks.forecastIngredient.mockReturnValue({
+        expectedDepletionDate: null,
+        status: "safe",
+        trend: "normal",
+        isColdStart: false,
+      });
+
+      const [result] = await loadDepletionForecast({ rpc: {} });
+
+      expect(result?.forecastSource).toBe("menu_demand");
+      expect(result?.expectedDepletionDate).toBeInstanceOf(Date);
+      expect(result?.status).toBe("critical");
     });
 
     it("loadDepletionForecast falls back to safety buffer 1 when rpc field is missing", async () => {


### PR DESCRIPTION
## Summary
- use menu/option demand forecasts as the primary depletion forecast source when available
- keep consumption-history depletion forecasts as fallback when menu demand is unavailable or cannot predict depletion
- show the forecast source in the inventory status list

## Verification
- npm run lint
- npm run typecheck
- npm run format:check
- npx vitest run tests/unit/application.test.ts tests/unit/forecast.test.ts
- npm run test:coverage
- npm run build

## Notes
- no database migration in this PR
- existing menu demand RPC from #125 is required