### PR TITLE
Add configurable order coverage days

### DIFF
--- a/src/app/(main)/inventory/orders/page.tsx
+++ b/src/app/(main)/inventory/orders/page.tsx
@@ -21,6 +21,7 @@ export default function InventoryOrdersPage(): React.ReactElement {
     (item) => item.purchaseRecommendation?.isOrderRecommended,
   );
   const groups = groupByVendor(recommendedItems);
+  const coverageDays = recommendedItems[0]?.purchaseRecommendation?.targetCoverageDays ?? 7;
 
   return (
     <section className="flex flex-col gap-section">
@@ -40,7 +41,7 @@ export default function InventoryOrdersPage(): React.ReactElement {
 
       <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
         <p className="text-body text-ink-1">
-          리드타임, 안전여유, 7일 운영분 기준으로 지금 사야 할 재료만 모았습니다.
+          리드타임, 안전여유, {coverageDays}일 운영분 기준으로 지금 사야 할 재료만 모았습니다.
         </p>
         <p className="mt-1 text-caption text-ink-3">
           거래처가 같은 재료는 한 번에 매입 등록으로 넘길 수 있습니다.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { STORE_TYPE_LABELS } from "@/features/auth/schemas";
 import { LogoutButton } from "@/features/settings/components/LogoutButton";
+import { PurchaseCoverageDaysEditor } from "@/features/settings/components/PurchaseCoverageDaysEditor";
 import { RegularDaysOffEditor } from "@/features/settings/components/RegularDaysOffEditor";
 import { SafetyBufferEditor } from "@/features/settings/components/SafetyBufferEditor";
 import { StoreNameEditor } from "@/features/settings/components/StoreNameEditor";
@@ -24,7 +25,7 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
 
   const { data } = await supabase
     .from("users")
-    .select("store_name, store_type, regular_days_off, safety_buffer_days")
+    .select("store_name, store_type, regular_days_off, safety_buffer_days, purchase_coverage_days")
     .eq("id", user.id)
     .maybeSingle();
 
@@ -33,9 +34,11 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
     store_type: StoreType;
     regular_days_off: Weekday[];
     safety_buffer_days: number;
+    purchase_coverage_days: number;
   } | null;
   const initialDaysOff: Weekday[] = profile?.regular_days_off ?? [];
   const safetyBufferDays = profile?.safety_buffer_days ?? 1;
+  const purchaseCoverageDays = profile?.purchase_coverage_days ?? 7;
   const storeName = profile?.store_name ?? "내 가게";
   const storeType = profile?.store_type ?? "cafe";
 
@@ -84,7 +87,7 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
           </p>
         </header>
 
-        <div className="grid gap-stack-tight md:grid-cols-3">
+        <div className="grid gap-stack-tight md:grid-cols-4">
           <RuleCard
             title="정기휴무"
             body="선택한 요일은 미래 시뮬레이션에서 소비 0으로 보고, 과거 평균 계산에서도 제외합니다."
@@ -97,12 +100,20 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
             title="안전여유일"
             body={`현재 ${safetyBufferDays}일로 설정되어 있습니다. 리드타임 뒤에 추가 버퍼를 더해 위험 단계를 더 보수적으로 잡습니다.`}
           />
+          <RuleCard
+            title="발주 커버일"
+            body={`현재 ${purchaseCoverageDays}일로 설정되어 있습니다. 권장 발주량은 리드타임과 안전여유 뒤에 이 기간만큼 더 팔 수 있게 계산합니다.`}
+          />
         </div>
 
         <RegularDaysOffEditor initialDaysOff={initialDaysOff} />
 
         <div className="grid gap-stack-tight border-t border-border pt-stack">
           <SafetyBufferEditor initialSafetyBufferDays={safetyBufferDays} userId={user.id} />
+          <PurchaseCoverageDaysEditor
+            initialPurchaseCoverageDays={purchaseCoverageDays}
+            userId={user.id}
+          />
           <SettingRow
             label="리드타임 기준"
             value={`각 재료는 구매 이력에서 가장 자주 연결된 거래처 리드타임을 따로 사용합니다. 거래처가 아직 없거나 구매 이력이 없으면 기본 1일로 계산합니다.`}
@@ -110,6 +121,10 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
           <SettingRow
             label="위험 단계 계산"
             value={`소진 예상일까지 남은 일수에서 거래처 리드타임과 안전여유 ${safetyBufferDays}일을 함께 빼서 safe / caution / order_needed / critical 단계를 정합니다.`}
+          />
+          <SettingRow
+            label="권장 발주량 계산"
+            value={`예상 수요 기준으로 리드타임과 안전여유를 버틴 뒤 ${purchaseCoverageDays}일치 운영분까지 채우도록 부족 수량을 추천합니다.`}
           />
           <VendorLeadTimeManager />
         </div>

--- a/src/features/settings/components/PurchaseCoverageDaysEditor.tsx
+++ b/src/features/settings/components/PurchaseCoverageDaysEditor.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Field } from "@/components/ui/field";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { useUpdatePurchaseCoverageDays } from "@/features/settings/hooks/useSettingsMutations";
+
+const purchaseCoverageSchema = z.object({
+  purchaseCoverageDays: z
+    .number({ invalid_type_error: "발주 커버일은 숫자로 입력해주세요" })
+    .int("발주 커버일은 정수여야 합니다")
+    .min(1, "발주 커버일은 1일 이상이어야 합니다")
+    .max(30, "발주 커버일은 30일 이하로 입력해주세요"),
+});
+
+type PurchaseCoverageFormInput = z.infer<typeof purchaseCoverageSchema>;
+
+interface PurchaseCoverageDaysEditorProps {
+  initialPurchaseCoverageDays: number;
+  userId: string;
+}
+
+export function PurchaseCoverageDaysEditor({
+  initialPurchaseCoverageDays,
+  userId,
+}: PurchaseCoverageDaysEditorProps): React.ReactElement {
+  const router = useRouter();
+  const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+  const mutation = useUpdatePurchaseCoverageDays();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty, isSubmitting },
+    reset,
+  } = useForm<PurchaseCoverageFormInput>({
+    resolver: zodResolver(purchaseCoverageSchema),
+    defaultValues: { purchaseCoverageDays: initialPurchaseCoverageDays },
+  });
+
+  async function onSubmit(values: PurchaseCoverageFormInput): Promise<void> {
+    setSubmitMessage(null);
+
+    try {
+      const nextValue = await mutation.mutateAsync({
+        userId,
+        purchaseCoverageDays: values.purchaseCoverageDays,
+      });
+      reset({ purchaseCoverageDays: nextValue });
+      setSubmitMessage("권장 발주 커버일을 저장했어요.");
+      router.refresh();
+    } catch (error) {
+      setSubmitMessage(error instanceof Error ? error.message : "발주 커버일 저장에 실패했어요.");
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(event) => void handleSubmit(onSubmit)(event)}
+      className="flex flex-col gap-stack"
+      noValidate
+    >
+      <Field label="권장 발주 커버일" error={errors.purchaseCoverageDays?.message}>
+        <input
+          {...register("purchaseCoverageDays", { valueAsNumber: true })}
+          type="number"
+          min={1}
+          max={30}
+          inputMode="numeric"
+          className="rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-1 tabular-nums shadow-soft"
+        />
+      </Field>
+
+      <p className="text-caption text-ink-3">
+        발주 추천 수량은 리드타임과 안전여유를 버틴 뒤, 이 일수만큼 더 운영할 수 있게 계산합니다.
+      </p>
+
+      <div className="flex items-center gap-stack-tight">
+        <PrimaryButton type="submit" disabled={isSubmitting || !isDirty}>
+          {isSubmitting ? "저장 중..." : "발주 커버일 저장"}
+        </PrimaryButton>
+        {submitMessage && (
+          <p
+            role="status"
+            className={mutation.isError ? "text-caption text-red" : "text-caption text-green"}
+          >
+            {submitMessage}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/features/settings/hooks/useSettingsMutations.ts
+++ b/src/features/settings/hooks/useSettingsMutations.ts
@@ -28,6 +28,11 @@ interface UpdateSafetyBufferDaysInput {
   safetyBufferDays: number;
 }
 
+interface UpdatePurchaseCoverageDaysInput {
+  userId: string;
+  purchaseCoverageDays: number;
+}
+
 export async function invalidateSettingsRelatedQueries(queryClient: QueryClient): Promise<void> {
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: todayDashboardQueryKey }),
@@ -78,6 +83,22 @@ async function updateSafetyBufferDays(input: UpdateSafetyBufferDaysInput): Promi
   return data.safety_buffer_days;
 }
 
+async function updatePurchaseCoverageDays(input: UpdatePurchaseCoverageDaysInput): Promise<number> {
+  const supabase = createClient() as unknown as SupabaseClient<Database>;
+  const { data, error } = await supabase
+    .from("users")
+    .update({ purchase_coverage_days: input.purchaseCoverageDays })
+    .eq("id", input.userId)
+    .select("purchase_coverage_days")
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (typeof data?.purchase_coverage_days !== "number") {
+    throw new Error("발주 커버일 저장 결과가 비어 있습니다.");
+  }
+  return data.purchase_coverage_days;
+}
+
 export function useUpdateStoreName(): UseMutationResult<string, Error, UpdateStoreNameInput> {
   const queryClient = useQueryClient();
   return useMutation({
@@ -110,6 +131,20 @@ export function useUpdateSafetyBufferDays(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateSafetyBufferDays,
+    onSuccess: async () => {
+      await invalidateSettingsRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function useUpdatePurchaseCoverageDays(): UseMutationResult<
+  number,
+  Error,
+  UpdatePurchaseCoverageDaysInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updatePurchaseCoverageDays,
     onSuccess: async () => {
       await invalidateSettingsRelatedQueries(queryClient);
     },

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -34,6 +34,7 @@ export interface IngredientForecastView extends ForecastResult {
   leadTimeVendorName: string | null;
   isDefaultLeadTime: boolean;
   safetyBufferDays: number;
+  purchaseCoverageDays: number;
   forecastSource: "menu_demand" | "consumption_history";
   purchaseRecommendation: PurchaseRecommendationResult | null;
 }
@@ -111,6 +112,9 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       amount: Number(s.amount),
     }));
     const safetyBufferDays = Number.isFinite(row.safetyBufferDays) ? row.safetyBufferDays : 1;
+    const purchaseCoverageDays = Number.isFinite(row.purchaseCoverageDays)
+      ? row.purchaseCoverageDays
+      : 7;
     const forecast = forecastIngredient({
       currentStock: row.currentStock,
       leadTimeDays: row.leadTimeDays,
@@ -130,6 +134,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       leadTimeVendorName: row.leadTimeVendorName,
       isDefaultLeadTime: row.isDefaultLeadTime,
       safetyBufferDays,
+      purchaseCoverageDays,
       forecastSource: "consumption_history" as const,
       purchaseRecommendation: null,
       ...forecast,
@@ -157,6 +162,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       safetyBufferDays: legacy.safetyBufferDays,
       dailyDemand: demand.dailyPredictions,
       today,
+      coverageDays: legacy.purchaseCoverageDays,
     });
 
     return {

--- a/src/lib/supabase/rpc-queries.ts
+++ b/src/lib/supabase/rpc-queries.ts
@@ -10,6 +10,7 @@ export interface DepletionForecastRow {
   leadTimeVendorName: string | null;
   isDefaultLeadTime: boolean;
   safetyBufferDays: number;
+  purchaseCoverageDays: number;
   consumptionSamples: Array<{ date: string; amount: number }>;
   signedUpAt: string;
   regularDaysOff: ReadonlyArray<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -49,6 +50,7 @@ interface DepletionForecastRawRow {
   lead_time_vendor_name: string | null;
   is_default_lead_time: boolean;
   safety_buffer_days?: number | null;
+  purchase_coverage_days?: number | null;
   consumption_samples: Array<{ date: string; amount: number }>;
   signed_up_at: string;
   regular_days_off: Array<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -311,6 +313,11 @@ export async function getDepletionForecast(
         typeof row.safety_buffer_days === "number" && Number.isFinite(row.safety_buffer_days)
           ? row.safety_buffer_days
           : 1,
+      purchaseCoverageDays:
+        typeof row.purchase_coverage_days === "number" &&
+        Number.isFinite(row.purchase_coverage_days)
+          ? row.purchase_coverage_days
+          : 7,
       consumptionSamples: row.consumption_samples ?? [],
       signedUpAt: row.signed_up_at,
       regularDaysOff: row.regular_days_off ?? [],

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -612,6 +612,7 @@ export type Database = {
           email: string
           id: string
           permanent_delete_at: string | null
+          purchase_coverage_days: number
           regular_days_off: Database["public"]["Enums"]["weekday"][]
           safety_buffer_days: number
           signed_up_at: string
@@ -626,6 +627,7 @@ export type Database = {
           email: string
           id: string
           permanent_delete_at?: string | null
+          purchase_coverage_days?: number
           regular_days_off?: Database["public"]["Enums"]["weekday"][]
           safety_buffer_days?: number
           signed_up_at?: string
@@ -640,6 +642,7 @@ export type Database = {
           email?: string
           id?: string
           permanent_delete_at?: string | null
+          purchase_coverage_days?: number
           regular_days_off?: Database["public"]["Enums"]["weekday"][]
           safety_buffer_days?: number
           signed_up_at?: string
@@ -760,6 +763,7 @@ export type Database = {
           lead_time_vendor_id: string | null
           lead_time_vendor_name: string | null
           name: string
+          purchase_coverage_days: number
           regular_days_off: Database["public"]["Enums"]["weekday"][]
           safety_buffer_days: number
           signed_up_at: string

--- a/supabase/migrations/047_add_purchase_coverage_days.sql
+++ b/supabase/migrations/047_add_purchase_coverage_days.sql
@@ -1,0 +1,133 @@
+-- Migration: 사용자별 권장 발주 커버일 설정
+-- 권장 발주량 계산 시 리드타임 + 안전여유 뒤에 추가로 확보할 운영일 수.
+
+alter table public.users
+add column if not exists purchase_coverage_days integer not null default 7;
+
+alter table public.users
+drop constraint if exists users_purchase_coverage_days_range;
+
+alter table public.users
+add constraint users_purchase_coverage_days_range
+check (purchase_coverage_days between 1 and 30);
+
+comment on column public.users.purchase_coverage_days is
+  '권장 발주량 계산 시 추가로 확보할 운영일 수. 기본 7일.';
+
+drop function if exists public.get_depletion_forecast();
+
+create function public.get_depletion_forecast()
+returns table (
+  ingredient_id uuid,
+  name text,
+  unit public.ingredient_unit,
+  current_stock numeric,
+  lead_time_days integer,
+  lead_time_vendor_id uuid,
+  lead_time_vendor_name text,
+  is_default_lead_time boolean,
+  safety_buffer_days integer,
+  purchase_coverage_days integer,
+  consumption_samples jsonb,
+  signed_up_at timestamptz,
+  regular_days_off public.weekday[]
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  return query
+  with vendor_choice as (
+    select
+      i.id as ingredient_id,
+      choice.vendor_id,
+      choice.vendor_name,
+      choice.lead_time_days
+    from public.ingredients i
+    left join lateral (
+      select
+        v.id as vendor_id,
+        v.name as vendor_name,
+        v.lead_time_days
+      from public.purchase_orders po
+      join public.vendors v on v.id = po.vendor_id
+      join public.purchase_order_items poi on poi.purchase_order_id = po.id
+      where poi.ingredient_id = i.id
+        and po.user_id = v_user_id
+      group by v.id, v.name, v.lead_time_days
+      order by count(*) desc, max(po.purchased_at) desc, v.name asc
+      limit 1
+    ) choice on true
+    where i.user_id = v_user_id
+      and i.is_active = true
+  )
+  select
+    i.id,
+    i.name,
+    i.unit,
+    i.current_stock,
+    coalesce(vc.lead_time_days, 1) as lead_time_days,
+    vc.vendor_id as lead_time_vendor_id,
+    vc.vendor_name as lead_time_vendor_name,
+    (vc.lead_time_days is null) as is_default_lead_time,
+    u.safety_buffer_days,
+    u.purchase_coverage_days,
+    coalesce(
+      (select jsonb_agg(jsonb_build_object('date', day, 'amount', total) order by day)
+       from (
+         select day, sum(total)::numeric as total
+         from (
+           select
+             s.sold_at as day,
+             sum(si.quantity * ri.quantity_per_serving) as total
+           from public.sales s
+           join public.sale_items si on si.sale_id = s.id
+           join public.recipe_items ri on ri.menu_id = si.menu_id
+           where ri.ingredient_id = i.id
+             and s.user_id = v_user_id
+             and s.sold_at >= current_date - interval '90 days'
+           group by s.sold_at
+
+           union all
+
+           select
+             s.sold_at as day,
+             sum(sio.quantity * ((recipe_item ->> 'quantity_per_selection')::numeric)) as total
+           from public.sales s
+           join public.sale_items si on si.sale_id = s.id
+           join public.sale_item_options sio on sio.sale_item_id = si.id
+           cross join lateral jsonb_array_elements(sio.recipe_items_snapshot) as recipe_item
+           where (recipe_item ->> 'ingredient_id')::uuid = i.id
+             and s.user_id = v_user_id
+             and s.sold_at >= current_date - interval '90 days'
+           group by s.sold_at
+         ) raw_daily
+         group by day
+       ) daily),
+      '[]'::jsonb
+    ) as consumption_samples,
+    u.signed_up_at,
+    u.regular_days_off
+  from public.ingredients i
+  join public.users u on u.id = i.user_id
+  left join vendor_choice vc on vc.ingredient_id = i.id
+  where i.user_id = v_user_id
+    and i.is_active = true
+  order by i.name;
+end;
+$$;
+
+comment on function public.get_depletion_forecast() is
+  '재고 예측 raw 데이터 반환. 소비 sample, 거래처 식별자, 권장 발주 커버일 설정을 포함한다.';
+
+revoke all on function public.get_depletion_forecast() from public;
+grant execute on function public.get_depletion_forecast() to authenticated;

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -284,6 +284,7 @@ describe("application layer", () => {
           leadTimeVendorName: "신선상회",
           isDefaultLeadTime: false,
           safetyBufferDays: 2,
+          purchaseCoverageDays: 7,
           expectedDepletionDate: new Date("2026-06-10T00:00:00.000Z"),
           status: "caution",
           trend: "rising",
@@ -317,6 +318,7 @@ describe("application layer", () => {
             leadTimeVendorName: "얼음상회",
             isDefaultLeadTime: false,
             safetyBufferDays: 1,
+            purchaseCoverageDays: 14,
             consumptionSamples: [{ date: "2026-06-01", amount: 1 }],
             signedUpAt: "2026-05-01T00:00:00.000Z",
             regularDaysOff: [],
@@ -356,6 +358,7 @@ describe("application layer", () => {
       expect(result?.expectedDepletionDate).toBeInstanceOf(Date);
       expect(result?.status).toBe("critical");
       expect(result?.purchaseRecommendation?.isOrderRecommended).toBe(true);
+      expect(result?.purchaseRecommendation?.targetCoverageDays).toBe(14);
       expect(result?.purchaseRecommendation?.recommendedOrderQuantity).toBeGreaterThan(0);
     });
 


### PR DESCRIPTION
## Summary
- Add user-level purchase_coverage_days setting with 1-30 day validation
- Add Settings UI for 권장 발주 커버일
- Return purchase_coverage_days from get_depletion_forecast and use it in purchase recommendation quantity
- Update order recommendation copy to reflect the configured coverage days

## Verification
- npm run typecheck
- npx vitest run tests/unit/application.test.ts tests/unit/forecast.test.ts
- npm run lint
- npm run format:check
- npm run build
- npm run test:coverage

## Notes
- Includes Supabase migration 047_add_purchase_coverage_days.sql