### PR TITLE
Surface forecast accuracy actions

### DIFF
--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
+import { useIngredientForecastAccuracy } from "@/features/inventory/hooks/useIngredientForecastAccuracy";
 import { IngredientStatusList } from "@/features/inventory/components/IngredientStatusList";
 import { ColdStartNotice } from "@/features/inventory/components/ColdStartNotice";
 import { AddIngredientForm } from "@/features/inventory/components/AddIngredientForm";
@@ -12,6 +13,7 @@ import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
 export default function InventoryPage(): React.ReactElement {
   const { data, isLoading, error } = useDepletionForecast();
+  const accuracyQuery = useIngredientForecastAccuracy(14);
   const [isAddOpen, setIsAddOpen] = useState(false);
 
   const isAllColdStart = (data ?? []).length > 0 && (data ?? []).every((d) => d.isColdStart);
@@ -56,7 +58,7 @@ export default function InventoryPage(): React.ReactElement {
 
       {isAllColdStart && <ColdStartNotice />}
 
-      {data && <IngredientStatusList items={data} />}
+      {data && <IngredientStatusList items={data} accuracyItems={accuracyQuery.data ?? []} />}
     </section>
   );
 }

--- a/src/features/inventory/components/IngredientForecastAccuracyList.tsx
+++ b/src/features/inventory/components/IngredientForecastAccuracyList.tsx
@@ -37,6 +37,8 @@ export function IngredientForecastAccuracyList({
         <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
       </section>
 
+      <PriorityNotice item={summary.priorityItem} />
+
       <div className="flex flex-col gap-stack">
         {items.map((item) => (
           <IngredientForecastAccuracyCard key={item.ingredientId} item={item} />
@@ -86,6 +88,8 @@ function IngredientForecastAccuracyCard({
         />
         <Metric label="비교일" value={`${item.evaluatedDayCount}일`} />
       </dl>
+
+      <TuningHint item={item} />
 
       <ol className="mt-stack grid grid-cols-7 gap-1.5">
         {item.dailyResults.slice(-7).map((day) => (
@@ -152,10 +156,36 @@ function BiasBadge({ bias }: { bias: IngredientForecastAccuracyView["bias"] }): 
   );
 }
 
+function PriorityNotice({
+  item,
+}: {
+  item: IngredientForecastAccuracyView | null;
+}): React.ReactElement | null {
+  if (!item || item.meanAbsolutePercentageError === null) return null;
+
+  return (
+    <section className="rounded-[24px] border border-amber/30 bg-amber-soft px-4 py-3 shadow-soft">
+      <p className="text-body text-amber-deep">
+        우선 확인: {item.name} · 오차율 {formatPercent(item.meanAbsolutePercentageError)}
+      </p>
+      <p className="mt-1 text-caption text-ink-3">{buildTuningHint(item)}</p>
+    </section>
+  );
+}
+
+function TuningHint({ item }: { item: IngredientForecastAccuracyView }): React.ReactElement {
+  return (
+    <p className="mt-stack rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
+      {buildTuningHint(item)}
+    </p>
+  );
+}
+
 function buildSummary(items: readonly IngredientForecastAccuracyView[]): {
   meanMape: number | null;
   overCount: number;
   underCount: number;
+  priorityItem: IngredientForecastAccuracyView | null;
 } {
   const valid = items.filter((item) => item.meanAbsolutePercentageError !== null);
   return {
@@ -166,7 +196,26 @@ function buildSummary(items: readonly IngredientForecastAccuracyView[]): {
         : null,
     overCount: items.filter((item) => item.bias === "over").length,
     underCount: items.filter((item) => item.bias === "under").length,
+    priorityItem:
+      valid.length > 0
+        ? ([...valid].sort(
+            (a, b) => (b.meanAbsolutePercentageError ?? 0) - (a.meanAbsolutePercentageError ?? 0),
+          )[0] ?? null)
+        : null,
   };
+}
+
+function buildTuningHint(item: IngredientForecastAccuracyView): string {
+  if (item.evaluatedDayCount < 3)
+    return "소비 비교일이 적습니다. 판매 데이터가 더 쌓인 뒤 판단하세요.";
+  if (item.bias === "under")
+    return "실제 소비가 예측보다 큽니다. 발주량 부족 위험을 먼저 확인하세요.";
+  if (item.bias === "over")
+    return "예측 소비가 실제보다 큽니다. 과발주 가능성이 있어 최근 판매 둔화를 확인하세요.";
+  if ((item.meanAbsolutePercentageError ?? 0) >= 0.5) {
+    return "오차율이 큽니다. 옵션 선택률, 레시피 변경, 주말/평일 편차를 확인하세요.";
+  }
+  return "예측 방향은 안정적입니다. 현재 발주 추천을 그대로 참고해도 됩니다.";
 }
 
 function barHeight(value: number, maxAmount: number): number {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -6,9 +6,11 @@ import { daysUntilDate, formatDateKoFromIso, formatNumber, localIsoDate } from "
 import type { DepletionStatus } from "@/lib/domain/forecast";
 import { useDeleteIngredient } from "@/features/purchase/hooks/useIngredients";
 import type { IngredientForecastView } from "../hooks/useDepletionForecast";
+import type { IngredientForecastAccuracyView } from "../hooks/useIngredientForecastAccuracy";
 
 interface IngredientStatusListProps {
   items: readonly IngredientForecastView[];
+  accuracyItems?: readonly IngredientForecastAccuracyView[];
 }
 
 const STATUS_GROUP_ORDER: readonly DepletionStatus[] = [
@@ -25,7 +27,10 @@ const STATUS_LABEL: Record<DepletionStatus, string> = {
   safe: "🟢 안전",
 };
 
-export function IngredientStatusList({ items }: IngredientStatusListProps): React.ReactElement {
+export function IngredientStatusList({
+  items,
+  accuracyItems = [],
+}: IngredientStatusListProps): React.ReactElement {
   if (items.length === 0) {
     return (
       <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
@@ -35,6 +40,9 @@ export function IngredientStatusList({ items }: IngredientStatusListProps): Reac
   }
 
   const grouped = new Map<DepletionStatus, IngredientForecastView[]>();
+  const accuracyByIngredient = new Map(
+    accuracyItems.map((accuracy) => [accuracy.ingredientId, accuracy]),
+  );
   for (const item of items) {
     const list = grouped.get(item.status) ?? [];
     list.push(item);
@@ -56,7 +64,11 @@ export function IngredientStatusList({ items }: IngredientStatusListProps): Reac
             </div>
             <ul className="flex flex-col gap-stack-tight">
               {list.map((item) => (
-                <IngredientRow key={item.ingredientId} item={item} />
+                <IngredientRow
+                  key={item.ingredientId}
+                  item={item}
+                  accuracy={accuracyByIngredient.get(item.ingredientId)}
+                />
               ))}
             </ul>
           </section>
@@ -66,7 +78,13 @@ export function IngredientStatusList({ items }: IngredientStatusListProps): Reac
   );
 }
 
-function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactElement {
+function IngredientRow({
+  item,
+  accuracy,
+}: {
+  item: IngredientForecastView;
+  accuracy?: IngredientForecastAccuracyView;
+}): React.ReactElement {
   const depletionLabel = formatDepletion(item);
   const deleteMutation = useDeleteIngredient();
 
@@ -102,6 +120,7 @@ function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactE
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
             <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
             {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
+            {accuracy && <AccuracyRiskBadge accuracy={accuracy} />}
           </div>
           <button
             type="button"
@@ -143,6 +162,39 @@ function IngredientRow({ item }: { item: IngredientForecastView }): React.ReactE
       )}
     </li>
   );
+}
+
+function AccuracyRiskBadge({
+  accuracy,
+}: {
+  accuracy: IngredientForecastAccuracyView;
+}): React.ReactElement | null {
+  const risk = getAccuracyRisk(accuracy);
+  if (!risk) return null;
+
+  return (
+    <Link
+      href="/inventory/forecast-accuracy"
+      className={cn(
+        "rounded-full px-2 py-0.5 text-micro shadow-soft",
+        risk.tone === "red" ? "bg-red-soft text-red-deep" : "bg-amber-soft text-amber-deep",
+      )}
+    >
+      {risk.label}
+    </Link>
+  );
+}
+
+function getAccuracyRisk(accuracy: IngredientForecastAccuracyView): {
+  label: string;
+  tone: "red" | "amber";
+} | null {
+  if (accuracy.evaluatedDayCount < 3) return { label: "예측 데이터 부족", tone: "amber" };
+  const mape = accuracy.meanAbsolutePercentageError;
+  if (mape === null) return null;
+  if (mape >= 0.8) return { label: "예측 신뢰도 낮음", tone: "red" };
+  if (mape >= 0.5 || accuracy.bias === "under") return { label: "발주량 확인 필요", tone: "amber" };
+  return null;
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {

--- a/src/features/inventory/components/MenuForecastAccuracyList.tsx
+++ b/src/features/inventory/components/MenuForecastAccuracyList.tsx
@@ -36,6 +36,8 @@ export function MenuForecastAccuracyList({
         <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
       </section>
 
+      <PriorityNotice item={summary.priorityItem} />
+
       <div className="flex flex-col gap-stack">
         {items.map((item) => (
           <MenuForecastAccuracyCard key={item.menuId} item={item} />
@@ -82,6 +84,8 @@ function MenuForecastAccuracyCard({
         <Metric label="평균 오차" value={formatNullableQuantity(item.averageAbsoluteError)} />
         <Metric label="비교일" value={`${item.evaluatedDayCount}일`} />
       </dl>
+
+      <TuningHint item={item} />
 
       <ol className="mt-stack grid grid-cols-7 gap-1.5">
         {item.dailyResults.slice(-7).map((day) => (
@@ -148,10 +152,36 @@ function BiasBadge({ bias }: { bias: MenuForecastAccuracyView["bias"] }): React.
   );
 }
 
+function PriorityNotice({
+  item,
+}: {
+  item: MenuForecastAccuracyView | null;
+}): React.ReactElement | null {
+  if (!item || item.meanAbsolutePercentageError === null) return null;
+
+  return (
+    <section className="rounded-[24px] border border-amber/30 bg-amber-soft px-4 py-3 shadow-soft">
+      <p className="text-body text-amber-deep">
+        우선 확인: {item.name} · 오차율 {formatPercent(item.meanAbsolutePercentageError)}
+      </p>
+      <p className="mt-1 text-caption text-ink-3">{buildTuningHint(item)}</p>
+    </section>
+  );
+}
+
+function TuningHint({ item }: { item: MenuForecastAccuracyView }): React.ReactElement {
+  return (
+    <p className="mt-stack rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
+      {buildTuningHint(item)}
+    </p>
+  );
+}
+
 function buildSummary(items: readonly MenuForecastAccuracyView[]): {
   meanMape: number | null;
   overCount: number;
   underCount: number;
+  priorityItem: MenuForecastAccuracyView | null;
 } {
   const valid = items.filter((item) => item.meanAbsolutePercentageError !== null);
   return {
@@ -162,7 +192,25 @@ function buildSummary(items: readonly MenuForecastAccuracyView[]): {
         : null,
     overCount: items.filter((item) => item.bias === "over").length,
     underCount: items.filter((item) => item.bias === "under").length,
+    priorityItem:
+      valid.length > 0
+        ? ([...valid].sort(
+            (a, b) => (b.meanAbsolutePercentageError ?? 0) - (a.meanAbsolutePercentageError ?? 0),
+          )[0] ?? null)
+        : null,
   };
+}
+
+function buildTuningHint(item: MenuForecastAccuracyView): string {
+  if (item.evaluatedDayCount < 3) return "판매 비교일이 적습니다. 데이터가 더 쌓인 뒤 판단하세요.";
+  if (item.bias === "under")
+    return "실제 판매가 예측보다 많습니다. 발주량 부족 위험을 먼저 확인하세요.";
+  if (item.bias === "over")
+    return "예측이 실제보다 큽니다. 과발주 가능성이 있어 최근 판매 둔화를 확인하세요.";
+  if ((item.meanAbsolutePercentageError ?? 0) >= 0.5) {
+    return "오차율이 큽니다. 주말/평일 편차나 최근 이벤트성 판매를 확인하세요.";
+  }
+  return "예측 방향은 안정적입니다. 큰 조정 없이 추이를 계속 보세요.";
 }
 
 function barHeight(value: number, maxQuantity: number): number {


### PR DESCRIPTION
## Summary
- highlight the highest-error menu and ingredient in forecast accuracy reports
- add plain Korean tuning hints for over/under forecasts, insufficient data, and large errors
- surface low-confidence ingredient forecast badges on the inventory list and link them to accuracy details

## Tests
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/application.test.ts
- npm run build