### PR TITLE
Add ingredient forecast accuracy report

### DIFF
--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import Link from "next/link";
+import { IngredientForecastAccuracyList } from "@/features/inventory/components/IngredientForecastAccuracyList";
 import { MenuForecastAccuracyList } from "@/features/inventory/components/MenuForecastAccuracyList";
+import { useIngredientForecastAccuracy } from "@/features/inventory/hooks/useIngredientForecastAccuracy";
 import { useMenuForecastAccuracy } from "@/features/inventory/hooks/useMenuForecastAccuracy";
 import { PageHeader } from "@/components/ui/page-header";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 
 export default function ForecastAccuracyPage(): React.ReactElement {
-  const query = useMenuForecastAccuracy();
+  const menuQuery = useMenuForecastAccuracy();
+  const ingredientQuery = useIngredientForecastAccuracy();
 
   return (
     <section className="flex flex-col gap-section">
@@ -23,16 +26,39 @@ export default function ForecastAccuracyPage(): React.ReactElement {
 
       <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
         <p className="text-body text-ink-1">
-          최근 14일 기준으로 메뉴 예측과 실제 판매량을 비교합니다.
+          최근 14일 기준으로 메뉴·재료 예측과 실제 판매/소비량을 비교합니다.
         </p>
         <p className="mt-1 text-caption text-ink-3">
           각 날짜의 예측은 그 전날까지의 판매 이력만 사용해 다시 계산합니다.
         </p>
       </section>
 
-      {query.isLoading && <LoadingText />}
-      {query.error && <ErrorAlert message={query.error.message} />}
-      {query.data && <MenuForecastAccuracyList items={query.data} />}
+      <AccuracySection title="재료 예측 정확도">
+        {ingredientQuery.isLoading && <LoadingText />}
+        {ingredientQuery.error && <ErrorAlert message={ingredientQuery.error.message} />}
+        {ingredientQuery.data && <IngredientForecastAccuracyList items={ingredientQuery.data} />}
+      </AccuracySection>
+
+      <AccuracySection title="메뉴 예측 정확도">
+        {menuQuery.isLoading && <LoadingText />}
+        {menuQuery.error && <ErrorAlert message={menuQuery.error.message} />}
+        {menuQuery.data && <MenuForecastAccuracyList items={menuQuery.data} />}
+      </AccuracySection>
+    </section>
+  );
+}
+
+function AccuracySection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <section className="flex flex-col gap-stack-tight">
+      <h2 className="text-title-md text-ink-1">{title}</h2>
+      {children}
     </section>
   );
 }

