### PR TITLE
Save order recommendation snapshots

### DIFF
--- a/src/app/(main)/inventory/orders/page.tsx
+++ b/src/app/(main)/inventory/orders/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { PageHeader } from "@/components/ui/page-header";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
+import { useOrderRecommendationSnapshot } from "@/features/inventory/hooks/useOrderRecommendationSnapshot";
 import { daysUntilDate, formatDateKoFromIso, formatNumber, localIsoDate } from "@/lib/utils/format";
 import type { IngredientForecastView } from "@/lib/application/inventory";
 
@@ -69,12 +72,13 @@ export default function InventoryOrdersPage(): React.ReactElement {
                 <h2 className="text-title-md text-ink-1">{group.vendorName}</h2>
                 <p className="text-caption text-ink-3">{group.items.length}개 재료 발주 권장</p>
               </div>
-              <Link
-                href={buildPurchaseHref(group.items, group.vendorId)}
-                className="halo-cta self-start rounded-2xl bg-brand-primary px-4 py-3 text-label font-semibold text-white shadow-card transition hover:-translate-y-0.5 sm:self-auto"
+              <OrderPurchaseButton
+                items={group.items}
+                vendorId={group.vendorId}
+                className="halo-cta self-start rounded-2xl bg-brand-primary px-4 py-3 text-label font-semibold text-white shadow-card transition hover:-translate-y-0.5 disabled:opacity-60 sm:self-auto"
               >
                 이 거래처 매입 등록
-              </Link>
+              </OrderPurchaseButton>
             </header>
 
             <ul className="flex flex-col gap-stack-tight">
@@ -99,12 +103,13 @@ export default function InventoryOrdersPage(): React.ReactElement {
                         )}
                         {item.unit}
                       </span>
-                      <Link
-                        href={buildPurchaseHref([item], item.leadTimeVendorId)}
-                        className="rounded-xl border border-border bg-card px-3 py-2 text-label text-ink-2 shadow-soft hover:bg-card-hover"
+                      <OrderPurchaseButton
+                        items={[item]}
+                        vendorId={item.leadTimeVendorId}
+                        className="rounded-xl border border-border bg-card px-3 py-2 text-label text-ink-2 shadow-soft hover:bg-card-hover disabled:opacity-60"
                       >
                         개별 등록
-                      </Link>
+                      </OrderPurchaseButton>
                     </div>
                   </div>
                 </li>
@@ -114,6 +119,50 @@ export default function InventoryOrdersPage(): React.ReactElement {
         ))}
       </div>
     </section>
+  );
+}
+
+function OrderPurchaseButton({
+  items,
+  vendorId,
+  className,
+  children,
+}: {
+  items: readonly IngredientForecastView[];
+  vendorId: string | null;
+  className: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const router = useRouter();
+  const snapshot = useOrderRecommendationSnapshot();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleClick(): Promise<void> {
+    setErrorMessage(null);
+    try {
+      const snapshotId = await snapshot.mutateAsync({ vendorId, items });
+      router.push(buildPurchaseHref(items, vendorId, snapshotId));
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "발주 추천 저장에 실패했어요.");
+    }
+  }
+
+  return (
+    <span className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={() => void handleClick()}
+        disabled={snapshot.isPending}
+        className={className}
+      >
+        {snapshot.isPending ? "저장 중..." : children}
+      </button>
+      {errorMessage && (
+        <span role="alert" className="text-caption text-red-deep">
+          {errorMessage}
+        </span>
+      )}
+    </span>
   );
 }
 
