### PR TITLE
Add forecast sensitivity settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ specs/001-mvp-core/        spec.md / data-model.md / contracts / tasks.md
    - 실제 소진일 계산에도 최근 추세를 반영하되, 계수는 `0.85~1.25`로 제한합니다.
    - 그래서 날씨/이벤트로 하루 매출이 튄 경우에도 예측이 과하게 흔들리지 않습니다.
 
+7. **예측 민감도 설정**
+   - 설정 화면에서 `안정적 / 기본 / 민감` 중 하나를 선택할 수 있습니다.
+   - `안정적`은 최근 변동을 천천히 반영하고 이상치 영향을 더 줄입니다.
+   - `기본`은 최근 흐름과 장기 평균을 균형 있게 반영합니다.
+   - `민감`은 최근 판매 변화를 빠르게 반영해 날씨·이벤트 영향이 큰 매장에 맞춥니다.
+   - 실제 파라미터는 [forecast.ts](/Users/yamon/Desktop/projects/ezstock/src/lib/domain/forecast.ts)의 `FORECAST_TUNING_PRESETS`가 단일 출처입니다.
+
 중요한 구현 포인트:
 
 - 서버 RPC는 **raw 데이터만** 만들고, 최종 `status/trend/isColdStart` 분류는 클라이언트 도메인 함수에서 수행합니다.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,11 +3,13 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { STORE_TYPE_LABELS } from "@/features/auth/schemas";
 import { LogoutButton } from "@/features/settings/components/LogoutButton";
+import { ForecastSensitivityEditor } from "@/features/settings/components/ForecastSensitivityEditor";
 import { PurchaseCoverageDaysEditor } from "@/features/settings/components/PurchaseCoverageDaysEditor";
 import { RegularDaysOffEditor } from "@/features/settings/components/RegularDaysOffEditor";
 import { SafetyBufferEditor } from "@/features/settings/components/SafetyBufferEditor";
 import { StoreNameEditor } from "@/features/settings/components/StoreNameEditor";
 import { VendorLeadTimeManager } from "@/features/settings/components/VendorLeadTimeManager";
+import type { ForecastSensitivity } from "@/lib/domain/forecast";
 import type { Weekday } from "@/lib/domain/regular-days-off";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
@@ -25,7 +27,9 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
 
   const { data } = await supabase
     .from("users")
-    .select("store_name, store_type, regular_days_off, safety_buffer_days, purchase_coverage_days")
+    .select(
+      "store_name, store_type, regular_days_off, safety_buffer_days, purchase_coverage_days, forecast_sensitivity",
+    )
     .eq("id", user.id)
     .maybeSingle();
 
@@ -35,10 +39,12 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
     regular_days_off: Weekday[];
     safety_buffer_days: number;
     purchase_coverage_days: number;
+    forecast_sensitivity: ForecastSensitivity;
   } | null;
   const initialDaysOff: Weekday[] = profile?.regular_days_off ?? [];
   const safetyBufferDays = profile?.safety_buffer_days ?? 1;
   const purchaseCoverageDays = profile?.purchase_coverage_days ?? 7;
+  const forecastSensitivity = profile?.forecast_sensitivity ?? "balanced";
   const storeName = profile?.store_name ?? "내 가게";
   const storeType = profile?.store_type ?? "cafe";
 
@@ -104,6 +110,10 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
             title="발주 커버일"
             body={`현재 ${purchaseCoverageDays}일로 설정되어 있습니다. 권장 발주량은 리드타임과 안전여유 뒤에 이 기간만큼 더 팔 수 있게 계산합니다.`}
           />
+          <RuleCard
+            title="예측 민감도"
+            body={`현재 ${formatForecastSensitivity(forecastSensitivity)} 모드입니다. 최근 판매 변화를 예측에 반영하는 속도를 조정합니다.`}
+          />
         </div>
 
         <RegularDaysOffEditor initialDaysOff={initialDaysOff} />
@@ -112,6 +122,10 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
           <SafetyBufferEditor initialSafetyBufferDays={safetyBufferDays} userId={user.id} />
           <PurchaseCoverageDaysEditor
             initialPurchaseCoverageDays={purchaseCoverageDays}
