### PR TITLE
Add purchase recommendations to inventory forecast

### DIFF
--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { daysUntilDate, formatNumber } from "@/lib/utils/format";
+import { daysUntilDate, formatDateKoFromIso, formatNumber, localIsoDate } from "@/lib/utils/format";
 import type { DepletionStatus } from "@/lib/domain/forecast";
 import { useDeleteIngredient } from "@/features/purchase/hooks/useIngredients";
 import type { IngredientForecastView } from "../hooks/useDepletionForecast";
@@ -118,6 +118,20 @@ function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactE
           {deleteMutation.error.message}
         </p>
       )}
+      {item.purchaseRecommendation?.isOrderRecommended && (
+        <div className="mt-2 rounded-2xl border border-blue/20 bg-blue-soft px-3 py-2 text-caption text-blue-deep">
+          <span className="font-semibold">
+            권장 발주{" "}
+            {formatNumber(Math.ceil(item.purchaseRecommendation.recommendedOrderQuantity))}
+            {item.unit}
+          </span>
+          <span className="text-blue-deep/70">
+            {" "}
+            · {formatOrderByDate(item.purchaseRecommendation.orderByDate)}까지 · 리드타임+ 안전여유+
+            {item.purchaseRecommendation.targetCoverageDays}일 운영분 기준
+          </span>
+        </div>
+      )}
     </li>
   );
 }
@@ -154,6 +168,11 @@ function formatDepletion(item: IngredientForecastView): string {
   if (days === null) return "예측 데이터 부족";
   if (days === 0) return "오늘 소진";
   return `${days}일 후 소진`;
+}
+
+function formatOrderByDate(date: Date | null): string {
+  if (!date) return "발주일 미정";
+  return formatDateKoFromIso(localIsoDate(date));
 }
 
 function TrendBadge({ trend }: { trend: "rising" | "falling" }): React.ReactElement {

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -3,10 +3,12 @@ import {
   forecastIngredientDemandFromMenus,
   forecastIngredient,
   forecastMenuDemand,
+  recommendPurchaseQuantity,
   type DailyConsumption,
   type DailyMenuDemand,
   type ForecastResult,
   type IngredientDemandForecast,
+  type PurchaseRecommendationResult,
 } from "@/lib/domain/forecast";
 import {
   applyInventoryReplay as applyInventoryReplayRpc,
@@ -32,6 +34,7 @@ export interface IngredientForecastView extends ForecastResult {
   isDefaultLeadTime: boolean;
   safetyBufferDays: number;
   forecastSource: "menu_demand" | "consumption_history";
+  purchaseRecommendation: PurchaseRecommendationResult | null;
 }
 
 export interface MenuDemandForecastView {
@@ -126,6 +129,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       isDefaultLeadTime: row.isDefaultLeadTime,
       safetyBufferDays,
       forecastSource: "consumption_history" as const,
+      purchaseRecommendation: null,
       ...forecast,
     };
   });
@@ -142,16 +146,23 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
 
   return legacyForecasts.map((legacy) => {
     const demand = demandByIngredient.get(legacy.ingredientId);
-    const depletionDate = demand
-      ? predictDepletionDateFromDemand(legacy.currentStock, demand)
-      : null;
+    if (!demand) return legacy;
+    const depletionDate = predictDepletionDateFromDemand(legacy.currentStock, demand);
     if (!depletionDate) return legacy;
+    const purchaseRecommendation = recommendPurchaseQuantity({
+      currentStock: legacy.currentStock,
+      leadTimeDays: legacy.leadTimeDays,
+      safetyBufferDays: legacy.safetyBufferDays,
+      dailyDemand: demand.dailyPredictions,
+      today,
+    });
 
     return {
       ...legacy,
       expectedDepletionDate: depletionDate,
       status: classifyStatus(depletionDate, legacy.leadTimeDays, legacy.safetyBufferDays, today),
       forecastSource: "menu_demand",
+      purchaseRecommendation,
     };
   });
 }

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -105,6 +105,22 @@ export interface ForecastResult {
   isColdStart: boolean;
 }
 
