### PR TITLE
Add forecast period controls

### DIFF
--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { Suspense } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { ForecastPeriodSelector } from "@/features/inventory/components/ForecastPeriodSelector";
 import { IngredientForecastAccuracyList } from "@/features/inventory/components/IngredientForecastAccuracyList";
 import { MenuForecastAccuracyList } from "@/features/inventory/components/MenuForecastAccuracyList";
 import { useIngredientForecastAccuracy } from "@/features/inventory/hooks/useIngredientForecastAccuracy";
@@ -9,9 +12,21 @@ import { PageHeader } from "@/components/ui/page-header";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 
+const BACKTEST_OPTIONS = [14, 30, 60] as const;
+
 export default function ForecastAccuracyPage(): React.ReactElement {
-  const menuQuery = useMenuForecastAccuracy();
-  const ingredientQuery = useIngredientForecastAccuracy();
+  return (
+    <Suspense fallback={<LoadingText />}>
+      <ForecastAccuracyContent />
+    </Suspense>
+  );
+}
+
+function ForecastAccuracyContent(): React.ReactElement {
+  const searchParams = useSearchParams();
+  const backtestDays = parseOption(searchParams.get("days"), BACKTEST_OPTIONS, 14);
+  const menuQuery = useMenuForecastAccuracy(backtestDays);
+  const ingredientQuery = useIngredientForecastAccuracy(backtestDays);
 
   return (
     <section className="flex flex-col gap-section">
@@ -26,12 +41,21 @@ export default function ForecastAccuracyPage(): React.ReactElement {
 
       <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
         <p className="text-body text-ink-1">
-          최근 14일 기준으로 메뉴·재료 예측과 실제 판매/소비량을 비교합니다.
+          최근 {backtestDays}일 기준으로 메뉴·재료 예측과 실제 판매/소비량을 비교합니다.
         </p>
         <p className="mt-1 text-caption text-ink-3">
           각 날짜의 예측은 그 전날까지의 판매 이력만 사용해 다시 계산합니다.
         </p>
       </section>
+
+      <ForecastPeriodSelector
+        label="백테스트 기간"
+        queryKey="days"
+        selectedValue={backtestDays}
+        options={BACKTEST_OPTIONS}
+        suffix="일"
+        pathname="/inventory/forecast-accuracy"
+      />
 
       <AccuracySection title="재료 예측 정확도">
         {ingredientQuery.isLoading && <LoadingText />}
@@ -46,6 +70,11 @@ export default function ForecastAccuracyPage(): React.ReactElement {
       </AccuracySection>
     </section>
   );
+}
+
+function parseOption<T extends number>(raw: string | null, options: readonly T[], fallback: T): T {
+  const value = Number(raw);
+  return options.includes(value as T) ? (value as T) : fallback;
 }
 
 function AccuracySection({

--- a/src/app/(main)/inventory/menu-forecast/page.tsx
+++ b/src/app/(main)/inventory/menu-forecast/page.tsx
@@ -1,14 +1,29 @@
 "use client";
 
+import { Suspense } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { ForecastPeriodSelector } from "@/features/inventory/components/ForecastPeriodSelector";
 import { MenuDemandForecastList } from "@/features/inventory/components/MenuDemandForecastList";
 import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
 import { PageHeader } from "@/components/ui/page-header";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 
+const HORIZON_OPTIONS = [7, 14, 30] as const;
+
 export default function MenuForecastPage(): React.ReactElement {
-  const query = useMenuDemandForecast();
+  return (
+    <Suspense fallback={<LoadingText />}>
+      <MenuForecastContent />
+    </Suspense>
+  );
+}
+
+function MenuForecastContent(): React.ReactElement {
+  const searchParams = useSearchParams();
+  const horizonDays = parseOption(searchParams.get("horizon"), HORIZON_OPTIONS, 7);
+  const query = useMenuDemandForecast(horizonDays);
 
   return (
     <section className="flex flex-col gap-section">
@@ -27,15 +42,31 @@ export default function MenuForecastPage(): React.ReactElement {
       />
 
       <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
-        <p className="text-body text-ink-1">앞으로 7일간 메뉴별 예상 판매량을 보여줍니다.</p>
+        <p className="text-body text-ink-1">
+          앞으로 {horizonDays}일간 메뉴별 예상 판매량을 보여줍니다.
+        </p>
         <p className="mt-1 text-caption text-ink-3">
           재료 소진 예측은 이 메뉴 수요와 옵션 선택률을 재료 레시피로 변환해서 계산합니다.
         </p>
       </section>
+
+      <ForecastPeriodSelector
+        label="예측 기간"
+        queryKey="horizon"
+        selectedValue={horizonDays}
+        options={HORIZON_OPTIONS}
+        suffix="일"
+        pathname="/inventory/menu-forecast"
+      />
 
       {query.isLoading && <LoadingText />}
       {query.error && <ErrorAlert message={query.error.message} />}
       {query.data && <MenuDemandForecastList items={query.data} />}
     </section>
   );
+}
+
+function parseOption<T extends number>(raw: string | null, options: readonly T[], fallback: T): T {
+  const value = Number(raw);
+  return options.includes(value as T) ? (value as T) : fallback;
 }

--- a/src/features/inventory/components/ForecastPeriodSelector.tsx
+++ b/src/features/inventory/components/ForecastPeriodSelector.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+interface ForecastPeriodSelectorProps {
+  label: string;
+  queryKey: string;
+  selectedValue: number;
+  options: readonly number[];
+  suffix: string;
+  pathname: string;
+}
+
+export function ForecastPeriodSelector({
+  label,
+  queryKey,
+  selectedValue,
+  options,
+  suffix,
+  pathname,
+}: ForecastPeriodSelectorProps): React.ReactElement {
+  return (
+    <div className="rounded-[24px] border border-border bg-card px-4 py-4 shadow-soft">
+      <p className="text-caption font-semibold text-ink-2">{label}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {options.map((option) => {
+          const selected = option === selectedValue;
+          return (
+            <Link
+              key={option}
+              href={`${pathname}?${queryKey}=${option}`}
+              aria-current={selected ? "page" : undefined}
+              className={cn(
+                "rounded-2xl px-3 py-2 text-caption font-semibold shadow-soft transition",
+                selected
+                  ? "bg-blue text-white"
+                  : "border border-border bg-white text-ink-2 hover:border-blue/30 hover:bg-blue-soft",
+              )}
+            >
+              {option}
+              {suffix}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/features/inventory/hooks/useIngredientForecastAccuracy.ts
+++ b/src/features/inventory/hooks/useIngredientForecastAccuracy.ts
@@ -12,17 +12,24 @@ export const ingredientForecastAccuracyQueryKey = [
   "ingredient-forecast-accuracy",
 ] as const;
 
+export const ingredientForecastAccuracyQueryKeyWithPeriod = (backtestDays: number) =>
+  [...ingredientForecastAccuracyQueryKey, backtestDays] as const;
+
 export type { IngredientForecastAccuracyView } from "@/lib/application/inventory";
 
-async function fetchIngredientForecastAccuracy(): Promise<IngredientForecastAccuracyView[]> {
+async function fetchIngredientForecastAccuracy(
+  backtestDays: number,
+): Promise<IngredientForecastAccuracyView[]> {
   const supabase = createClient();
-  return loadIngredientForecastAccuracyViews(supabase);
+  return loadIngredientForecastAccuracyViews(supabase, backtestDays);
 }
 
-export function useIngredientForecastAccuracy(): UseQueryResult<IngredientForecastAccuracyView[]> {
+export function useIngredientForecastAccuracy(
+  backtestDays: number = 14,
+): UseQueryResult<IngredientForecastAccuracyView[]> {
   return useQuery({
-    queryKey: ingredientForecastAccuracyQueryKey,
-    queryFn: fetchIngredientForecastAccuracy,
+    queryKey: ingredientForecastAccuracyQueryKeyWithPeriod(backtestDays),
+    queryFn: () => fetchIngredientForecastAccuracy(backtestDays),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/features/inventory/hooks/useMenuDemandForecast.ts
+++ b/src/features/inventory/hooks/useMenuDemandForecast.ts
@@ -7,19 +7,22 @@ import {
 } from "@/lib/application/inventory";
 import { createClient } from "@/lib/supabase/client";
 
-export const menuDemandForecastQueryKey = ["inventory", "menu-demand-forecast"] as const;
+export const menuDemandForecastQueryKey = (horizonDays: number) =>
+  ["inventory", "menu-demand-forecast", horizonDays] as const;
 
 export type { MenuDemandForecastView } from "@/lib/application/inventory";
 
-async function fetchMenuDemandForecast(): Promise<MenuDemandForecastView[]> {
+async function fetchMenuDemandForecast(horizonDays: number): Promise<MenuDemandForecastView[]> {
   const supabase = createClient();
-  return loadMenuDemandForecastViews(supabase);
+  return loadMenuDemandForecastViews(supabase, horizonDays);
 }
 
-export function useMenuDemandForecast(): UseQueryResult<MenuDemandForecastView[]> {
+export function useMenuDemandForecast(
+  horizonDays: number = 7,
+): UseQueryResult<MenuDemandForecastView[]> {
   return useQuery({
-    queryKey: menuDemandForecastQueryKey,
-    queryFn: fetchMenuDemandForecast,
+    queryKey: menuDemandForecastQueryKey(horizonDays),
+    queryFn: () => fetchMenuDemandForecast(horizonDays),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/features/inventory/hooks/useMenuForecastAccuracy.ts
+++ b/src/features/inventory/hooks/useMenuForecastAccuracy.ts
@@ -7,19 +7,24 @@ import {
 } from "@/lib/application/inventory";
 import { createClient } from "@/lib/supabase/client";
 
-export const menuForecastAccuracyQueryKey = ["inventory", "menu-forecast-accuracy"] as const;
+export const menuForecastAccuracyQueryKey = (backtestDays: number) =>
+  ["inventory", "menu-forecast-accuracy", backtestDays] as const;
 
 export type { MenuForecastAccuracyView } from "@/lib/application/inventory";
 
-async function fetchMenuForecastAccuracy(): Promise<MenuForecastAccuracyView[]> {
+async function fetchMenuForecastAccuracy(
+  backtestDays: number,
+): Promise<MenuForecastAccuracyView[]> {
   const supabase = createClient();
-  return loadMenuForecastAccuracyViews(supabase);
+  return loadMenuForecastAccuracyViews(supabase, backtestDays);
 }
 
-export function useMenuForecastAccuracy(): UseQueryResult<MenuForecastAccuracyView[]> {
+export function useMenuForecastAccuracy(
+  backtestDays: number = 14,
+): UseQueryResult<MenuForecastAccuracyView[]> {
   return useQuery({
-    queryKey: menuForecastAccuracyQueryKey,
-    queryFn: fetchMenuForecastAccuracy,
+    queryKey: menuForecastAccuracyQueryKey(backtestDays),
+    queryFn: () => fetchMenuForecastAccuracy(backtestDays),
     staleTime: 5 * 60 * 1000,
   });
 }


### PR DESCRIPTION
## Summary
- Add URL-based period controls for menu demand forecast and forecast accuracy pages
- Scope React Query cache keys by selected forecast/backtest period
- Support menu forecast horizons of 7/14/30 days and accuracy backtests of 14/30/60 days

## Verification
- npm run typecheck
- npm run build
- npm run lint
- npm run format:check

## Notes
- No Supabase migration required