+            userId={user.id}
+          />
+          <ForecastSensitivityEditor
+            initialForecastSensitivity={forecastSensitivity}
             userId={user.id}
           />
           <SettingRow
@@ -165,6 +179,12 @@ export default async function SettingsPage(): Promise<React.ReactElement> {
       </section>
     </main>
   );
+}
+
+function formatForecastSensitivity(value: ForecastSensitivity): string {
+  if (value === "stable") return "안정적";
+  if (value === "responsive") return "민감";
+  return "기본";
 }
 
 function SettingRow({

--- a/src/features/settings/components/ForecastSensitivityEditor.tsx
+++ b/src/features/settings/components/ForecastSensitivityEditor.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import type { ForecastSensitivity } from "@/lib/domain/forecast";
+import { PrimaryButton } from "@/components/ui/primary-button";
+import { useUpdateForecastSensitivity } from "@/features/settings/hooks/useSettingsMutations";
+
+interface ForecastSensitivityEditorProps {
+  initialForecastSensitivity: ForecastSensitivity;
+  userId: string;
+}
+
+const OPTIONS: Array<{
+  value: ForecastSensitivity;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "stable",
+    label: "안정적",
+    description: "최근 변동을 천천히 반영합니다. 과발주를 줄이고 싶은 매장에 적합합니다.",
+  },
+  {
+    value: "balanced",
+    label: "기본",
+    description: "최근 흐름과 장기 평균을 균형 있게 반영합니다.",
+  },
+  {
+    value: "responsive",
+    label: "민감",
+    description: "최근 판매 변화를 빠르게 반영합니다. 날씨나 이벤트 영향이 큰 매장에 적합합니다.",
+  },
+];
+
+export function ForecastSensitivityEditor({
+  initialForecastSensitivity,
+  userId,
+}: ForecastSensitivityEditorProps): React.ReactElement {
+  const router = useRouter();
+  const [value, setValue] = useState<ForecastSensitivity>(initialForecastSensitivity);
+  const [savedValue, setSavedValue] = useState<ForecastSensitivity>(initialForecastSensitivity);
+  const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+  const mutation = useUpdateForecastSensitivity();
+  const isDirty = value !== savedValue;
+
+  async function handleSubmit(): Promise<void> {
+    setSubmitMessage(null);
+
+    try {
+      const nextValue = await mutation.mutateAsync({
+        userId,
+        forecastSensitivity: value,
+      });
+      setValue(nextValue);
+      setSavedValue(nextValue);
+      setSubmitMessage("예측 민감도를 저장했어요.");
+      router.refresh();
+    } catch (error) {
+      setSubmitMessage(error instanceof Error ? error.message : "예측 민감도 저장에 실패했어요.");
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-stack">
+      <div>
+        <p className="text-label text-ink-2">예측 민감도</p>
+        <p className="mt-1 text-caption text-ink-3">
+          최근 판매 변화를 예측에 얼마나 빠르게 반영할지 정합니다.
+        </p>
+      </div>
+
+      <div className="grid gap-stack-tight md:grid-cols-3">
+        {OPTIONS.map((option) => {
+          const selected = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => setValue(option.value)}
+              className={cn(
+                "rounded-2xl border px-stack py-stack text-left shadow-soft transition",
+                selected
+                  ? "border-blue bg-blue-soft text-blue-deep"
+                  : "border-border bg-card text-ink-2 hover:bg-card-hover",
+              )}
+              aria-pressed={selected}
+            >
+              <span className="block text-body font-semibold">{option.label}</span>
+              <span className="mt-1 block text-caption">{option.description}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-stack-tight">
+        <PrimaryButton
+          type="button"
+          onClick={() => void handleSubmit()}
+          disabled={!isDirty || mutation.isPending}
+        >
+          {mutation.isPending ? "저장 중..." : "예측 민감도 저장"}
+        </PrimaryButton>
+        {submitMessage && (
+          <p
+            role="status"
+            className={mutation.isError ? "text-caption text-red" : "text-caption text-green"}
+          >
+            {submitMessage}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/features/settings/hooks/useSettingsMutations.ts
+++ b/src/features/settings/hooks/useSettingsMutations.ts
@@ -11,6 +11,7 @@ import { createClient } from "@/lib/supabase/client";
 import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
 import { todayDashboardQueryKey } from "@/features/dashboard/hooks/useTodayDashboard";
 import type { Weekday } from "@/lib/domain/regular-days-off";
+import type { ForecastSensitivity } from "@/lib/domain/forecast";
 import { updateRegularDaysOff } from "@/lib/supabase/rpc";
 import type { Database } from "@/lib/supabase/types";
 
@@ -31,6 +32,11 @@ interface UpdateSafetyBufferDaysInput {
 interface UpdatePurchaseCoverageDaysInput {
   userId: string;
   purchaseCoverageDays: number;
+}
+
+interface UpdateForecastSensitivityInput {
+  userId: string;
+  forecastSensitivity: ForecastSensitivity;
 }
 
 export async function invalidateSettingsRelatedQueries(queryClient: QueryClient): Promise<void> {
@@ -99,6 +105,25 @@ async function updatePurchaseCoverageDays(input: UpdatePurchaseCoverageDaysInput
   return data.purchase_coverage_days;
 }
 
+async function updateForecastSensitivity(
+  input: UpdateForecastSensitivityInput,
+): Promise<ForecastSensitivity> {
+  const supabase = createClient() as unknown as SupabaseClient<Database>;
+  const { data, error } = await supabase
+    .from("users")
+    .update({ forecast_sensitivity: input.forecastSensitivity })
+    .eq("id", input.userId)
+    .select("forecast_sensitivity")
+    .single();
+
+  if (error) throw new Error(error.message);
+  const value = data?.forecast_sensitivity;
+  if (value !== "stable" && value !== "balanced" && value !== "responsive") {
+    throw new Error("예측 민감도 저장 결과가 비어 있습니다.");
+  }
+  return value;
+}
+
 export function useUpdateStoreName(): UseMutationResult<string, Error, UpdateStoreNameInput> {
   const queryClient = useQueryClient();
   return useMutation({
@@ -145,6 +170,20 @@ export function useUpdatePurchaseCoverageDays(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updatePurchaseCoverageDays,
+    onSuccess: async () => {
+      await invalidateSettingsRelatedQueries(queryClient);
+    },
+  });
+}
+
+export function useUpdateForecastSensitivity(): UseMutationResult<
+  ForecastSensitivity,
+  Error,
+  UpdateForecastSensitivityInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateForecastSensitivity,
     onSuccess: async () => {
       await invalidateSettingsRelatedQueries(queryClient);
     },

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -123,6 +123,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       daysOff: row.regularDaysOff,
       signupDate: new Date(row.signedUpAt),
       today,
+      sensitivity: row.forecastSensitivity,
     });
     return {
       ingredientId: row.ingredientId,
@@ -195,6 +196,7 @@ export async function loadMenuDemandForecastViews(
         signupDate: new Date(row.signedUpAt),
         today,
         horizonDays,
+        sensitivity: row.forecastSensitivity,
       });
       const dailyPredictions = forecast.dailyPredictions.map((day) => ({
         date: day.date,
@@ -263,6 +265,7 @@ export async function loadMenuForecastAccuracyViews(
           signupDate: new Date(row.signedUpAt),
           today: trainUntil,
           horizonDays: 1,
+          sensitivity: row.forecastSensitivity,
         });
         const actualQuantity = sampleByDate.get(dateKey(targetDate))?.quantity ?? 0;
         const predictedQuantity = forecast.dailyPredictions[0]?.predictedQuantity ?? 0;
@@ -367,6 +370,7 @@ export async function loadIngredientForecastAccuracyViews(
             signupDate: new Date(row.signedUpAt),
             today: trainUntil,
             horizonDays: 1,
+            sensitivity: row.forecastSensitivity,
           }),
         };
       }),
@@ -458,6 +462,7 @@ export async function loadMenuBasedIngredientDemandForecast(
           signupDate: new Date(row.signedUpAt),
           today,
           horizonDays,
+          sensitivity: row.forecastSensitivity,
         }),
       };
     }),

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -24,15 +24,40 @@ const COLD_START_DAYS = 7;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_FORECAST_DAYS = 365;
 const TREND_THRESHOLD = 0.2;
-const RECENCY_DECAY_DAYS = 14;
-const MIN_GROUP_SAMPLE_SIZE = 8;
-const OUTLIER_CAP_MULTIPLIER = 3;
+const DEFAULT_RECENCY_DECAY_DAYS = 14;
+const DEFAULT_MIN_GROUP_SAMPLE_SIZE = 8;
+const DEFAULT_OUTLIER_CAP_MULTIPLIER = 3;
 const TREND_FACTOR_MIN = 0.85;
 const TREND_FACTOR_MAX = 1.25;
 
 export type DepletionStatus = "safe" | "caution" | "order_needed" | "critical";
 export type ConsumptionTrend = "normal" | "rising" | "falling";
 export type BusinessDayType = "weekday" | "friday" | "weekend";
+export type ForecastSensitivity = "stable" | "balanced" | "responsive";
+
+export interface ForecastTuning {
+  recencyDecayDays: number;
+  minGroupSampleSize: number;
+  outlierCapMultiplier: number;
+}
+
+export const FORECAST_TUNING_PRESETS: Record<ForecastSensitivity, ForecastTuning> = {
+  stable: {
+    recencyDecayDays: 21,
+    minGroupSampleSize: 12,
+    outlierCapMultiplier: 2.5,
+  },
+  balanced: {
+    recencyDecayDays: DEFAULT_RECENCY_DECAY_DAYS,
+    minGroupSampleSize: DEFAULT_MIN_GROUP_SAMPLE_SIZE,
+    outlierCapMultiplier: DEFAULT_OUTLIER_CAP_MULTIPLIER,
+  },
+  responsive: {
+    recencyDecayDays: 7,
+    minGroupSampleSize: 5,
+    outlierCapMultiplier: 4,
+  },
+};
 
 export interface DailyConsumption {
   date: Date;
@@ -96,6 +121,7 @@ export interface ForecastInput {
   daysOff: readonly Weekday[];
   signupDate: Date;
   today: Date;
+  sensitivity?: ForecastSensitivity;
 }
 
 export interface ForecastResult {
@@ -127,6 +153,7 @@ export interface MenuDemandForecastInput {
   signupDate: Date;
   today: Date;
   horizonDays?: number;
+  sensitivity?: ForecastSensitivity;
 }
 
 export interface MenuDemandForecastDay {
@@ -202,14 +229,16 @@ export function computeBusinessDayUsageModel(
   samples: readonly DailyConsumption[],
   daysOff: readonly Weekday[],
   today: Date,
+  sensitivity: ForecastSensitivity = "balanced",
 ): UsageForecastModel {
+  const tuning = FORECAST_TUNING_PRESETS[sensitivity];
   const usableSamples = samples
     .filter((sample) => !isRegularDayOff(sample.date, daysOff) && sample.amount > 0)
     .map((sample) => ({
       ...sample,
-      amount: capOutlier(sample.amount, samples),
+      amount: capOutlier(sample.amount, samples, tuning.outlierCapMultiplier),
       dayType: businessDayTypeOf(sample.date, daysOff),
-      weight: recencyWeight(sample.date, today),
+      weight: recencyWeight(sample.date, today, tuning.recencyDecayDays),
     }))
     .filter((sample): sample is DailyConsumption & { dayType: BusinessDayType; weight: number } =>
       Boolean(sample.dayType),
@@ -248,7 +277,7 @@ export function computeBusinessDayUsageModel(
     const groupAverage = bucket.weightSum.isZero()
       ? globalAverage
       : bucket.weightedSum.dividedBy(bucket.weightSum);
-    const confidence = Math.min(bucket.count / MIN_GROUP_SAMPLE_SIZE, 1);
+    const confidence = Math.min(bucket.count / tuning.minGroupSampleSize, 1);
     const stabilized = groupAverage.times(confidence).plus(globalAverage.times(1 - confidence));
     usageByDayType.set(dayType, stabilized);
   }
@@ -259,12 +288,16 @@ export function computeBusinessDayUsageModel(
   };
 }
 
-function recencyWeight(date: Date, today: Date): number {
+function recencyWeight(date: Date, today: Date, decayDays: number): number {
   const daysAgo = Math.max(0, (today.getTime() - date.getTime()) / ONE_DAY_MS);
-  return Math.exp(-daysAgo / RECENCY_DECAY_DAYS);
+  return Math.exp(-daysAgo / decayDays);
 }
 
-function capOutlier(amount: number, samples: readonly DailyConsumption[]): number {
+function capOutlier(
+  amount: number,
+  samples: readonly DailyConsumption[],
+  capMultiplier: number,
+): number {
   const positiveAmounts = samples
     .map((sample) => sample.amount)
     .filter((value) => value > 0)
@@ -273,7 +306,7 @@ function capOutlier(amount: number, samples: readonly DailyConsumption[]): numbe
 
   const median = positiveAmounts[Math.floor(positiveAmounts.length / 2)];
   if (!median || median <= 0) return amount;
-  return Math.min(amount, median * OUTLIER_CAP_MULTIPLIER);
+  return Math.min(amount, median * capMultiplier);
 }
 
 function weightedAverage(samples: readonly { amount: number; weight: number }[]): Decimal {
@@ -489,6 +522,7 @@ export function forecastIngredient(input: ForecastInput): ForecastResult {
     input.consumptionSamples,
     input.daysOff,
     input.today,
+    input.sensitivity,
   );
   const depletionDate = predictDepletionDate({
     currentStock: input.currentStock,
@@ -528,7 +562,12 @@ export function forecastMenuDemand(input: MenuDemandForecastInput): MenuDemandFo
     date: sample.date,
     amount: sample.quantity,
   }));
-  const model = computeBusinessDayUsageModel(consumptionLikeSamples, input.daysOff, input.today);
+  const model = computeBusinessDayUsageModel(
+    consumptionLikeSamples,
+    input.daysOff,
+    input.today,
+    input.sensitivity,
+  );
   const trendFactor = computeTrendFactor(consumptionLikeSamples, input.today);
   const trend = detectTrend(consumptionLikeSamples, input.today);
   const predictions: MenuDemandForecastDay[] = [];

--- a/src/lib/supabase/rpc-queries.ts
+++ b/src/lib/supabase/rpc-queries.ts
@@ -11,6 +11,7 @@ export interface DepletionForecastRow {
   isDefaultLeadTime: boolean;
   safetyBufferDays: number;
   purchaseCoverageDays: number;
+  forecastSensitivity: "stable" | "balanced" | "responsive";
   consumptionSamples: Array<{ date: string; amount: number }>;
   signedUpAt: string;
   regularDaysOff: ReadonlyArray<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -36,6 +37,7 @@ export interface MenuDemandForecastRow {
     }>;
   }>;
   demandSamples: Array<{ date: string; quantity: number }>;
+  forecastSensitivity: "stable" | "balanced" | "responsive";
   signedUpAt: string;
   regularDaysOff: ReadonlyArray<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
 }
@@ -80,6 +82,7 @@ interface DepletionForecastRawRow {
   is_default_lead_time: boolean;
   safety_buffer_days?: number | null;
   purchase_coverage_days?: number | null;
+  forecast_sensitivity?: "stable" | "balanced" | "responsive" | null;
   consumption_samples: Array<{ date: string; amount: number }>;
   signed_up_at: string;
   regular_days_off: Array<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
@@ -105,6 +108,7 @@ interface MenuDemandForecastRawRow {
     }> | null;
   }> | null;
   demand_samples: Array<{ date: string; quantity: number }>;
+  forecast_sensitivity?: "stable" | "balanced" | "responsive" | null;
   signed_up_at: string;
   regular_days_off: Array<"MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN">;
 }
@@ -376,6 +380,7 @@ export async function getDepletionForecast(
         Number.isFinite(row.purchase_coverage_days)
           ? row.purchase_coverage_days
           : 7,
+      forecastSensitivity: normalizeForecastSensitivity(row.forecast_sensitivity),
       consumptionSamples: row.consumption_samples ?? [],
       signedUpAt: row.signed_up_at,
       regularDaysOff: row.regular_days_off ?? [],
@@ -416,11 +421,19 @@ export async function getMenuDemandForecast(
         })),
       })),
       demandSamples: row.demand_samples ?? [],
+      forecastSensitivity: normalizeForecastSensitivity(row.forecast_sensitivity),
       signedUpAt: row.signed_up_at,
       regularDaysOff: row.regular_days_off ?? [],
     })),
     error: null,
   };