+export interface PurchaseRecommendationInput {
+  currentStock: number;
+  leadTimeDays: number;
+  safetyBufferDays: number;
+  dailyDemand: readonly IngredientDemandForecastDay[];
+  today: Date;
+  coverageDays?: number;
+}
+
+export interface PurchaseRecommendationResult {
+  recommendedOrderQuantity: number;
+  orderByDate: Date | null;
+  targetCoverageDays: number;
+  isOrderRecommended: boolean;
+}
+
 export interface MenuDemandForecastInput {
   demandSamples: readonly DailyMenuDemand[];
   daysOff: readonly Weekday[];
@@ -346,6 +362,74 @@ export function classifyStatus(
   if (buffer === 2) return "order_needed";
   if (buffer <= 4) return "caution";
   return "safe";
+}
+
+/**
+ * 발주 추천량.
+ *
+ * 현재 재고가 `리드타임 + 안전여유 + 목표 커버리지` 기간의 예상 소요량을
+ * 커버하도록 부족분만 추천한다. 기본 목표 커버리지는 7일이다.
+ */
+export function recommendPurchaseQuantity({
+  currentStock,
+  leadTimeDays,
+  safetyBufferDays,
+  dailyDemand,
+  today,
+  coverageDays = 7,
+}: PurchaseRecommendationInput): PurchaseRecommendationResult {
+  const targetCoverageDays = Math.max(1, Math.ceil(coverageDays));
+  const reorderWindowDays = Math.max(0, Math.ceil(leadTimeDays)) + Math.max(0, safetyBufferDays);
+  const targetWindowDays = reorderWindowDays + targetCoverageDays;
+  const normalizedToday = startOfForecastDay(today);
+  const demandByDay = dailyDemand
+    .filter((day) => startOfForecastDay(day.date).getTime() > normalizedToday.getTime())
+    .sort((a, b) => startOfForecastDay(a.date).getTime() - startOfForecastDay(b.date).getTime());
+
+  const targetDemand = demandByDay
+    .slice(0, targetWindowDays)
+    .reduce((sum, day) => sum + Math.max(0, day.amount), 0);
+  const recommendedOrderQuantity = Math.max(0, targetDemand - Math.max(0, currentStock));
+
+  const orderByDate = computeOrderByDate({
+    currentStock,
+    leadTimeDays,
+    safetyBufferDays,
+    dailyDemand: demandByDay,
+    today: normalizedToday,
+  });
+
+  return {
+    recommendedOrderQuantity,
+    orderByDate,
+    targetCoverageDays,
+    isOrderRecommended: recommendedOrderQuantity > 0,
+  };
+}
+
+function computeOrderByDate({
+  currentStock,
+  leadTimeDays,
+  safetyBufferDays,
+  dailyDemand,
+  today,
+}: {
+  currentStock: number;
+  leadTimeDays: number;
+  safetyBufferDays: number;
+  dailyDemand: readonly IngredientDemandForecastDay[];
+  today: Date;
+}): Date | null {
+  let stock = currentStock;
+  for (const day of dailyDemand) {
+    stock -= Math.max(0, day.amount);
+    if (stock <= 0) {
+      const orderBy = new Date(startOfForecastDay(day.date));
+      orderBy.setDate(orderBy.getDate() - Math.max(0, Math.ceil(leadTimeDays)) - safetyBufferDays);
+      return orderBy.getTime() < today.getTime() ? today : orderBy;
+    }
+  }
+  return null;
 }
 
 /**

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -287,6 +287,7 @@ describe("application layer", () => {
           trend: "rising",
           isColdStart: false,
           forecastSource: "consumption_history",
+          purchaseRecommendation: null,
         },
       ]);
 
@@ -351,6 +352,8 @@ describe("application layer", () => {
       expect(result?.forecastSource).toBe("menu_demand");
       expect(result?.expectedDepletionDate).toBeInstanceOf(Date);
       expect(result?.status).toBe("critical");
+      expect(result?.purchaseRecommendation?.isOrderRecommended).toBe(true);
+      expect(result?.purchaseRecommendation?.recommendedOrderQuantity).toBeGreaterThan(0);
     });
 
     it("loadDepletionForecast falls back to safety buffer 1 when rpc field is missing", async () => {

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -12,6 +12,7 @@ import {
   forecastMenuDemand,
   isColdStart,
   predictDepletionDate,
+  recommendPurchaseQuantity,
   type DailyConsumption,
   type DailyMenuDemand,
 } from "@/lib/domain/forecast";
@@ -252,6 +253,43 @@ describe("classifyStatus (FR-013)", () => {
     const date = new Date(today.getTime() + 6 * ONE_DAY);
     expect(classifyStatus(date, 1, 1, today)).toBe("caution");
     expect(classifyStatus(date, 1, 3, today)).toBe("order_needed");
+  });
+});
+
+describe("recommendPurchaseQuantity", () => {
+  it("리드타임 + 안전여유 + 7일 운영분까지 부족한 수량을 추천한다", () => {
+    const result = recommendPurchaseQuantity({
+      currentStock: 100,
+      leadTimeDays: 2,
+      safetyBufferDays: 1,
+      today,
+      dailyDemand: Array.from({ length: 10 }, (_, index) => ({
+        date: new Date(today.getTime() + (index + 1) * ONE_DAY),
+        amount: 20,
+      })),
+    });
+
+    expect(result.recommendedOrderQuantity).toBe(100);
+    expect(result.targetCoverageDays).toBe(7);
+    expect(result.isOrderRecommended).toBe(true);
+    expect(result.orderByDate).toEqual(new Date(today.getTime() + 2 * ONE_DAY));
+  });
+
+  it("현재 재고가 목표 커버리지를 채우면 발주 추천하지 않는다", () => {
+    const result = recommendPurchaseQuantity({
+      currentStock: 1_000,
+      leadTimeDays: 1,
+      safetyBufferDays: 1,
+      today,
+      dailyDemand: Array.from({ length: 10 }, (_, index) => ({
+        date: new Date(today.getTime() + (index + 1) * ONE_DAY),
+        amount: 20,
+      })),
+    });
+
+    expect(result.recommendedOrderQuantity).toBe(0);
+    expect(result.isOrderRecommended).toBe(false);
+    expect(result.orderByDate).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add domain logic to recommend purchase quantity from forecasted ingredient demand
- Surface recommended order quantity and order-by date on inventory forecast cards
- Use menu/option-based ingredient demand when available, with lead time + safety buffer + 7 operating days coverage

## Verification
- npm run typecheck
- npx vitest run tests/unit/forecast.test.ts tests/unit/application.test.ts
- npm run lint
- npm run format:check
- npm run build

## Notes
- No Supabase migration required