--- a/src/features/inventory/components/IngredientForecastAccuracyList.tsx
+++ b/src/features/inventory/components/IngredientForecastAccuracyList.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatNumber, WEEKDAY_KO } from "@/lib/utils/format";
+import type { IngredientForecastAccuracyView } from "../hooks/useIngredientForecastAccuracy";
+
+interface IngredientForecastAccuracyListProps {
+  items: readonly IngredientForecastAccuracyView[];
+}
+
+const BIAS_LABEL: Record<IngredientForecastAccuracyView["bias"], string> = {
+  over: "과대예측",
+  under: "과소예측",
+  balanced: "균형",
+  insufficient_data: "데이터 부족",
+};
+
+export function IngredientForecastAccuracyList({
+  items,
+}: IngredientForecastAccuracyListProps): React.ReactElement {
+  if (items.length === 0) {
+    return (
+      <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
+        아직 비교할 재료 사용 이력이 없어요. 판매 데이터가 쌓이면 재료 예측 정확도를 확인할 수
+        있습니다.
+      </p>
+    );
+  }
+
+  const summary = buildSummary(items);
+
+  return (
+    <div className="flex flex-col gap-section">
+      <section className="grid grid-cols-3 gap-stack-tight">
+        <SummaryTile label="평균 오차율" value={formatPercent(summary.meanMape)} />
+        <SummaryTile label="과대예측" value={`${summary.overCount}개`} />
+        <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
+      </section>
+
+      <div className="flex flex-col gap-stack">
+        {items.map((item) => (
+          <IngredientForecastAccuracyCard key={item.ingredientId} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SummaryTile({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="rounded-2xl border border-border bg-card px-3 py-3 text-center shadow-soft">
+      <p className="text-micro text-ink-4">{label}</p>
+      <p className="mt-1 text-title-md text-ink-1">{value}</p>
+    </div>
+  );
+}
+
+function IngredientForecastAccuracyCard({
+  item,
+}: {
+  item: IngredientForecastAccuracyView;
+}): React.ReactElement {
+  const maxAmount = Math.max(
+    1,
+    ...item.dailyResults.flatMap((day) => [day.actualAmount, day.predictedAmount]),
+  );
+
+  return (
+    <article className="glow-panel rounded-[28px] border border-border bg-card px-tile py-stack shadow-card">
+      <div className="flex items-start justify-between gap-stack">
+        <div className="min-w-0">
+          <h2 className="break-words text-title-md text-ink-1">{item.name}</h2>
+          <p className="mt-1 text-caption text-ink-3">
+            실제 {formatAmount(item.actualTotalAmount, item.unit)} · 예측{" "}
+            {formatAmount(item.predictedTotalAmount, item.unit)}
+          </p>
+        </div>
+        <BiasBadge bias={item.bias} />
+      </div>
+
+      <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
+        <Metric label="오차율" value={formatPercent(item.meanAbsolutePercentageError)} />
+        <Metric
+          label="평균 오차"
+          value={formatNullableAmount(item.averageAbsoluteError, item.unit)}
+        />
+        <Metric label="비교일" value={`${item.evaluatedDayCount}일`} />
+      </dl>
+
+      <ol className="mt-stack grid grid-cols-7 gap-1.5">
+        {item.dailyResults.slice(-7).map((day) => (
+          <li key={day.date.toISOString()} className="flex min-w-0 flex-col items-center gap-1">
+            <span className="text-micro text-ink-4">{formatShortDate(day.date)}</span>
+            <div className="flex h-16 w-full items-end justify-center gap-0.5 rounded-xl bg-bg px-1">
+              <div
+                title="실제"
+                className="w-1/2 rounded-lg bg-blue shadow-soft"
+                style={{ height: `${barHeight(day.actualAmount, maxAmount)}%` }}
+              />
+              <div
+                title="예측"
+                className="w-1/2 rounded-lg bg-amber shadow-soft"
+                style={{ height: `${barHeight(day.predictedAmount, maxAmount)}%` }}
+              />
+            </div>
+            <span className="text-micro text-ink-3 tabular-nums">
+              {formatAmount(day.actualAmount, item.unit)}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="mt-stack flex items-center gap-3 text-micro text-ink-3">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-blue" />
+          실제
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-amber" />
+          예측
+        </span>
+      </div>
+    </article>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="rounded-2xl bg-bg px-3 py-3">
+      <dt className="text-micro text-ink-4">{label}</dt>
+      <dd className="mt-1 text-body text-ink-1">{value}</dd>
+    </div>
+  );
+}
+
+function BiasBadge({ bias }: { bias: IngredientForecastAccuracyView["bias"] }): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full px-2.5 py-1 text-micro shadow-soft",
+        bias === "over"
+          ? "bg-red-soft text-red-deep"
+          : bias === "under"
+            ? "bg-amber-soft text-amber-deep"
+            : bias === "balanced"
+              ? "bg-blue-soft text-blue-deep"
+              : "bg-bg text-ink-3",
+      )}
+    >
+      {BIAS_LABEL[bias]}
+    </span>
+  );
+}
+
+function buildSummary(items: readonly IngredientForecastAccuracyView[]): {
+  meanMape: number | null;
+  overCount: number;
+  underCount: number;
+} {
+  const valid = items.filter((item) => item.meanAbsolutePercentageError !== null);
+  return {
+    meanMape:
+      valid.length > 0
+        ? valid.reduce((sum, item) => sum + (item.meanAbsolutePercentageError ?? 0), 0) /
+          valid.length
+        : null,
+    overCount: items.filter((item) => item.bias === "over").length,
+    underCount: items.filter((item) => item.bias === "under").length,
+  };
+}
+
+function barHeight(value: number, maxAmount: number): number {
+  if (value <= 0) return 4;
+  return Math.max(6, (value / maxAmount) * 100);
+}
+
+function formatAmount(value: number, unit: IngredientForecastAccuracyView["unit"]): string {
+  return `${formatNumber(Number(value.toFixed(1)))}${unit}`;
+}
+
+function formatNullableAmount(
+  value: number | null,
+  unit: IngredientForecastAccuracyView["unit"],
+): string {
+  return value === null ? "-" : formatAmount(value, unit);
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? "-" : `${Math.round(value * 100)}%`;
+}
+
+function formatShortDate(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()} ${WEEKDAY_KO[date.getDay()]}`;
+}

--- a/src/features/inventory/hooks/useIngredientForecastAccuracy.ts
+++ b/src/features/inventory/hooks/useIngredientForecastAccuracy.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  loadIngredientForecastAccuracyViews,
+  type IngredientForecastAccuracyView,
+} from "@/lib/application/inventory";
+import { createClient } from "@/lib/supabase/client";
+
+export const ingredientForecastAccuracyQueryKey = [
+  "inventory",
+  "ingredient-forecast-accuracy",
+] as const;
+
+export type { IngredientForecastAccuracyView } from "@/lib/application/inventory";
+
+async function fetchIngredientForecastAccuracy(): Promise<IngredientForecastAccuracyView[]> {
+  const supabase = createClient();
+  return loadIngredientForecastAccuracyViews(supabase);
+}
+
+export function useIngredientForecastAccuracy(): UseQueryResult<IngredientForecastAccuracyView[]> {
+  return useQuery({
+    queryKey: ingredientForecastAccuracyQueryKey,
+    queryFn: fetchIngredientForecastAccuracy,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -77,6 +77,25 @@ export interface MenuForecastAccuracyView {
   }>;
 }
 
+export interface IngredientForecastAccuracyView {
+  ingredientId: string;
+  name: string;
+  unit: "g" | "ml" | "piece";
+  averageAbsoluteError: number | null;
+  meanAbsolutePercentageError: number | null;
+  bias: "over" | "under" | "balanced" | "insufficient_data";
+  evaluatedDayCount: number;
+  actualTotalAmount: number;
+  predictedTotalAmount: number;
+  dailyResults: Array<{
+    date: Date;
+    actualAmount: number;
+    predictedAmount: number;
+    absoluteError: number;
+    absolutePercentageError: number | null;
+  }>;
+}
+
 export async function loadDepletionForecast(client: RpcClient): Promise<IngredientForecastView[]> {
   const { data, error } = await getDepletionForecast(client);
   if (error) throw new Error(error.message);
@@ -270,6 +289,127 @@ export async function loadMenuForecastAccuracyViews(
       const aError = a.meanAbsolutePercentageError;
       const bError = b.meanAbsolutePercentageError;
       return bError - aError;
+    });
+}
+
+export async function loadIngredientForecastAccuracyViews(
+  client: RpcClient,
+  backtestDays: number = MENU_FORECAST_BACKTEST_DAYS,
+): Promise<IngredientForecastAccuracyView[]> {
+  const [menuResult, ingredientResult] = await Promise.all([
+    getMenuDemandForecast(client),
+    getDepletionForecast(client),
+  ]);
+  if (menuResult.error) throw new Error(menuResult.error.message);
+  if (ingredientResult.error) throw new Error(ingredientResult.error.message);
+
+  const menus = menuResult.data ?? [];
+  const ingredients = ingredientResult.data ?? [];
+  const actualByIngredient = new Map(
+    ingredients.map((row) => [
+      row.ingredientId,
+      new Map(
+        row.consumptionSamples.map((sample) => [
+          dateKey(startOfDay(new Date(sample.date))),
+          Number(sample.amount),
+        ]),
+      ),
+    ]),
+  );
+  const latestActualDate =
+    ingredients
+      .flatMap((row) => row.consumptionSamples.map((sample) => startOfDay(new Date(sample.date))))
+      .sort((a, b) => a.getTime() - b.getTime())
+      .at(-1) ?? startOfDay(new Date());
+  const targetDates = Array.from({ length: backtestDays }, (_, index) =>
+    addDays(latestActualDate, index - backtestDays + 1),
+  );
+
+  const predictedByIngredient = new Map<string, Map<string, number>>();
+  for (const targetDate of targetDates) {
+    const trainUntil = addDays(targetDate, -1);
+    const predicted = forecastIngredientDemandFromMenus(
+      menus.map((row) => {
+        const demandSamples: DailyMenuDemand[] = row.demandSamples
+          .map((sample) => ({
+            date: startOfDay(new Date(sample.date)),
+            quantity: Number(sample.quantity),
+          }))
+          .filter((sample) => sample.date.getTime() <= trainUntil.getTime());
+
+        return {
+          menuId: row.menuId,
+          name: row.name,
+          baseRecipe: row.baseRecipe,
+          optionGroups: row.optionGroups,
+          demandForecast: forecastMenuDemand({
+            demandSamples,
+            daysOff: row.regularDaysOff,
+            signupDate: new Date(row.signedUpAt),
+            today: trainUntil,
+            horizonDays: 1,
+          }),
+        };
+      }),
+    );
+
+    for (const ingredient of predicted) {
+      const amount = ingredient.dailyPredictions[0]?.amount ?? 0;
+      const daily = predictedByIngredient.get(ingredient.ingredientId) ?? new Map<string, number>();
+      daily.set(dateKey(targetDate), amount);
+      predictedByIngredient.set(ingredient.ingredientId, daily);
+    }
+  }
+
+  return ingredients
+    .map((ingredient) => {
+      const actualDaily =
+        actualByIngredient.get(ingredient.ingredientId) ?? new Map<string, number>();
+      const predictedDaily =
+        predictedByIngredient.get(ingredient.ingredientId) ?? new Map<string, number>();
+      const dailyResults = targetDates.map((date) => {
+        const key = dateKey(date);
+        const actualAmount = actualDaily.get(key) ?? 0;
+        const predictedAmount = predictedDaily.get(key) ?? 0;
+        const absoluteError = Math.abs(predictedAmount - actualAmount);
+        return {
+          date,
+          actualAmount,
+          predictedAmount,
+          absoluteError,
+          absolutePercentageError:
+            actualAmount > 0 ? absoluteError / Math.max(1, actualAmount) : null,
+        };
+      });
+      const evaluated = dailyResults.filter((result) => result.actualAmount > 0);
+      const actualTotalAmount = sumBy(dailyResults, (result) => result.actualAmount);
+      const predictedTotalAmount = sumBy(dailyResults, (result) => result.predictedAmount);
+      const averageAbsoluteError =
+        evaluated.length > 0
+          ? sumBy(evaluated, (result) => result.absoluteError) / evaluated.length
+          : null;
+      const meanAbsolutePercentageError =
+        evaluated.length > 0
+          ? sumBy(evaluated, (result) => result.absolutePercentageError ?? 0) / evaluated.length
+          : null;
+
+      return {
+        ingredientId: ingredient.ingredientId,
+        name: ingredient.name,
+        unit: ingredient.unit,
+        averageAbsoluteError,
+        meanAbsolutePercentageError,
+        bias: classifyForecastBias(actualTotalAmount, predictedTotalAmount, evaluated.length),
+        evaluatedDayCount: evaluated.length,
+        actualTotalAmount,
+        predictedTotalAmount,
+        dailyResults,
+      };
+    })
+    .sort((a, b) => {
+      if (a.meanAbsolutePercentageError === null) return 1;
+      if (b.meanAbsolutePercentageError === null) return -1;
+      return b.meanAbsolutePercentageError - a.meanAbsolutePercentageError;
     });
 }
 

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -53,6 +53,7 @@ import { loadCalendarMonth, withConsecutiveMissingDays } from "@/lib/application
 import {
   applyInventoryReplay,
   loadDepletionForecast,
+  loadIngredientForecastAccuracyViews,
   loadMenuForecastAccuracyViews,
   loadMenuDemandForecastViews,
   loadMenuBasedIngredientDemandForecast,
@@ -548,6 +549,59 @@ describe("application layer", () => {
       expect(result?.evaluatedDayCount).toBe(7);
       expect(result?.actualTotalQuantity).toBe(70);
       expect(result?.predictedTotalQuantity).toBeGreaterThan(0);
+      expect(result?.meanAbsolutePercentageError).not.toBeNull();
+      expect(result?.bias).not.toBe("insufficient_data");
+    });
+
+    it("loadIngredientForecastAccuracyViews compares ingredient demand forecast with actual consumption", async () => {
+      rpcMocks.getMenuDemandForecast.mockResolvedValue({
+        data: [
+          {
+            menuId: "menu-1",
+            name: "과일빙수",
+            price: 12000,
+            isActive: true,
+            baseRecipe: [{ ingredientId: "ice", quantityPerServing: 100 }],
+            optionGroups: [],
+            demandSamples: Array.from({ length: 30 }, (_, index) => ({
+              date: `2026-05-${String(index + 1).padStart(2, "0")}`,
+              quantity: 10,
+            })),
+            signedUpAt: "2026-04-01T00:00:00.000Z",
+            regularDaysOff: [],
+          },
+        ],
+        error: null,
+      });
+      rpcMocks.getDepletionForecast.mockResolvedValue({
+        data: [
+          {
+            ingredientId: "ice",
+            name: "얼음",
+            unit: "g",
+            currentStock: 10000,
+            leadTimeDays: 1,
+            leadTimeVendorName: null,
+            isDefaultLeadTime: true,
+            safetyBufferDays: 1,
+            consumptionSamples: Array.from({ length: 30 }, (_, index) => ({
+              date: `2026-05-${String(index + 1).padStart(2, "0")}`,
+              amount: 1000,
+            })),
+            signedUpAt: "2026-04-01T00:00:00.000Z",
+            regularDaysOff: [],
+          },
+        ],
+        error: null,
+      });
+
+      const [result] = await loadIngredientForecastAccuracyViews({ rpc: {} }, 7);
+
+      expect(result?.ingredientId).toBe("ice");
+      expect(result?.dailyResults).toHaveLength(7);
+      expect(result?.evaluatedDayCount).toBe(7);
+      expect(result?.actualTotalAmount).toBe(7000);
+      expect(result?.predictedTotalAmount).toBeGreaterThan(0);
       expect(result?.meanAbsolutePercentageError).not.toBeNull();
       expect(result?.bias).not.toBe("insufficient_data");
     });


### PR DESCRIPTION
## Summary
- extend /inventory/forecast-accuracy with ingredient-level forecast backtesting
- compare menu-derived predicted ingredient demand with actual ingredient consumption samples
- show ingredient MAPE, average absolute error, over/under/balanced bias, and actual-vs-predicted bars

## Verification
- npm run lint
- npm run typecheck
- npm run format:check
- npx vitest run tests/unit/application.test.ts tests/unit/forecast.test.ts
- npm run test:coverage
- npm run build

## Notes
- stacked on #128 / codex-menu-forecast-accuracy
- no database migration