+}
+
+function normalizeForecastSensitivity(
+  value: string | null | undefined,
+): "stable" | "balanced" | "responsive" {
+  if (value === "stable" || value === "responsive") return value;
+  return "balanced";
 }
 
 export function getOrderRecommendationReport(

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -610,6 +610,7 @@ export type Database = {
           analytics_consent: boolean
           created_at: string
           email: string
+          forecast_sensitivity: "stable" | "balanced" | "responsive"
           id: string
           permanent_delete_at: string | null
           purchase_coverage_days: number
@@ -625,6 +626,7 @@ export type Database = {
           analytics_consent?: boolean
           created_at?: string
           email: string
+          forecast_sensitivity?: "stable" | "balanced" | "responsive"
           id: string
           permanent_delete_at?: string | null
           purchase_coverage_days?: number
@@ -640,6 +642,7 @@ export type Database = {
           analytics_consent?: boolean
           created_at?: string
           email?: string
+          forecast_sensitivity?: "stable" | "balanced" | "responsive"
           id?: string
           permanent_delete_at?: string | null
           purchase_coverage_days?: number
@@ -763,6 +766,7 @@ export type Database = {
           lead_time_vendor_id: string | null
           lead_time_vendor_name: string | null
           name: string
+          forecast_sensitivity: string
           purchase_coverage_days: number
           regular_days_off: Database["public"]["Enums"]["weekday"][]
           safety_buffer_days: number
@@ -780,6 +784,7 @@ export type Database = {
           name: string
           option_groups: Json
           price: number
+          forecast_sensitivity: string
           regular_days_off: Database["public"]["Enums"]["weekday"][]
           signed_up_at: string
         }[]

--- a/supabase/migrations/050_add_forecast_sensitivity.sql
+++ b/supabase/migrations/050_add_forecast_sensitivity.sql
@@ -1,0 +1,279 @@
+-- Migration: 사용자별 예측 민감도 설정
+-- 최근 판매 변화를 예측에 얼마나 빠르게 반영할지 선택한다.
+
+alter table public.users
+add column if not exists forecast_sensitivity text not null default 'balanced';
+
+alter table public.users
+drop constraint if exists users_forecast_sensitivity_check;
+
+alter table public.users
+add constraint users_forecast_sensitivity_check
+check (forecast_sensitivity in ('stable', 'balanced', 'responsive'));
+
+comment on column public.users.forecast_sensitivity is
+  '예측 민감도. stable=완만, balanced=기본, responsive=최근 변화 빠른 반영.';
+
+drop function if exists public.get_depletion_forecast();
+
+create function public.get_depletion_forecast()
+returns table (
+  ingredient_id uuid,
+  name text,
+  unit public.ingredient_unit,
+  current_stock numeric,
+  lead_time_days integer,
+  lead_time_vendor_id uuid,
+  lead_time_vendor_name text,
+  is_default_lead_time boolean,
+  safety_buffer_days integer,
+  purchase_coverage_days integer,
+  forecast_sensitivity text,
+  consumption_samples jsonb,
+  signed_up_at timestamptz,
+  regular_days_off public.weekday[]
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  return query
+  with vendor_choice as (
+    select
+      i.id as ingredient_id,
+      choice.vendor_id,
+      choice.vendor_name,
+      choice.lead_time_days
+    from public.ingredients i
+    left join lateral (
+      select
+        v.id as vendor_id,
+        v.name as vendor_name,
+        v.lead_time_days
+      from public.purchase_orders po
+      join public.vendors v on v.id = po.vendor_id
+      join public.purchase_order_items poi on poi.purchase_order_id = po.id
+      where poi.ingredient_id = i.id
+        and po.user_id = v_user_id
+      group by v.id, v.name, v.lead_time_days
+      order by count(*) desc, max(po.purchased_at) desc, v.name asc
+      limit 1
+    ) choice on true
+    where i.user_id = v_user_id
+      and i.is_active = true
+  )
+  select
+    i.id,
+    i.name,
+    i.unit,
+    i.current_stock,
+    coalesce(vc.lead_time_days, 1) as lead_time_days,
+    vc.vendor_id as lead_time_vendor_id,
+    vc.vendor_name as lead_time_vendor_name,
+    (vc.lead_time_days is null) as is_default_lead_time,
+    u.safety_buffer_days,
+    u.purchase_coverage_days,
+    u.forecast_sensitivity,
+    coalesce(
+      (select jsonb_agg(jsonb_build_object('date', day, 'amount', total) order by day)
+       from (
+         select day, sum(total)::numeric as total
+         from (
+           select
+             s.sold_at as day,
+             sum(si.quantity * ri.quantity_per_serving) as total
+           from public.sales s
+           join public.sale_items si on si.sale_id = s.id
+           join public.recipe_items ri on ri.menu_id = si.menu_id
+           where ri.ingredient_id = i.id
+             and s.user_id = v_user_id
+             and s.sold_at >= current_date - interval '90 days'
+           group by s.sold_at
+
+           union all
+
+           select
+             s.sold_at as day,
+             sum(sio.quantity * ((recipe_item ->> 'quantity_per_selection')::numeric)) as total
+           from public.sales s
+           join public.sale_items si on si.sale_id = s.id
+           join public.sale_item_options sio on sio.sale_item_id = si.id
+           cross join lateral jsonb_array_elements(sio.recipe_items_snapshot) as recipe_item
+           where (recipe_item ->> 'ingredient_id')::uuid = i.id
+             and s.user_id = v_user_id
+             and s.sold_at >= current_date - interval '90 days'
+           group by s.sold_at
+         ) raw_daily
+         group by day
+       ) daily),
+      '[]'::jsonb
+    ) as consumption_samples,
+    u.signed_up_at,
+    u.regular_days_off
+  from public.ingredients i
+  join public.users u on u.id = i.user_id
+  left join vendor_choice vc on vc.ingredient_id = i.id
+  where i.user_id = v_user_id
+    and i.is_active = true
+  order by i.name;
+end;
+$$;
+
+comment on function public.get_depletion_forecast() is
+  '재고 예측 raw 데이터 반환. 소비 sample, 거래처 식별자, 권장 발주 커버일, 예측 민감도 설정을 포함한다.';
+
+revoke all on function public.get_depletion_forecast() from public;
+grant execute on function public.get_depletion_forecast() to authenticated;
+
+drop function if exists public.get_menu_demand_forecast();
+
+create function public.get_menu_demand_forecast()
+returns table (
+  menu_id uuid,
+  name text,
+  price numeric,
+  is_active boolean,
+  base_recipe jsonb,
+  option_groups jsonb,
+  demand_samples jsonb,
+  forecast_sensitivity text,
+  signed_up_at timestamptz,
+  regular_days_off public.weekday[]
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  return query
+  with menu_sales as (
+    select
+      si.menu_id,
+      sum(si.quantity)::numeric as total_quantity
+    from public.sales s
+    join public.sale_items si on si.sale_id = s.id
+    where s.user_id = v_user_id
+      and s.sold_at >= current_date - interval '90 days'
+    group by si.menu_id
+  ),
+  option_sales as (
+    select
+      si.menu_id,
+      sio.option_value_id,
+      sum(sio.quantity)::numeric as selected_quantity
+    from public.sales s
+    join public.sale_items si on si.sale_id = s.id
+    join public.sale_item_options sio on sio.sale_item_id = si.id
+    where s.user_id = v_user_id
+      and s.sold_at >= current_date - interval '90 days'
+    group by si.menu_id, sio.option_value_id
+  )
+  select
+    m.id,
+    m.name,
+    m.price,
+    m.is_active,
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object(
+          'ingredient_id', ri.ingredient_id,
+          'quantity_per_serving', ri.quantity_per_serving
+        ) order by ri.ingredient_id)
+        from public.recipe_items ri
+        where ri.menu_id = m.id
+      ),
+      '[]'::jsonb
+    ) as base_recipe,
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object(
+          'option_group_id', og.id,
+          'name', og.name,
+          'selection_type', og.selection_type,
+          'is_required', og.is_required,
+          'values', coalesce(values_json.values, '[]'::jsonb)
+        ) order by og.sort_order, og.name)
+        from public.menu_option_groups og
+        left join menu_sales ms on ms.menu_id = m.id
+        left join lateral (
+          select jsonb_agg(jsonb_build_object(
+            'option_value_id', ov.id,
+            'name', ov.name,
+            'is_default', ov.is_default,
+            'selection_rate', case
+              when coalesce(ms.total_quantity, 0) > 0
+                then coalesce(os.selected_quantity, 0) / ms.total_quantity
+              else 0
+            end,
+            'recipe', coalesce(recipe_json.recipe, '[]'::jsonb)
+          ) order by ov.sort_order, ov.name) as values
+          from public.menu_option_values ov
+          left join option_sales os on os.option_value_id = ov.id and os.menu_id = m.id
+          left join lateral (
+            select jsonb_agg(jsonb_build_object(
+              'ingredient_id', ovr.ingredient_id,
+              'quantity_per_selection', ovr.quantity_per_selection
+            ) order by ovr.ingredient_id) as recipe
+            from public.menu_option_value_recipe_items ovr
+            where ovr.option_value_id = ov.id
+              and ovr.user_id = v_user_id
+          ) recipe_json on true
+          where ov.option_group_id = og.id
+            and ov.user_id = v_user_id
+            and ov.is_active = true
+        ) values_json on true
+        where og.menu_id = m.id
+          and og.user_id = v_user_id
+          and og.is_active = true
+      ),
+      '[]'::jsonb
+    ) as option_groups,
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('date', sold_at, 'quantity', quantity) order by sold_at)
+        from (
+          select
+            s.sold_at,
+            sum(si.quantity)::integer as quantity
+          from public.sales s
+          join public.sale_items si on si.sale_id = s.id
+          where s.user_id = v_user_id
+            and si.menu_id = m.id
+            and s.sold_at >= current_date - interval '90 days'
+          group by s.sold_at
+        ) daily
+      ),
+      '[]'::jsonb
+    ) as demand_samples,
+    u.forecast_sensitivity,
+    u.signed_up_at,
+    u.regular_days_off
+  from public.menus m
+  join public.users u on u.id = m.user_id
+  where m.user_id = v_user_id
+    and m.is_active = true
+  order by m.name;
+end;
+$$;
+
+comment on function public.get_menu_demand_forecast() is
+  '메뉴별 수요 예측 raw 데이터 반환. 판매 수량, 레시피, 옵션 선택률, 예측 민감도 설정을 반환한다.';
+
+revoke all on function public.get_menu_demand_forecast() from public;
+grant execute on function public.get_menu_demand_forecast() to authenticated;

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -76,6 +76,24 @@ describe("business day usage model", () => {
     expect(model.fallbackDailyUsage.toNumber()).toBeGreaterThan(80);
   });
 
