### PR TITLE
Prefill purchase form from inventory recommendation

### DIFF
--- a/src/app/purchase/page.tsx
+++ b/src/app/purchase/page.tsx
@@ -1,5 +1,7 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
+import { LoadingText } from "@/components/ui/query-state";
 import { PurchaseForm } from "@/features/purchase/components/PurchaseForm";
 
 export default function PurchasePage(): React.ReactElement {
@@ -16,7 +18,9 @@ export default function PurchasePage(): React.ReactElement {
           </Link>
         </div>
       </header>
-      <PurchaseForm />
+      <Suspense fallback={<LoadingText />}>
+        <PurchaseForm />
+      </Suspense>
     </main>
   );
 }

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { daysUntilDate, formatDateKoFromIso, formatNumber, localIsoDate } from "@/lib/utils/format";
 import type { DepletionStatus } from "@/lib/domain/forecast";
@@ -119,17 +120,25 @@ function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactE
         </p>
       )}
       {item.purchaseRecommendation?.isOrderRecommended && (
-        <div className="mt-2 rounded-2xl border border-blue/20 bg-blue-soft px-3 py-2 text-caption text-blue-deep">
-          <span className="font-semibold">
-            권장 발주{" "}
-            {formatNumber(Math.ceil(item.purchaseRecommendation.recommendedOrderQuantity))}
-            {item.unit}
-          </span>
-          <span className="text-blue-deep/70">
-            {" "}
-            · {formatOrderByDate(item.purchaseRecommendation.orderByDate)}까지 · 리드타임+ 안전여유+
-            {item.purchaseRecommendation.targetCoverageDays}일 운영분 기준
-          </span>
+        <div className="mt-2 flex flex-col gap-2 rounded-2xl border border-blue/20 bg-blue-soft px-3 py-2 text-caption text-blue-deep sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <span className="font-semibold">
+              권장 발주{" "}
+              {formatNumber(Math.ceil(item.purchaseRecommendation.recommendedOrderQuantity))}
+              {item.unit}
+            </span>
+            <span className="text-blue-deep/70">
+              {" "}
+              · {formatOrderByDate(item.purchaseRecommendation.orderByDate)}까지 · 리드타임+
+              안전여유+{item.purchaseRecommendation.targetCoverageDays}일 운영분 기준
+            </span>
+          </div>
+          <Link
+            href={buildPurchasePrefillHref(item)}
+            className="self-start rounded-xl bg-blue px-3 py-2 text-label text-white shadow-soft transition hover:-translate-y-0.5 sm:self-auto"
+          >
+            매입 등록
+          </Link>
         </div>
       )}
     </li>
@@ -173,6 +182,15 @@ function formatDepletion(item: IngredientForecastView): string {
 function formatOrderByDate(date: Date | null): string {
   if (!date) return "발주일 미정";
   return formatDateKoFromIso(localIsoDate(date));
+}
+
+function buildPurchasePrefillHref(item: IngredientForecastView): string {
+  const quantity = Math.ceil(item.purchaseRecommendation?.recommendedOrderQuantity ?? 0);
+  const params = new URLSearchParams({
+    ingredientId: item.ingredientId,
+    quantity: String(quantity),
+  });
+  return `/purchase?${params.toString()}`;
 }
 
 function TrendBadge({ trend }: { trend: "rising" | "falling" }): React.ReactElement {

--- a/src/features/purchase/components/PurchaseForm.tsx
+++ b/src/features/purchase/components/PurchaseForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useForm, useFieldArray, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Field } from "@/components/ui/field";
@@ -20,6 +21,8 @@ const todayString = (): string => new Date().toISOString().slice(0, 10);
 
 export function PurchaseForm(): React.ReactElement {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const prefilledItem = getPrefilledPurchaseItem(searchParams);
   const { data: vendors } = useVendors();
   const { data: ingredients } = useIngredients();
   const { data: isFirstPurchase } = useIsFirstPurchase();
@@ -40,7 +43,7 @@ export function PurchaseForm(): React.ReactElement {
     defaultValues: {
       vendorId: "",
       purchasedAt: todayString(),
-      items: [{ ingredientId: "", quantity: 0, amount: 0 }],
+      items: [prefilledItem ?? { ingredientId: "", quantity: 0, amount: 0 }],
     },
   });
 
@@ -122,6 +125,12 @@ export function PurchaseForm(): React.ReactElement {
           </button>
         </header>
 
+        {prefilledItem && (
+          <p className="rounded-2xl bg-blue-soft px-3 py-2 text-caption text-blue-deep">
+            재고 예측의 권장 발주 수량을 첫 항목에 채웠어요. 실제 거래 금액만 입력하면 됩니다.
+          </p>
+        )}
+
         {fields.map((field, idx) => (
           <ItemRow
             key={field.id}
@@ -157,6 +166,20 @@ export function PurchaseForm(): React.ReactElement {
       </PrimaryButton>
     </form>
   );
+}
+
+function getPrefilledPurchaseItem(
+  searchParams: ReturnType<typeof useSearchParams>,
+): SavePurchaseInput["items"][number] | null {
+  const ingredientId = searchParams.get("ingredientId");
+  const quantity = Number(searchParams.get("quantity"));
+  if (!ingredientId || !Number.isFinite(quantity) || quantity <= 0) return null;
+
+  return {
+    ingredientId,
+    quantity,
+    amount: 0,
+  };
 }
 
 interface VendorPickerProps {


### PR DESCRIPTION
## Summary
- Add a purchase registration CTA to inventory order recommendations
- Pass recommended ingredient and quantity through purchase URL query params
- Prefill the first purchase form item from the recommendation and show a small guidance note

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build

## Notes
- No Supabase migration required
- Vendor auto-selection is not included because the forecast view currently exposes vendor name, not vendor id