### PR TITLE
Add order recommendation report

### DIFF
--- a/src/app/(main)/inventory/orders/page.tsx
+++ b/src/app/(main)/inventory/orders/page.tsx
@@ -32,6 +32,9 @@ export default function InventoryOrdersPage(): React.ReactElement {
         title="오늘 주문할 것"
         action={
           <div className="flex gap-stack-tight">
+            <Link href="/inventory/orders/report" className={SECONDARY_BUTTON_CLASSES}>
+              이력
+            </Link>
             <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
               재료 예측
             </Link>

--- a/src/app/(main)/inventory/orders/report/page.tsx
+++ b/src/app/(main)/inventory/orders/report/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import Link from "next/link";
+import { differenceInCalendarDays } from "date-fns";
+import { PageHeader } from "@/components/ui/page-header";
+import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
+import { useOrderRecommendationReport } from "@/features/inventory/hooks/useOrderRecommendationReport";
+import { formatDateKoFromIso, formatNumber, localIsoDate } from "@/lib/utils/format";
+import type { OrderRecommendationReportData } from "@/lib/supabase/rpc";
+
+type Snapshot = OrderRecommendationReportData["snapshots"][number];
+
+export default function OrderRecommendationReportPage(): React.ReactElement {
+  const query = useOrderRecommendationReport();
+  const report = query.data;
+
+  return (
+    <section className="flex flex-col gap-section">
+      <PageHeader
+        title="발주 추천 이력"
+        action={
+          <div className="flex gap-stack-tight">
+            <Link href="/inventory/orders" className={SECONDARY_BUTTON_CLASSES}>
+              오늘 주문할 것
+            </Link>
+            <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
+              재료 예측
+            </Link>
+          </div>
+        }
+      />
+
+      <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
+        <p className="text-body text-ink-1">
+          최근 발주 추천이 실제 매입으로 이어졌는지 확인합니다.
+        </p>
+        <p className="mt-1 text-caption text-ink-3">
+          과잉/부족 발주 분석은 이 이력이 쌓인 뒤 다음 단계에서 계산합니다.
+        </p>
+      </section>
+
+      {query.isLoading && <LoadingText />}
+      {query.error && <ErrorAlert message={query.error.message} />}
+
+      {report && (
+        <>
+          <SummaryCards summary={report.summary} />
+          {report.snapshots.length === 0 ? (
+            <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
+              아직 저장된 발주 추천 이력이 없습니다.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-stack">
+              {report.snapshots.map((snapshot) => (
+                <SnapshotCard key={snapshot.snapshotId} snapshot={snapshot} />
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function SummaryCards({
+  summary,
+}: {
+  summary: OrderRecommendationReportData["summary"];
+}): React.ReactElement {
+  return (
+    <div className="grid gap-stack-tight md:grid-cols-3">
+      <SummaryCard label="최근 추천" value={`${summary.snapshotCount}건`} />
+      <SummaryCard label="매입 완료" value={`${summary.convertedCount}건`} tone="green" />
+      <SummaryCard label="매입 전" value={`${summary.pendingCount}건`} tone="amber" />
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  tone = "blue",
+}: {
+  label: string;
+  value: string;
+  tone?: "blue" | "green" | "amber";
+}): React.ReactElement {
+  const toneClass =
+    tone === "green"
+      ? "bg-green-soft text-green"
+      : tone === "amber"
+        ? "bg-amber-soft text-amber-deep"
+        : "bg-blue-soft text-blue-deep";
+  return (
+    <div className={`rounded-[24px] border border-border px-5 py-4 shadow-soft ${toneClass}`}>
+      <p className="text-caption opacity-80">{label}</p>
+      <p className="mt-1 text-title-md">{value}</p>
+    </div>
+  );
+}
+
+function SnapshotCard({ snapshot }: { snapshot: Snapshot }): React.ReactElement {
+  const isConverted = Boolean(snapshot.purchaseOrderId);
+  return (
+    <li className="glow-panel rounded-[28px] border border-border bg-card p-5 shadow-card">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-micro uppercase tracking-[0.14em] text-blue-deep">
+            {snapshot.vendorName ?? "거래처 미지정"}
+          </p>
+          <h2 className="mt-1 text-title-md text-ink-1">
+            {formatDateTime(snapshot.createdAt)} 추천
+          </h2>
+          <p className="mt-1 text-caption text-ink-3">
+            {snapshot.items.length}개 재료 · {elapsedLabel(snapshot.createdAt)}
+          </p>
+        </div>
+        <span
+          className={
+            isConverted
+              ? "rounded-full bg-green-soft px-3 py-1.5 text-caption font-semibold text-green"
+              : "rounded-full bg-amber-soft px-3 py-1.5 text-caption font-semibold text-amber-deep"
+          }
+        >
+          {isConverted
+            ? `매입 완료${snapshot.purchasedAt ? ` · ${formatDateKoFromIso(snapshot.purchasedAt)}` : ""}`
+            : "매입 전"}
+        </span>
+      </div>
+
+      <ul className="mt-stack flex flex-col gap-2">
+        {snapshot.items.map((item) => (
+          <li
+            key={`${snapshot.snapshotId}-${item.ingredientId}`}
+            className="rounded-2xl border border-border bg-bg px-4 py-3"
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-body text-ink-1">{item.ingredientName}</p>
+                <p className="text-caption text-ink-3">
+                  당시 재고 {formatNumber(item.currentStock)}
+                  {item.unit} · {depletionLabel(item.expectedDepletionDate)} ·{" "}
+                  {orderByLabel(item.orderByDate)}
+                </p>
+              </div>
+              <span className="rounded-full bg-blue-soft px-3 py-1.5 text-caption font-semibold text-blue-deep">
+                추천 {formatNumber(item.recommendedQuantity)}
+                {item.unit}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return `${formatDateKoFromIso(localIsoDate(date))} ${String(date.getHours()).padStart(
+    2,
+    "0",
+  )}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+function elapsedLabel(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "시점 확인 불가";
+  const days = Math.max(0, differenceInCalendarDays(new Date(), date));
+  if (days === 0) return "오늘 추천";
+  if (days === 1) return "어제 추천";
+  return `${days}일 전 추천`;
+}
+
+function depletionLabel(value: string | null): string {
+  if (!value) return "소진일 미정";
+  return `${formatDateKoFromIso(value)} 소진 예상`;
+}
+
+function orderByLabel(value: string | null): string {
+  if (!value) return "발주일 미정";
+  return `${formatDateKoFromIso(value)}까지`;
+}

--- a/src/features/inventory/hooks/useOrderRecommendationReport.ts
+++ b/src/features/inventory/hooks/useOrderRecommendationReport.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import {
+  getOrderRecommendationReport,
+  type OrderRecommendationReportData,
+} from "@/lib/supabase/rpc";
+
+export const orderRecommendationReportQueryKey = ["inventory", "order-report"] as const;
+
+async function fetchOrderRecommendationReport(): Promise<OrderRecommendationReportData> {
+  const supabase = createClient();
+  const { data, error } = await getOrderRecommendationReport(supabase, 30);
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("발주 추천 리포트 데이터가 비어 있습니다.");
+  return data;
+}
+
+export function useOrderRecommendationReport(): UseQueryResult<OrderRecommendationReportData> {
+  return useQuery({
+    queryKey: orderRecommendationReportQueryKey,
+    queryFn: fetchOrderRecommendationReport,
+    staleTime: 60 * 1000,
+  });
+}

--- a/src/lib/supabase/rpc-queries.ts
+++ b/src/lib/supabase/rpc-queries.ts
@@ -40,6 +40,35 @@ export interface MenuDemandForecastRow {
   regularDaysOff: ReadonlyArray<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
 }
 
+export interface OrderRecommendationReportData {
+  summary: {
+    snapshotCount: number;
+    convertedCount: number;
+    pendingCount: number;
+  };
+  snapshots: Array<{
+    snapshotId: string;
+    vendorId: string | null;
+    vendorName: string | null;
+    source: string;
+    purchaseOrderId: string | null;
+    purchasedAt: string | null;
+    createdAt: string;
+    items: Array<{
+      ingredientId: string;
+      ingredientName: string;
+      unit: "g" | "ml" | "piece";
+      recommendedQuantity: number;
+      currentStock: number;
+      expectedDepletionDate: string | null;
+      orderByDate: string | null;
+      leadTimeDays: number;
+      safetyBufferDays: number;
+      purchaseCoverageDays: number;
+    }>;
+  }>;
+}
+
 interface DepletionForecastRawRow {
   ingredient_id: string;
   name: string;
@@ -78,6 +107,35 @@ interface MenuDemandForecastRawRow {
   demand_samples: Array<{ date: string; quantity: number }>;
   signed_up_at: string;
   regular_days_off: Array<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
+}
+
+interface OrderRecommendationReportRaw {
+  summary?: {
+    snapshot_count?: number;
+    converted_count?: number;
+    pending_count?: number;
+  };
+  snapshots?: Array<{
+    snapshot_id: string;
+    vendor_id: string | null;
+    vendor_name: string | null;
+    source: string;
+    purchase_order_id: string | null;
+    purchased_at: string | null;
+    created_at: string;
+    items?: Array<{
+      ingredient_id: string;
+      ingredient_name: string;
+      unit: "g" | "ml" | "piece";
+      recommended_quantity: number;
+      current_stock: number;
+      expected_depletion_date: string | null;
+      order_by_date: string | null;
+      lead_time_days: number;
+      safety_buffer_days: number;
+      purchase_coverage_days: number;
+    }>;
+  }>;
 }
 
 export interface CalendarCumulative {
@@ -363,4 +421,43 @@ export async function getMenuDemandForecast(
     })),
     error: null,
   };
+}
+
+export function getOrderRecommendationReport(
+  client: ClientLike,
+  limit = 30,
+): Promise<RpcResult<OrderRecommendationReportData>> {
+  return callRpcMapped<OrderRecommendationReportRaw, OrderRecommendationReportData>(
+    client,
+    "get_order_recommendation_report",
+    { p_limit: limit },
+    (raw) => ({
+      summary: {
+        snapshotCount: Number(raw.summary?.snapshot_count ?? 0),
+        convertedCount: Number(raw.summary?.converted_count ?? 0),
+        pendingCount: Number(raw.summary?.pending_count ?? 0),
+      },
+      snapshots: (raw.snapshots ?? []).map((snapshot) => ({
+        snapshotId: snapshot.snapshot_id,
+        vendorId: snapshot.vendor_id,
+        vendorName: snapshot.vendor_name,
+        source: snapshot.source,
+        purchaseOrderId: snapshot.purchase_order_id,
+        purchasedAt: snapshot.purchased_at,
+        createdAt: snapshot.created_at,
+        items: (snapshot.items ?? []).map((item) => ({
+          ingredientId: item.ingredient_id,
+          ingredientName: item.ingredient_name,
+          unit: item.unit,
+          recommendedQuantity: numeric(item.recommended_quantity),
+          currentStock: numeric(item.current_stock),
+          expectedDepletionDate: item.expected_depletion_date,
+          orderByDate: item.order_by_date,
+          leadTimeDays: Number(item.lead_time_days),
+          safetyBufferDays: Number(item.safety_buffer_days),
+          purchaseCoverageDays: Number(item.purchase_coverage_days),
+        })),
+      })),
+    }),
+  );
 }

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -784,6 +784,10 @@ export type Database = {
           signed_up_at: string
         }[]
       }
+      get_order_recommendation_report: {
+        Args: { p_limit?: number }
+        Returns: Json
+      }
       get_today_dashboard: { Args: never; Returns: Json }
       request_withdrawal: {
         Args: never

--- a/supabase/migrations/049_order_recommendation_report_rpc.sql
+++ b/supabase/migrations/049_order_recommendation_report_rpc.sql
@@ -1,0 +1,133 @@
+-- Migration: 발주 추천 이력 리포트 RPC
+-- 최근 추천 스냅샷과 매입 전환 여부를 화면용 JSON으로 반환.
+
+create or replace function public.get_order_recommendation_report(p_limit integer default 30)
+returns jsonb
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_limit, 30), 100));
+  v_result jsonb;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  with recent_snapshots as (
+    select
+      s.id,
+      s.vendor_id,
+      v.name as vendor_name,
+      s.source,
+      s.purchase_order_id,
+      po.purchased_at,
+      s.created_at
+    from public.order_recommendation_snapshots s
+    left join public.vendors v
+      on v.id = s.vendor_id
+     and v.user_id = v_user_id
+    left join public.purchase_orders po
+      on po.id = s.purchase_order_id
+     and po.user_id = v_user_id
+    where s.user_id = v_user_id
+    order by s.created_at desc
+    limit v_limit
+  ),
+  snapshot_rows as (
+    select
+      s.id,
+      s.vendor_id,
+      s.vendor_name,
+      s.source,
+      s.purchase_order_id,
+      s.purchased_at,
+      s.created_at,
+      coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'ingredient_id', i.id,
+            'ingredient_name', i.name,
+            'unit', i.unit,
+            'recommended_quantity', si.recommended_quantity,
+            'current_stock', si.current_stock,
+            'expected_depletion_date', si.expected_depletion_date,
+            'order_by_date', si.order_by_date,
+            'lead_time_days', si.lead_time_days,
+            'safety_buffer_days', si.safety_buffer_days,
+            'purchase_coverage_days', si.purchase_coverage_days
+          )
+          order by i.name
+        ) filter (where si.id is not null),
+        '[]'::jsonb
+      ) as items
+    from recent_snapshots s
+    left join public.order_recommendation_snapshot_items si
+      on si.snapshot_id = s.id
+     and si.user_id = v_user_id
+    left join public.ingredients i
+      on i.id = si.ingredient_id
+     and i.user_id = v_user_id
+    group by
+      s.id,
+      s.vendor_id,
+      s.vendor_name,
+      s.source,
+      s.purchase_order_id,
+      s.purchased_at,
+      s.created_at
+  ),
+  summary as (
+    select
+      count(*)::integer as snapshot_count,
+      count(*) filter (where purchase_order_id is not null)::integer as converted_count,
+      count(*) filter (where purchase_order_id is null)::integer as pending_count
+    from snapshot_rows
+  )
+  select jsonb_build_object(
+    'summary', jsonb_build_object(
+      'snapshot_count', summary.snapshot_count,
+      'converted_count', summary.converted_count,
+      'pending_count', summary.pending_count
+    ),
+    'snapshots', coalesce(
+      jsonb_agg(
+        jsonb_build_object(
+          'snapshot_id', sr.id,
+          'vendor_id', sr.vendor_id,
+          'vendor_name', sr.vendor_name,
+          'source', sr.source,
+          'purchase_order_id', sr.purchase_order_id,
+          'purchased_at', sr.purchased_at,
+          'created_at', sr.created_at,
+          'items', sr.items
+        )
+        order by sr.created_at desc
+      ) filter (where sr.id is not null),
+      '[]'::jsonb
+    )
+  )
+  into v_result
+  from summary
+  left join snapshot_rows sr on true
+  group by summary.snapshot_count, summary.converted_count, summary.pending_count;
+
+  return coalesce(
+    v_result,
+    jsonb_build_object(
+      'summary', jsonb_build_object(
+        'snapshot_count', 0,
+        'converted_count', 0,
+        'pending_count', 0
+      ),
+      'snapshots', '[]'::jsonb
+    )
+  );
+end;
+$$;
+
+revoke all on function public.get_order_recommendation_report(integer) from public;
+grant execute on function public.get_order_recommendation_report(integer) to authenticated;


### PR DESCRIPTION
## Summary
- Add get_order_recommendation_report RPC for recent order recommendation snapshots
- Add /inventory/orders/report page with summary cards and snapshot details
- Link the order recommendation page to the report

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- npm run test:coverage

## Notes
- Includes Supabase migration 049_order_recommendation_report_rpc.sql