+  it("예측 민감도가 높을수록 최근 증가분을 더 빠르게 반영한다", () => {
+    const samples: DailyConsumption[] = [
+      { date: daysAgo(50), amount: 20 },
+      { date: daysAgo(40), amount: 20 },
+      { date: daysAgo(30), amount: 20 },
+      { date: daysAgo(3), amount: 100 },
+      { date: daysAgo(2), amount: 100 },
+      { date: daysAgo(1), amount: 100 },
+    ];
+
+    const stable = computeBusinessDayUsageModel(samples, [], today, "stable");
+    const responsive = computeBusinessDayUsageModel(samples, [], today, "responsive");
+
+    expect(responsive.fallbackDailyUsage.toNumber()).toBeGreaterThan(
+      stable.fallbackDailyUsage.toNumber(),
+    );
+  });
+
   it("그룹 표본이 적으면 전체 영업일 평균과 섞어 안정화한다", () => {
     const samples: DailyConsumption[] = [
       { date: new Date("2026-04-03"), amount: 100 },


### PR DESCRIPTION
## Summary
- add per-user forecast sensitivity setting: stable / balanced / responsive
- wire sensitivity into menu demand, ingredient depletion, backtest, and order recommendation calculations
- expose the setting on the Settings page with plain Korean guidance
- add migration 050 to persist sensitivity and return it from forecast RPCs
- document tuning presets and add unit coverage

## Tests
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/forecast.test.ts tests/unit/application.test.ts
- npx vitest run
- npm run build

## Migration
- requires Supabase migration after merge: supabase/migrations/050_add_forecast_sensitivity.sql