### PR TITLE
Add menu forecast accuracy report

### DIFF
--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { MenuForecastAccuracyList } from "@/features/inventory/components/MenuForecastAccuracyList";
+import { useMenuForecastAccuracy } from "@/features/inventory/hooks/useMenuForecastAccuracy";
+import { PageHeader } from "@/components/ui/page-header";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
+
+export default function ForecastAccuracyPage(): React.ReactElement {
+  const query = useMenuForecastAccuracy();
+
+  return (
+    <section className="flex flex-col gap-section">
+      <PageHeader
+        title="예측 정확도"
+        action={
+          <Link href="/inventory/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
+            메뉴 예측
+          </Link>
+        }
+      />
+
+      <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
+        <p className="text-body text-ink-1">
+          최근 14일 기준으로 메뉴 예측과 실제 판매량을 비교합니다.
+        </p>
+        <p className="mt-1 text-caption text-ink-3">
+          각 날짜의 예측은 그 전날까지의 판매 이력만 사용해 다시 계산합니다.
+        </p>
+      </section>
+
+      {query.isLoading && <LoadingText />}
+      {query.error && <ErrorAlert message={query.error.message} />}
+      {query.data && <MenuForecastAccuracyList items={query.data} />}
+    </section>
+  );
+}

--- a/src/app/(main)/inventory/menu-forecast/page.tsx
+++ b/src/app/(main)/inventory/menu-forecast/page.tsx
@@ -15,9 +15,14 @@ export default function MenuForecastPage(): React.ReactElement {
       <PageHeader
         title="메뉴 수요 예측"
         action={
-          <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
-            재료 예측
-          </Link>
+          <div className="flex gap-stack-tight">
+            <Link href="/inventory/forecast-accuracy" className={SECONDARY_BUTTON_CLASSES}>
+              정확도
+            </Link>
+            <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
+              재료 예측
+            </Link>
+          </div>
         }
       />
 

--- a/src/features/inventory/components/MenuForecastAccuracyList.tsx
+++ b/src/features/inventory/components/MenuForecastAccuracyList.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatNumber, WEEKDAY_KO } from "@/lib/utils/format";
+import type { MenuForecastAccuracyView } from "../hooks/useMenuForecastAccuracy";
+
+interface MenuForecastAccuracyListProps {
+  items: readonly MenuForecastAccuracyView[];
+}
+
+const BIAS_LABEL: Record<MenuForecastAccuracyView["bias"], string> = {
+  over: "과대예측",
+  under: "과소예측",
+  balanced: "균형",
+  insufficient_data: "데이터 부족",
+};
+
+export function MenuForecastAccuracyList({
+  items,
+}: MenuForecastAccuracyListProps): React.ReactElement {
+  if (items.length === 0) {
+    return (
+      <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
+        아직 비교할 판매 이력이 없어요. 판매 데이터가 쌓이면 예측 정확도를 확인할 수 있습니다.
+      </p>
+    );
+  }
+
+  const summary = buildSummary(items);
+
+  return (
+    <div className="flex flex-col gap-section">
+      <section className="grid grid-cols-3 gap-stack-tight">
+        <SummaryTile label="평균 오차율" value={formatPercent(summary.meanMape)} />
+        <SummaryTile label="과대예측" value={`${summary.overCount}개`} />
+        <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
+      </section>
+
+      <div className="flex flex-col gap-stack">
+        {items.map((item) => (
+          <MenuForecastAccuracyCard key={item.menuId} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SummaryTile({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="rounded-2xl border border-border bg-card px-3 py-3 text-center shadow-soft">
+      <p className="text-micro text-ink-4">{label}</p>
+      <p className="mt-1 text-title-md text-ink-1">{value}</p>
+    </div>
+  );
+}
+
+function MenuForecastAccuracyCard({
+  item,
+}: {
+  item: MenuForecastAccuracyView;
+}): React.ReactElement {
+  const maxQuantity = Math.max(
+    1,
+    ...item.dailyResults.flatMap((day) => [day.actualQuantity, day.predictedQuantity]),
+  );
+
+  return (
+    <article className="glow-panel rounded-[28px] border border-border bg-card px-tile py-stack shadow-card">
+      <div className="flex items-start justify-between gap-stack">
+        <div className="min-w-0">
+          <h2 className="break-words text-title-md text-ink-1">{item.name}</h2>
+          <p className="mt-1 text-caption text-ink-3">
+            실제 {formatQuantity(item.actualTotalQuantity)} · 예측{" "}
+            {formatQuantity(item.predictedTotalQuantity)}
+          </p>
+        </div>
+        <BiasBadge bias={item.bias} />
+      </div>
+
+      <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
+        <Metric label="오차율" value={formatPercent(item.meanAbsolutePercentageError)} />
+        <Metric label="평균 오차" value={formatNullableQuantity(item.averageAbsoluteError)} />
+        <Metric label="비교일" value={`${item.evaluatedDayCount}일`} />
+      </dl>
+
+      <ol className="mt-stack grid grid-cols-7 gap-1.5">
+        {item.dailyResults.slice(-7).map((day) => (
+          <li key={day.date.toISOString()} className="flex min-w-0 flex-col items-center gap-1">
+            <span className="text-micro text-ink-4">{formatShortDate(day.date)}</span>
+            <div className="flex h-16 w-full items-end justify-center gap-0.5 rounded-xl bg-bg px-1">
+              <div
+                title="실제"
+                className="w-1/2 rounded-lg bg-blue shadow-soft"
+                style={{ height: `${barHeight(day.actualQuantity, maxQuantity)}%` }}
+              />
+              <div
+                title="예측"
+                className="w-1/2 rounded-lg bg-amber shadow-soft"
+                style={{ height: `${barHeight(day.predictedQuantity, maxQuantity)}%` }}
+              />
+            </div>
+            <span className="text-micro text-ink-3 tabular-nums">
+              {formatQuantity(day.actualQuantity)}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="mt-stack flex items-center gap-3 text-micro text-ink-3">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-blue" />
+          실제
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-amber" />
+          예측
+        </span>
+      </div>
+    </article>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="rounded-2xl bg-bg px-3 py-3">
+      <dt className="text-micro text-ink-4">{label}</dt>
+      <dd className="mt-1 text-body text-ink-1">{value}</dd>
+    </div>
+  );
+}
+
+function BiasBadge({ bias }: { bias: MenuForecastAccuracyView["bias"] }): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full px-2.5 py-1 text-micro shadow-soft",
+        bias === "over"
+          ? "bg-red-soft text-red-deep"
+          : bias === "under"
+            ? "bg-amber-soft text-amber-deep"
+            : bias === "balanced"
+              ? "bg-blue-soft text-blue-deep"
+              : "bg-bg text-ink-3",
+      )}
+    >
+      {BIAS_LABEL[bias]}
+    </span>
+  );
+}
+
+function buildSummary(items: readonly MenuForecastAccuracyView[]): {
+  meanMape: number | null;
+  overCount: number;
+  underCount: number;
+} {
+  const valid = items.filter((item) => item.meanAbsolutePercentageError !== null);
+  return {
+    meanMape:
+      valid.length > 0
+        ? valid.reduce((sum, item) => sum + (item.meanAbsolutePercentageError ?? 0), 0) /
+          valid.length
+        : null,
+    overCount: items.filter((item) => item.bias === "over").length,
+    underCount: items.filter((item) => item.bias === "under").length,
+  };
+}
+
+function barHeight(value: number, maxQuantity: number): number {
+  if (value <= 0) return 4;
+  return Math.max(6, (value / maxQuantity) * 100);
+}
+
+function formatQuantity(value: number): string {
+  return `${formatNumber(Number(value.toFixed(1)))}개`;
+}
+
+function formatNullableQuantity(value: number | null): string {
+  return value === null ? "-" : formatQuantity(value);
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? "-" : `${Math.round(value * 100)}%`;
+}
+
+function formatShortDate(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()} ${WEEKDAY_KO[date.getDay()]}`;
+}

--- a/src/features/inventory/hooks/useMenuForecastAccuracy.ts
+++ b/src/features/inventory/hooks/useMenuForecastAccuracy.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  loadMenuForecastAccuracyViews,
+  type MenuForecastAccuracyView,
+} from "@/lib/application/inventory";
+import { createClient } from "@/lib/supabase/client";
+
+export const menuForecastAccuracyQueryKey = ["inventory", "menu-forecast-accuracy"] as const;
+
+export type { MenuForecastAccuracyView } from "@/lib/application/inventory";
+
+async function fetchMenuForecastAccuracy(): Promise<MenuForecastAccuracyView[]> {
+  const supabase = createClient();
+  return loadMenuForecastAccuracyViews(supabase);
+}
+
+export function useMenuForecastAccuracy(): UseQueryResult<MenuForecastAccuracyView[]> {
+  return useQuery({
+    queryKey: menuForecastAccuracyQueryKey,
+    queryFn: fetchMenuForecastAccuracy,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -20,6 +20,7 @@ interface RpcClient {
 }
 
 const MENU_DEMAND_DEPLETION_HORIZON_DAYS = 365;
+const MENU_FORECAST_BACKTEST_DAYS = 14;
 
 export interface IngredientForecastView extends ForecastResult {
   ingredientId: string;
@@ -55,6 +56,24 @@ export interface MenuDemandForecastView {
       selectionRate: number;
       isDefault: boolean;
     }>;
+  }>;
+}
+
+export interface MenuForecastAccuracyView {
+  menuId: string;
+  name: string;
+  averageAbsoluteError: number | null;
+  meanAbsolutePercentageError: number | null;
+  bias: "over" | "under" | "balanced" | "insufficient_data";
+  evaluatedDayCount: number;
+  actualTotalQuantity: number;
+  predictedTotalQuantity: number;
+  dailyResults: Array<{
+    date: Date;
+    actualQuantity: number;
+    predictedQuantity: number;
+    absoluteError: number;
+    absolutePercentageError: number | null;
   }>;
 }
 
@@ -174,6 +193,86 @@ export async function loadMenuDemandForecastViews(
     .sort((a, b) => b.sevenDayTotalQuantity - a.sevenDayTotalQuantity);
 }
 
+export async function loadMenuForecastAccuracyViews(
+  client: RpcClient,
+  backtestDays: number = MENU_FORECAST_BACKTEST_DAYS,
+): Promise<MenuForecastAccuracyView[]> {
+  const { data, error } = await getMenuDemandForecast(client);
+  if (error) throw new Error(error.message);
+
+  return (data ?? [])
+    .map((row) => {
+      const samples = row.demandSamples
+        .map((sample) => ({
+          date: startOfDay(new Date(sample.date)),
+          quantity: Number(sample.quantity),
+        }))
+        .sort((a, b) => a.date.getTime() - b.date.getTime());
+      const sampleByDate = new Map(samples.map((sample) => [dateKey(sample.date), sample]));
+      const latestSampleDate = samples.at(-1)?.date ?? startOfDay(new Date());
+      const targetDates = Array.from({ length: backtestDays }, (_, index) =>
+        addDays(latestSampleDate, index - backtestDays + 1),
+      );
+
+      const dailyResults = targetDates.map((targetDate) => {
+        const trainUntil = addDays(targetDate, -1);
+        const trainingSamples: DailyMenuDemand[] = samples
+          .filter((sample) => sample.date.getTime() <= trainUntil.getTime())
+          .map((sample) => ({ date: sample.date, quantity: sample.quantity }));
+        const forecast = forecastMenuDemand({
+          demandSamples: trainingSamples,
+          daysOff: row.regularDaysOff,
+          signupDate: new Date(row.signedUpAt),
+          today: trainUntil,
+          horizonDays: 1,
+        });
+        const actualQuantity = sampleByDate.get(dateKey(targetDate))?.quantity ?? 0;
+        const predictedQuantity = forecast.dailyPredictions[0]?.predictedQuantity ?? 0;
+        const absoluteError = Math.abs(predictedQuantity - actualQuantity);
+
+        return {
+          date: targetDate,
+          actualQuantity,
+          predictedQuantity,
+          absoluteError,
+          absolutePercentageError:
+            actualQuantity > 0 ? absoluteError / Math.max(1, actualQuantity) : null,
+        };
+      });
+
+      const evaluated = dailyResults.filter((result) => result.actualQuantity > 0);
+      const actualTotalQuantity = sumBy(dailyResults, (result) => result.actualQuantity);
+      const predictedTotalQuantity = sumBy(dailyResults, (result) => result.predictedQuantity);
+      const averageAbsoluteError =
+        evaluated.length > 0
+          ? sumBy(evaluated, (result) => result.absoluteError) / evaluated.length
+          : null;
+      const meanAbsolutePercentageError =
+        evaluated.length > 0
+          ? sumBy(evaluated, (result) => result.absolutePercentageError ?? 0) / evaluated.length
+          : null;
+
+      return {
+        menuId: row.menuId,
+        name: row.name,
+        averageAbsoluteError,
+        meanAbsolutePercentageError,
+        bias: classifyForecastBias(actualTotalQuantity, predictedTotalQuantity, evaluated.length),
+        evaluatedDayCount: evaluated.length,
+        actualTotalQuantity,
+        predictedTotalQuantity,
+        dailyResults,
+      };
+    })
+    .sort((a, b) => {
+      if (a.meanAbsolutePercentageError === null) return 1;
+      if (b.meanAbsolutePercentageError === null) return -1;
+      const aError = a.meanAbsolutePercentageError;
+      const bError = b.meanAbsolutePercentageError;
+      return bError - aError;
+    });
+}
+
 export async function loadMenuBasedIngredientDemandForecast(
   client: RpcClient,
   horizonDays: number = 7,
@@ -233,6 +332,35 @@ function predictDepletionDateFromDemand(
 
 function startOfDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return startOfDay(next);
+}
+
+function dateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+    date.getDate(),
+  ).padStart(2, "0")}`;
+}
+
+function sumBy<T>(items: readonly T[], selector: (item: T) => number): number {
+  return items.reduce((sum, item) => sum + selector(item), 0);
+}
+
+function classifyForecastBias(
+  actualTotalQuantity: number,
+  predictedTotalQuantity: number,
+  evaluatedDayCount: number,
+): MenuForecastAccuracyView["bias"] {
+  if (evaluatedDayCount === 0 || actualTotalQuantity === 0) return "insufficient_data";
+
+  const ratio = predictedTotalQuantity / actualTotalQuantity;
+  if (ratio >= 1.15) return "over";
+  if (ratio <= 0.85) return "under";
+  return "balanced";
 }
 
 export interface ApplyInventoryReplayInput {

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -53,6 +53,7 @@ import { loadCalendarMonth, withConsecutiveMissingDays } from "@/lib/application
 import {
   applyInventoryReplay,
   loadDepletionForecast,
+  loadMenuForecastAccuracyViews,
   loadMenuDemandForecastViews,
   loadMenuBasedIngredientDemandForecast,
 } from "@/lib/application/inventory";
@@ -517,6 +518,38 @@ describe("application layer", () => {
         "large",
         "regular",
       ]);
+    });
+
+    it("loadMenuForecastAccuracyViews backtests predicted demand against actual sales", async () => {
+      rpcMocks.getMenuDemandForecast.mockResolvedValue({
+        data: [
+          {
+            menuId: "menu-1",
+            name: "과일빙수",
+            price: 12000,
+            isActive: true,
+            baseRecipe: [],
+            optionGroups: [],
+            demandSamples: Array.from({ length: 30 }, (_, index) => ({
+              date: `2026-05-${String(index + 1).padStart(2, "0")}`,
+              quantity: 10,
+            })),
+            signedUpAt: "2026-04-01T00:00:00.000Z",
+            regularDaysOff: [],
+          },
+        ],
+        error: null,
+      });
+
+      const [result] = await loadMenuForecastAccuracyViews({ rpc: {} }, 7);
+
+      expect(result?.menuId).toBe("menu-1");
+      expect(result?.dailyResults).toHaveLength(7);
+      expect(result?.evaluatedDayCount).toBe(7);
+      expect(result?.actualTotalQuantity).toBe(70);
+      expect(result?.predictedTotalQuantity).toBeGreaterThan(0);
+      expect(result?.meanAbsolutePercentageError).not.toBeNull();
+      expect(result?.bias).not.toBe("insufficient_data");
     });
   });
 


### PR DESCRIPTION
## Summary
- add /inventory/forecast-accuracy for menu demand forecast backtesting
- compare predicted vs actual menu quantities over the recent 14-day sample window
- show MAPE, average absolute error, over/under/balanced bias, and actual-vs-predicted bars
- link the report from the menu forecast page

## Verification
- npm run lint
- npm run typecheck
- npm run format:check
- npx vitest run tests/unit/application.test.ts tests/unit/forecast.test.ts
- npm run test:coverage
- npm run build

## Notes
- no database migration
- this PR covers menu forecast accuracy first; ingredient-level backtest can build on top of this