@@ -143,9 +192,11 @@ function groupByVendor(items: readonly IngredientForecastView[]): OrderGroup[] {
 function buildPurchaseHref(
   items: readonly IngredientForecastView[],
   vendorId: string | null,
+  snapshotId?: string,
 ): string {
   const params = new URLSearchParams();
   if (vendorId) params.set("vendorId", vendorId);
+  if (snapshotId) params.set("snapshotId", snapshotId);
   for (const item of items) {
     const quantity = Math.ceil(item.purchaseRecommendation?.recommendedOrderQuantity ?? 0);
     if (quantity > 0) params.append("item", `${item.ingredientId}:${quantity}`);

--- a/src/features/inventory/hooks/useOrderRecommendationSnapshot.ts
+++ b/src/features/inventory/hooks/useOrderRecommendationSnapshot.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { localIsoDate } from "@/lib/utils/format";
+import {
+  saveOrderRecommendationSnapshot,
+  type SaveOrderRecommendationSnapshotInput,
+} from "@/lib/supabase/rpc";
+import type { IngredientForecastView } from "@/lib/application/inventory";
+
+interface SaveOrderRecommendationSnapshotVariables {
+  vendorId: string | null;
+  items: readonly IngredientForecastView[];
+}
+
+function toSnapshotInput(
+  variables: SaveOrderRecommendationSnapshotVariables,
+): SaveOrderRecommendationSnapshotInput {
+  return {
+    vendorId: variables.vendorId,
+    source: "inventory_orders",
+    items: variables.items.flatMap((item) => {
+      const recommendation = item.purchaseRecommendation;
+      if (!recommendation?.isOrderRecommended) return [];
+      return [
+        {
+          ingredientId: item.ingredientId,
+          recommendedQuantity: Math.ceil(recommendation.recommendedOrderQuantity),
+          currentStock: item.currentStock,
+          expectedDepletionDate: item.expectedDepletionDate
+            ? localIsoDate(item.expectedDepletionDate)
+            : null,
+          orderByDate: recommendation.orderByDate ? localIsoDate(recommendation.orderByDate) : null,
+          leadTimeDays: item.leadTimeDays,
+          safetyBufferDays: item.safetyBufferDays,
+          purchaseCoverageDays: recommendation.targetCoverageDays,
+        },
+      ];
+    }),
+  };
+}
+
+async function saveSnapshot(variables: SaveOrderRecommendationSnapshotVariables): Promise<string> {
+  const supabase = createClient();
+  const { data, error } = await saveOrderRecommendationSnapshot(
+    supabase,
+    toSnapshotInput(variables),
+  );
+  if (error) throw new Error(error.message);
+  const snapshotId = data?.[0]?.snapshot_id;
+  if (!snapshotId) throw new Error("발주 추천 스냅샷 저장 결과가 비어 있습니다.");
+  return snapshotId;
+}
+
+export function useOrderRecommendationSnapshot(): UseMutationResult<
+  string,
+  Error,
+  SaveOrderRecommendationSnapshotVariables
+> {
+  return useMutation({ mutationFn: saveSnapshot });
+}

--- a/src/features/purchase/components/PurchaseForm.tsx
+++ b/src/features/purchase/components/PurchaseForm.tsx
@@ -24,6 +24,7 @@ export function PurchaseForm(): React.ReactElement {
   const searchParams = useSearchParams();
   const prefilledItems = getPrefilledPurchaseItems(searchParams);
   const prefilledVendorId = searchParams.get("vendorId") ?? "";
+  const recommendationSnapshotId = searchParams.get("snapshotId");
   const { data: vendors } = useVendors();
   const { data: ingredients } = useIngredients();
   const { data: isFirstPurchase } = useIsFirstPurchase();
@@ -54,7 +55,7 @@ export function PurchaseForm(): React.ReactElement {
   function onSubmit(values: SavePurchaseInput): void {
     setSavedAlerts(null);
     submit.mutate(
-      { ...values, isFirstPurchase: isFirstPurchase ?? false },
+      { ...values, isFirstPurchase: isFirstPurchase ?? false, recommendationSnapshotId },
       {
         onSuccess: (result) => {
           setSavedAlerts(result.priceChangeAlerts);

--- a/src/features/purchase/hooks/usePurchaseSubmit.ts
+++ b/src/features/purchase/hooks/usePurchaseSubmit.ts
@@ -4,7 +4,10 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { submitPurchase, type SubmitPurchaseInput } from "@/lib/application/purchase";
-import type { SavePurchaseResult } from "@/lib/supabase/rpc";
+import {
+  linkOrderRecommendationSnapshotPurchase,
+  type SavePurchaseResult,
+} from "@/lib/supabase/rpc";
 import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import { todayDashboardQueryKey } from "@/features/dashboard/hooks/useTodayDashboard";
@@ -13,6 +16,7 @@ import type { SavePurchaseInput } from "../schemas";
 
 interface SubmitVariables extends SavePurchaseInput {
   isFirstPurchase: boolean;
+  recommendationSnapshotId?: string | null;
 }
 
 async function submit(input: SubmitVariables): Promise<SavePurchaseResult> {
@@ -22,7 +26,14 @@ async function submit(input: SubmitVariables): Promise<SavePurchaseResult> {
     purchasedAt: input.purchasedAt,
     items: input.items,
   };
-  return submitPurchase(supabase, payload);
+  const result = await submitPurchase(supabase, payload);
+  if (input.recommendationSnapshotId) {
+    await linkOrderRecommendationSnapshotPurchase(supabase, {
+      snapshotId: input.recommendationSnapshotId,
+      purchaseOrderId: result.purchaseOrderId,
+    });
+  }
+  return result;
 }
 
 export function usePurchaseSubmit(): UseMutationResult<SavePurchaseResult, Error, SubmitVariables> {

--- a/src/lib/supabase/rpc.ts
+++ b/src/lib/supabase/rpc.ts
@@ -234,6 +234,21 @@ interface SavePurchaseArgs {
   items: ReadonlyArray<{ ingredientId: string; quantity: number; amount: number }>;
 }
 
+export interface SaveOrderRecommendationSnapshotInput {
+  vendorId?: string | null;
+  source: string;
+  items: ReadonlyArray<{
+    ingredientId: string;
+    recommendedQuantity: number;
+    currentStock: number;
+    expectedDepletionDate?: string | null;
+    orderByDate?: string | null;
+    leadTimeDays: number;
+    safetyBufferDays: number;
+    purchaseCoverageDays: number;
+  }>;
+}
+
 export interface PriceChangeAlert {
   ingredientId: string;
   ingredientName: string;
@@ -481,4 +496,34 @@ export function savePurchase(
       })),
     }),
   );
+}
+
+export function saveOrderRecommendationSnapshot(
+  client: ClientLike,
+  args: SaveOrderRecommendationSnapshotInput,
+): Promise<RpcResult<Array<{ snapshot_id: string }>>> {
+  return callRpc(client, "save_order_recommendation_snapshot", {
+    p_vendor_id: args.vendorId ?? null,
+    p_source: args.source,
+    p_items: args.items.map((item) => ({
+      ingredient_id: item.ingredientId,
+      recommended_quantity: item.recommendedQuantity,
+      current_stock: item.currentStock,
+      expected_depletion_date: item.expectedDepletionDate ?? null,
+      order_by_date: item.orderByDate ?? null,
+      lead_time_days: item.leadTimeDays,
+      safety_buffer_days: item.safetyBufferDays,
+      purchase_coverage_days: item.purchaseCoverageDays,
+    })),
+  });
+}
+
+export function linkOrderRecommendationSnapshotPurchase(
+  client: ClientLike,
+  args: { snapshotId: string; purchaseOrderId: string },
+): Promise<RpcResult<Array<{ snapshot_id: string; purchase_order_id: string }>>> {
+  return callRpc(client, "link_order_recommendation_snapshot_purchase", {
+    p_snapshot_id: args.snapshotId,
+    p_purchase_order_id: args.purchaseOrderId,
+  });
 }

--- a/supabase/migrations/048_order_recommendation_snapshots.sql
+++ b/supabase/migrations/048_order_recommendation_snapshots.sql
@@ -1,0 +1,179 @@
+-- Migration: 발주 추천 스냅샷 저장
+-- 추천 당시의 수량/재고/소진일을 저장해 추후 과잉/부족 발주 리포트의 기준 데이터로 사용.
+
+create table if not exists public.order_recommendation_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  vendor_id uuid references public.vendors(id) on delete set null,
+  source text not null default 'inventory_orders',
+  purchase_order_id uuid references public.purchase_orders(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.order_recommendation_snapshot_items (
+  id uuid primary key default gen_random_uuid(),
+  snapshot_id uuid not null references public.order_recommendation_snapshots(id) on delete cascade,
+  user_id uuid not null references public.users(id) on delete cascade,
+  ingredient_id uuid not null references public.ingredients(id) on delete cascade,
+  recommended_quantity numeric not null,
+  current_stock numeric not null,
+  expected_depletion_date date,
+  order_by_date date,
+  lead_time_days integer not null,
+  safety_buffer_days integer not null,
+  purchase_coverage_days integer not null,
+  created_at timestamptz not null default now(),
+  constraint order_recommendation_snapshot_items_quantity_check
+    check (recommended_quantity > 0),
+  constraint order_recommendation_snapshot_items_stock_check
+    check (current_stock >= 0),
+  constraint order_recommendation_snapshot_items_days_check
+    check (lead_time_days >= 0 and safety_buffer_days >= 0 and purchase_coverage_days >= 1)
+);
+
+create index if not exists order_recommendation_snapshots_user_created_idx
+  on public.order_recommendation_snapshots(user_id, created_at desc);
+
+create index if not exists order_recommendation_snapshot_items_snapshot_idx
+  on public.order_recommendation_snapshot_items(snapshot_id);
+
+alter table public.order_recommendation_snapshots enable row level security;
+alter table public.order_recommendation_snapshot_items enable row level security;
+
+drop policy if exists order_recommendation_snapshots_owner_select on public.order_recommendation_snapshots;
+create policy order_recommendation_snapshots_owner_select
+on public.order_recommendation_snapshots
+for select
+using (user_id = auth.uid());
+
+drop policy if exists order_recommendation_snapshot_items_owner_select on public.order_recommendation_snapshot_items;
+create policy order_recommendation_snapshot_items_owner_select
+on public.order_recommendation_snapshot_items
+for select
+using (user_id = auth.uid());
+
+create or replace function public.save_order_recommendation_snapshot(
+  p_vendor_id uuid,
+  p_source text,
+  p_items jsonb
+)
+returns table (
+  snapshot_id uuid
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_snapshot_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if p_vendor_id is not null and not exists (
+    select 1 from public.vendors v where v.id = p_vendor_id and v.user_id = v_user_id
+  ) then
+    raise exception 'vendor_not_found' using errcode = 'P0002';
+  end if;
+
+  if p_items is null or jsonb_typeof(p_items) <> 'array' or jsonb_array_length(p_items) = 0 then
+    raise exception 'empty_order_recommendation_items' using errcode = '22023';
+  end if;
+
+  insert into public.order_recommendation_snapshots (user_id, vendor_id, source)
+  values (v_user_id, p_vendor_id, coalesce(nullif(p_source, ''), 'inventory_orders'))
+  returning id into v_snapshot_id;
+
+  insert into public.order_recommendation_snapshot_items (
+    snapshot_id,
+    user_id,
+    ingredient_id,
+    recommended_quantity,
+    current_stock,
+    expected_depletion_date,
+    order_by_date,
+    lead_time_days,
+    safety_buffer_days,
+    purchase_coverage_days
+  )
+  select
+    v_snapshot_id,
+    v_user_id,
+    (item ->> 'ingredient_id')::uuid,
+    (item ->> 'recommended_quantity')::numeric,
+    (item ->> 'current_stock')::numeric,
+    nullif(item ->> 'expected_depletion_date', '')::date,
+    nullif(item ->> 'order_by_date', '')::date,
+    (item ->> 'lead_time_days')::integer,
+    (item ->> 'safety_buffer_days')::integer,
+    (item ->> 'purchase_coverage_days')::integer
+  from jsonb_array_elements(p_items) as item
+  join public.ingredients i
+    on i.id = (item ->> 'ingredient_id')::uuid
+   and i.user_id = v_user_id
+   and i.is_active = true;
+
+  if not exists (
+    select 1
+    from public.order_recommendation_snapshot_items si
+    where si.snapshot_id = v_snapshot_id
+  ) then
+    raise exception 'no_valid_order_recommendation_items' using errcode = '22023';
+  end if;
+
+  return query select v_snapshot_id;
+end;
+$$;
+
+create or replace function public.link_order_recommendation_snapshot_purchase(
+  p_snapshot_id uuid,
+  p_purchase_order_id uuid
+)
+returns table (
+  snapshot_id uuid,
+  purchase_order_id uuid
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if p_snapshot_id is null then
+    raise exception 'snapshot_id_required' using errcode = '22023';
+  end if;
+
+  if not exists (
+    select 1
+    from public.purchase_orders po
+    where po.id = p_purchase_order_id
+      and po.user_id = v_user_id
+  ) then
+    raise exception 'purchase_order_not_found' using errcode = 'P0002';
+  end if;
+
+  update public.order_recommendation_snapshots s
+  set purchase_order_id = p_purchase_order_id
+  where s.id = p_snapshot_id
+    and s.user_id = v_user_id;
+
+  if not found then
+    raise exception 'snapshot_not_found' using errcode = 'P0002';
+  end if;
+
+  return query select p_snapshot_id, p_purchase_order_id;
+end;
+$$;
+
+revoke all on function public.save_order_recommendation_snapshot(uuid, text, jsonb) from public;
+grant execute on function public.save_order_recommendation_snapshot(uuid, text, jsonb) to authenticated;
+
+revoke all on function public.link_order_recommendation_snapshot_purchase(uuid, uuid) from public;
+grant execute on function public.link_order_recommendation_snapshot_purchase(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary
- Add order recommendation snapshot tables and RPCs for future purchase recommendation reporting
- Save a snapshot when users start purchase registration from /inventory/orders
- Pass snapshotId into purchase form and link it to the saved purchase order
- Keep purchase save non-blocking if snapshot linkage fails after the purchase is saved

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- npm run test:coverage

## Notes
- Includes Supabase migration 048_order_recommendation_snapshots.sql