### PR TITLE
Add menu demand forecast screen

### DIFF
--- a/src/app/(main)/inventory/menu-forecast/page.tsx
+++ b/src/app/(main)/inventory/menu-forecast/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { MenuDemandForecastList } from "@/features/inventory/components/MenuDemandForecastList";
+import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
+import { PageHeader } from "@/components/ui/page-header";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
+
+export default function MenuForecastPage(): React.ReactElement {
+  const query = useMenuDemandForecast();
+
+  return (
+    <section className="flex flex-col gap-section">
+      <PageHeader
+        title="메뉴 수요 예측"
+        action={
+          <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
+            재료 예측
+          </Link>
+        }
+      />
+
+      <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
+        <p className="text-body text-ink-1">앞으로 7일간 메뉴별 예상 판매량을 보여줍니다.</p>
+        <p className="mt-1 text-caption text-ink-3">
+          재료 소진 예측은 이 메뉴 수요와 옵션 선택률을 재료 레시피로 변환해서 계산합니다.
+        </p>
+      </section>
+
+      {query.isLoading && <LoadingText />}
+      {query.error && <ErrorAlert message={query.error.message} />}
+      {query.data && <MenuDemandForecastList items={query.data} />}
+    </section>
+  );
+}

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -22,6 +22,9 @@ export default function InventoryPage(): React.ReactElement {
         title="재료"
         action={
           <div className="flex gap-stack-tight">
+            <Link href="/inventory/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
+              메뉴 예측
+            </Link>
             <Link href="/inventory/stock-count" className={SECONDARY_BUTTON_CLASSES}>
               실사
             </Link>

--- a/src/features/inventory/components/MenuDemandForecastList.tsx
+++ b/src/features/inventory/components/MenuDemandForecastList.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatNumber, WEEKDAY_KO } from "@/lib/utils/format";
+import type { MenuDemandForecastView } from "../hooks/useMenuDemandForecast";
+
+interface MenuDemandForecastListProps {
+  items: readonly MenuDemandForecastView[];
+}
+
+const TREND_LABEL: Record<MenuDemandForecastView["trend"], string> = {
+  rising: "판매 증가",
+  falling: "판매 감소",
+  normal: "보통",
+};
+
+export function MenuDemandForecastList({ items }: MenuDemandForecastListProps): React.ReactElement {
+  if (items.length === 0) {
+    return (
+      <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
+        판매 이력이 있는 메뉴가 아직 없어요. 판매를 입력하면 메뉴별 예상 수요가 표시됩니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-stack">
+      {items.map((item) => (
+        <MenuDemandForecastCard key={item.menuId} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function MenuDemandForecastCard({ item }: { item: MenuDemandForecastView }): React.ReactElement {
+  const maxDailyQuantity = Math.max(
+    1,
+    ...item.dailyPredictions.map((day) => day.predictedQuantity),
+  );
+
+  return (
+    <article className="glow-panel rounded-[28px] border border-border bg-card px-tile py-stack shadow-card">
+      <div className="flex items-start justify-between gap-stack">
+        <div className="min-w-0">
+          <h2 className="break-words text-title-md text-ink-1">{item.name}</h2>
+          <p className="mt-1 text-caption text-ink-3">
+            7일 예상 {formatQuantity(item.sevenDayTotalQuantity)} · 내일{" "}
+            {formatQuantity(item.tomorrowQuantity)}
+          </p>
+        </div>
+        <TrendBadge trend={item.trend} isColdStart={item.isColdStart} />
+      </div>
+
+      <ol className="mt-stack grid grid-cols-7 gap-1.5">
+        {item.dailyPredictions.map((day) => (
+          <li key={day.date.toISOString()} className="flex min-w-0 flex-col items-center gap-1">
+            <span className="text-micro text-ink-4">{formatShortDate(day.date)}</span>
+            <div className="flex h-16 w-full items-end rounded-xl bg-blue-soft px-1">
+              <div
+                className="w-full rounded-lg bg-blue shadow-soft"
+                style={{
+                  height: `${Math.max(6, (day.predictedQuantity / maxDailyQuantity) * 100)}%`,
+                }}
+              />
+            </div>
+            <span className="text-micro text-ink-3 tabular-nums">
+              {formatQuantity(day.predictedQuantity)}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      {item.optionGroups.length > 0 && (
+        <div className="mt-stack flex flex-col gap-stack-tight border-t border-border pt-stack-tight">
+          <p className="text-caption font-semibold text-ink-2">옵션 선택률</p>
+          {item.optionGroups.map((group) => (
+            <OptionGroupSummary key={group.optionGroupId} group={group} />
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function OptionGroupSummary({
+  group,
+}: {
+  group: MenuDemandForecastView["optionGroups"][number];
+}): React.ReactElement {
+  const label = group.selectionType === "single" ? "택1" : "추가";
+  const visibleValues = group.values.slice(0, 4);
+
+  return (
+    <div className="rounded-2xl bg-bg px-3 py-3">
+      <div className="flex items-center justify-between gap-stack-tight">
+        <span className="text-caption text-ink-2">{group.name}</span>
+        <span className="rounded-full bg-white px-2 py-0.5 text-micro text-ink-3 shadow-soft">
+          {label}
+        </span>
+      </div>
+      <ul className="mt-2 flex flex-col gap-1.5">
+        {visibleValues.map((value) => (
+          <li key={value.optionValueId} className="flex items-center gap-2">
+            <span className="min-w-0 flex-1 truncate text-caption text-ink-3">
+              {value.name}
+              {value.isDefault ? " · 기본" : ""}
+            </span>
+            <div className="h-2 w-24 overflow-hidden rounded-full bg-white shadow-soft">
+              <div
+                className="h-full rounded-full bg-blue"
+                style={{ width: `${Math.min(100, Math.max(0, value.selectionRate * 100))}%` }}
+              />
+            </div>
+            <span className="w-11 text-right text-caption text-ink-2 tabular-nums">
+              {formatRate(value.selectionRate)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function TrendBadge({
+  trend,
+  isColdStart,
+}: {
+  trend: MenuDemandForecastView["trend"];
+  isColdStart: boolean;
+}): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full px-2.5 py-1 text-micro shadow-soft",
+        trend === "rising"
+          ? "bg-red-soft text-red-deep"
+          : trend === "falling"
+            ? "bg-blue-soft text-blue-deep"
+            : "bg-bg text-ink-3",
+      )}
+    >
+      {isColdStart ? "데이터 수집 중" : TREND_LABEL[trend]}
+    </span>
+  );
+}
+
+function formatQuantity(value: number): string {
+  return `${formatNumber(Number(value.toFixed(1)))}개`;
+}
+
+function formatRate(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatShortDate(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()} ${WEEKDAY_KO[date.getDay()]}`;
+}

--- a/src/features/inventory/hooks/useMenuDemandForecast.ts
+++ b/src/features/inventory/hooks/useMenuDemandForecast.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  loadMenuDemandForecastViews,
+  type MenuDemandForecastView,
+} from "@/lib/application/inventory";
+import { createClient } from "@/lib/supabase/client";
+
+export const menuDemandForecastQueryKey = ["inventory", "menu-demand-forecast"] as const;
+
+export type { MenuDemandForecastView } from "@/lib/application/inventory";
+
+async function fetchMenuDemandForecast(): Promise<MenuDemandForecastView[]> {
+  const supabase = createClient();
+  return loadMenuDemandForecastViews(supabase);
+}
+
+export function useMenuDemandForecast(): UseQueryResult<MenuDemandForecastView[]> {
+  return useQuery({
+    queryKey: menuDemandForecastQueryKey,
+    queryFn: fetchMenuDemandForecast,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -33,6 +33,31 @@ export interface IngredientForecastView extends ForecastResult {
   forecastSource: "menu_demand" | "consumption_history";
 }
 
+export interface MenuDemandForecastView {
+  menuId: string;
+  name: string;
+  price: number;
+  tomorrowQuantity: number;
+  sevenDayTotalQuantity: number;
+  trend: "rising" | "falling" | "normal";
+  isColdStart: boolean;
+  dailyPredictions: Array<{
+    date: Date;
+    predictedQuantity: number;
+  }>;
+  optionGroups: Array<{
+    optionGroupId: string;
+    name: string;
+    selectionType: "single" | "add_on";
+    values: Array<{
+      optionValueId: string;
+      name: string;
+      selectionRate: number;
+      isDefault: boolean;
+    }>;
+  }>;
+}
+
 export async function loadDepletionForecast(client: RpcClient): Promise<IngredientForecastView[]> {
   const { data, error } = await getDepletionForecast(client);
   if (error) throw new Error(error.message);
@@ -91,6 +116,62 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       forecastSource: "menu_demand",
     };
   });
+}
+
+export async function loadMenuDemandForecastViews(
+  client: RpcClient,
+  horizonDays: number = 7,
+): Promise<MenuDemandForecastView[]> {
+  const { data, error } = await getMenuDemandForecast(client);
+  if (error) throw new Error(error.message);
+
+  const today = new Date();
+  return (data ?? [])
+    .map((row) => {
+      const demandSamples: DailyMenuDemand[] = row.demandSamples.map((sample) => ({
+        date: new Date(sample.date),
+        quantity: Number(sample.quantity),
+      }));
+      const forecast = forecastMenuDemand({
+        demandSamples,
+        daysOff: row.regularDaysOff,
+        signupDate: new Date(row.signedUpAt),
+        today,
+        horizonDays,
+      });
+      const dailyPredictions = forecast.dailyPredictions.map((day) => ({
+        date: day.date,
+        predictedQuantity: day.predictedQuantity,
+      }));
+
+      return {
+        menuId: row.menuId,
+        name: row.name,
+        price: row.price,
+        tomorrowQuantity: dailyPredictions[0]?.predictedQuantity ?? 0,
+        sevenDayTotalQuantity: dailyPredictions.reduce(
+          (sum, day) => sum + day.predictedQuantity,
+          0,
+        ),
+        trend: forecast.trend,
+        isColdStart: forecast.isColdStart,
+        dailyPredictions,
+        optionGroups: row.optionGroups.map((group) => ({
+          optionGroupId: group.optionGroupId,
+          name: group.name,
+          selectionType: group.selectionType,
+          values: group.values
+            .map((value) => ({
+              optionValueId: value.optionValueId,
+              name: value.name,
+              selectionRate: value.selectionRate,
+              isDefault: value.isDefault,
+            }))
+            .sort((a, b) => b.selectionRate - a.selectionRate),
+        })),
+      };
+    })
+    .sort((a, b) => b.sevenDayTotalQuantity - a.sevenDayTotalQuantity);
 }
 
 export async function loadMenuBasedIngredientDemandForecast(

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -53,6 +53,7 @@ import { loadCalendarMonth, withConsecutiveMissingDays } from "@/lib/application
 import {
   applyInventoryReplay,
   loadDepletionForecast,
+  loadMenuDemandForecastViews,
   loadMenuBasedIngredientDemandForecast,
 } from "@/lib/application/inventory";
 import { submitPurchase } from "@/lib/application/purchase";
@@ -461,6 +462,61 @@ describe("application layer", () => {
         ?.amount;
       expect(ice).toBeGreaterThan(0);
       expect(condensed).toBeCloseTo((ice ?? 0) * 0.1);
+    });
+
+    it("loadMenuDemandForecastViews exposes menu demand totals and option rates", async () => {
+      rpcMocks.getMenuDemandForecast.mockResolvedValue({
+        data: [
+          {
+            menuId: "menu-1",
+            name: "과일빙수",
+            price: 12000,
+            isActive: true,
+            baseRecipe: [{ ingredientId: "ice", quantityPerServing: 100 }],
+            optionGroups: [
+              {
+                optionGroupId: "size",
+                name: "사이즈",
+                selectionType: "single",
+                isRequired: true,
+                values: [
+                  {
+                    optionValueId: "large",
+                    name: "라지",
+                    isDefault: false,
+                    selectionRate: 0.6,
+                    recipe: [],
+                  },
+                  {
+                    optionValueId: "regular",
+                    name: "레귤러",
+                    isDefault: true,
+                    selectionRate: 0.4,
+                    recipe: [],
+                  },
+                ],
+              },
+            ],
+            demandSamples: Array.from({ length: 30 }, (_, index) => ({
+              date: `2026-05-${String(index + 1).padStart(2, "0")}`,
+              quantity: 10,
+            })),
+            signedUpAt: "2026-04-01T00:00:00.000Z",
+            regularDaysOff: [],
+          },
+        ],
+        error: null,
+      });
+
+      const [result] = await loadMenuDemandForecastViews({ rpc: {} }, 7);
+
+      expect(result?.menuId).toBe("menu-1");
+      expect(result?.dailyPredictions).toHaveLength(7);
+      expect(result?.sevenDayTotalQuantity).toBeGreaterThan(0);
+      expect(result?.optionGroups[0]?.values.map((value) => value.optionValueId)).toEqual([
+        "large",
+        "regular",
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- add /inventory/menu-forecast for 7-day menu demand forecasts
- show tomorrow/7-day expected quantities, trend, daily bars, and option selection rates
- add an Inventory page entry point and application-layer view model test

## Verification
- npm run lint
- npm run typecheck
- npm run format:check
- npx vitest run tests/unit/application.test.ts tests/unit/forecast.test.ts
- npm run test:coverage
- npm run build

## Notes
- no database migration
- in-app browser session was unavailable locally, so route rendering was verified by Next build