### PR TITLE
Show menu forecasts on calendar

### DIFF
--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -4,7 +4,12 @@ import Link from "next/link";
 import { differenceInCalendarDays } from "date-fns";
 import { useParams } from "next/navigation";
 import { useCalendarMonth } from "@/features/calendar/hooks/useCalendarMonth";
+import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
 import { useSaleByDate, type SaleWithItems } from "@/features/sale/hooks/useSaleByDate";
+import {
+  buildCalendarMenuForecastByDate,
+  type CalendarMenuForecastSummary,
+} from "@/features/calendar/lib/menu-forecast-calendar";
 import { daysUntilLock, isSaleLocked } from "@/lib/domain/snapshot";
 import { MARGIN_LABEL } from "@/lib/domain/margin";
 import {
@@ -28,8 +33,14 @@ export default function CalendarDateDetailPage(): React.ReactElement {
   const year = parsedDate?.getFullYear() ?? null;
   const month = parsedDate ? parsedDate.getMonth() + 1 : null;
   const todayIso = useTodayIso();
+  const today = todayIso ? (parseLocalDateFromIso(todayIso) ?? new Date()) : new Date();
+  const isFutureDate = parsedDate ? differenceInCalendarDays(parsedDate, today) > 0 : false;
+  const forecastHorizonDays = parsedDate
+    ? Math.min(365, Math.max(7, differenceInCalendarDays(parsedDate, today) + 1))
+    : 7;
   const calendarQuery = useCalendarMonth(year, month);
   const saleQuery = useSaleByDate(date);
+  const menuForecastQuery = useMenuDemandForecast(forecastHorizonDays);
 
   if (!parsedDate) {
     return (
@@ -41,6 +52,8 @@ export default function CalendarDateDetailPage(): React.ReactElement {
   }
 
   const cell = calendarQuery.data?.cells.find((item) => item.date === date) ?? null;
+  const menuForecast =
+    buildCalendarMenuForecastByDate(menuForecastQuery.data ?? []).get(date) ?? null;
   const prevDate = addDaysIso(parsedDate, -1);
   const nextDate = addDaysIso(parsedDate, 1);
 
@@ -60,9 +73,12 @@ export default function CalendarDateDetailPage(): React.ReactElement {
         </div>
       </header>
 
-      {calendarQuery.isLoading || saleQuery.isLoading || !todayIso ? (
+      {calendarQuery.isLoading ||
+      saleQuery.isLoading ||
+      (isFutureDate && menuForecastQuery.isLoading) ||
+      !todayIso ? (
         <p className="text-body-regular text-ink-3">불러오는 중…</p>
-      ) : calendarQuery.error || saleQuery.error ? (
+      ) : calendarQuery.error || saleQuery.error || (isFutureDate && menuForecastQuery.error) ? (
         <Notice tone="red">날짜 상세를 불러오지 못했어요. 잠시 후 다시 시도해주세요.</Notice>
       ) : (
         <DateDetailBody
@@ -70,6 +86,7 @@ export default function CalendarDateDetailPage(): React.ReactElement {
           date={date}
           parsedDate={parsedDate}
           sale={saleQuery.data ?? null}
+          menuForecast={menuForecast}
           todayIso={todayIso}
         />
       )}
@@ -82,6 +99,7 @@ interface DateDetailBodyProps {
   date: string;
   parsedDate: Date;
   sale: SaleWithItems | null;
+  menuForecast: CalendarMenuForecastSummary | null;
   todayIso: string;
 }
 
@@ -90,13 +108,14 @@ function DateDetailBody({
   date,
   parsedDate,
   sale,
+  menuForecast,
   todayIso,
 }: DateDetailBodyProps): React.ReactElement {
   const today = parseLocalDateFromIso(todayIso) ?? new Date();
   const daysFromToday = differenceInCalendarDays(parsedDate, today);
 
   if (cell?.isFuture) {
-    return <Notice tone="neutral">아직 오지 않은 날이에요. 미래 데이터는 입력할 수 없어요.</Notice>;
+    return <FutureForecastDetail date={date} forecast={menuForecast} />;
   }
   if (cell?.isBeforeSignup) {
     return <Notice tone="neutral">가입 전 데이터예요.</Notice>;
@@ -108,6 +127,64 @@ function DateDetailBody({
     return <ExistingSaleDetail sale={sale} hasPurchase={cell?.hasPurchase ?? false} />;
   }
   return <MissingSaleDetail date={date} daysFromToday={daysFromToday} />;
+}
+
+function FutureForecastDetail({
+  date,
+  forecast,
+}: {
+  date: string;
+  forecast: CalendarMenuForecastSummary | null;
+}): React.ReactElement {
+  if (!forecast || forecast.items.length === 0) {
+    return (
+      <Notice tone="neutral">
+        아직 오지 않은 날이에요. 예측할 판매 이력이 부족해서 메뉴 소요량을 표시하지 못했어요.
+      </Notice>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-section">
+      <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
+        <div className="flex flex-col gap-stack-tight">
+          <p className="text-micro text-ink-3">현재 예측 모델 기준</p>
+          <div className="grid grid-cols-2 gap-stack">
+            <Metric label="예상 매출" value={`${formatWon(forecast.totalRevenue)}원`} />
+            <Metric label="예상 판매" value={`${formatNumber(forecast.totalQuantity)}개`} />
+          </div>
+          <Notice tone="neutral">
+            미래 날짜는 판매 입력은 막고, 현재까지의 판매 이력으로 계산한 예측만 보여줘요.
+          </Notice>
+        </div>
+      </article>
+
+      <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
+        <div className="flex items-center justify-between gap-stack">
+          <h2 className="text-title-md text-ink-1">예측 메뉴 소요량</h2>
+          <span className="text-micro text-ink-3">{date}</span>
+        </div>
+        <ul className="flex flex-col gap-stack-tight">
+          {forecast.items.map((item) => (
+            <li key={item.menuId} className="rounded-lg bg-bg p-stack">
+              <div className="flex items-start justify-between gap-stack">
+                <div className="flex flex-col gap-1">
+                  <p className="text-body text-ink-1">{item.name}</p>
+                  <p className="text-micro text-ink-3">
+                    예상 {formatNumber(Number(item.predictedQuantity.toFixed(1)))}개 ×{" "}
+                    {formatWon(item.price)}원
+                  </p>
+                </div>
+                <p className="text-body tabular-nums text-ink-1">
+                  {formatWon(item.predictedRevenue)}원
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </article>
+    </div>
+  );
 }
 
 interface ExistingSaleDetailProps {

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { differenceInCalendarDays } from "date-fns";
 import { useCalendarMonth } from "@/features/calendar/hooks/useCalendarMonth";
+import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
 import { MonthHeader } from "@/features/calendar/components/MonthHeader";
 import { MonthCumulativeCard } from "@/features/calendar/components/MonthCumulativeCard";
 import { CalendarGrid } from "@/features/calendar/components/CalendarGrid";
 import { CalendarLegend } from "@/features/calendar/components/CalendarLegend";
+import { buildCalendarMenuForecastByDate } from "@/features/calendar/lib/menu-forecast-calendar";
 import { trackEvent } from "@/lib/analytics/ga4";
+import { parseLocalDateFromIso } from "@/lib/utils/format";
 import { useTodayIso } from "@/lib/utils/use-today-iso";
 import type { EnrichedCalendarCell } from "@/features/calendar/lib/consecutive-missing";
 
@@ -26,6 +30,7 @@ export default function CalendarPage(): React.ReactElement {
   const todayIso = useTodayIso();
   const [year, setYear] = useState<number | null>(null);
   const [month, setMonth] = useState<number | null>(null);
+  const forecastHorizonDays = computeForecastHorizonDays(year, month, todayIso);
 
   // 초기 mount 시 클라이언트 시각으로 현재 연/월 세팅 (SSR/CSR drift 차단)
   useEffect(() => {
@@ -35,6 +40,11 @@ export default function CalendarPage(): React.ReactElement {
   }, []);
 
   const query = useCalendarMonth(year, month);
+  const menuForecastQuery = useMenuDemandForecast(forecastHorizonDays);
+  const menuForecastByDate = useMemo(
+    () => buildCalendarMenuForecastByDate(menuForecastQuery.data ?? []),
+    [menuForecastQuery.data],
+  );
 
   // primitive deps로 month 변경 + operating_days 변경에만 발화. 동일 데이터 refetch엔 skip.
   const operatingDays = query.data?.cumulative.operatingDays ?? null;
@@ -105,6 +115,7 @@ export default function CalendarPage(): React.ReactElement {
         year={year}
         month={month}
         cells={query.data.cells}
+        menuForecastByDate={menuForecastByDate}
         selectedDate={null}
         todayIso={todayIso}
         onSelect={handleSelect}
@@ -112,4 +123,15 @@ export default function CalendarPage(): React.ReactElement {
       <CalendarLegend />
     </section>
   );
+}
+
+function computeForecastHorizonDays(
+  year: number | null,
+  month: number | null,
+  todayIso: string | null,
+): number {
+  if (year === null || month === null || !todayIso) return 60;
+  const today = parseLocalDateFromIso(todayIso) ?? new Date();
+  const monthEnd = new Date(year, month, 0);
+  return Math.min(365, Math.max(7, differenceInCalendarDays(monthEnd, today) + 1));
 }

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { WEEKDAY_KO, parseLocalDateFromIso } from "@/lib/utils/format";
+import { WEEKDAY_KO, formatNumber, parseLocalDateFromIso } from "@/lib/utils/format";
 import type { EnrichedCalendarCell } from "../lib/consecutive-missing";
 import { INTENSITY_LEVELS, INTENSITY_STEP_PCT } from "../lib/intensity";
+import type { CalendarMenuForecastSummary } from "../lib/menu-forecast-calendar";
 
 interface CalendarGridProps {
   year: number;
   month: number;
   cells: readonly EnrichedCalendarCell[];
+  menuForecastByDate?: ReadonlyMap<string, CalendarMenuForecastSummary>;
   selectedDate: string | null;
   todayIso: string | null;
   onSelect: (cell: EnrichedCalendarCell) => void;
@@ -25,6 +27,7 @@ export function CalendarGrid({
   year,
   month,
   cells,
+  menuForecastByDate,
   selectedDate,
   todayIso,
   onSelect,
@@ -45,6 +48,7 @@ export function CalendarGrid({
           <DayCell
             key={cell.date}
             cell={cell}
+            forecast={menuForecastByDate?.get(cell.date) ?? null}
             maxRevenue={maxRevenue}
             isSelected={cell.date === selectedDate}
             isToday={cell.date === todayIso}
@@ -77,6 +81,7 @@ function BlankCell(): React.ReactElement {
 
 interface DayCellProps {
   cell: EnrichedCalendarCell;
+  forecast: CalendarMenuForecastSummary | null;
   maxRevenue: number;
   isSelected: boolean;
   isToday: boolean;
@@ -85,6 +90,7 @@ interface DayCellProps {
 
 function DayCell({
   cell,
+  forecast,
   maxRevenue,
   isSelected,
   isToday,
@@ -122,7 +128,9 @@ function DayCell({
         {day}
       </span>
 
-      {!isSelected && <BottomLabel cell={cell} isStrongMissing={isStrongMissing} />}
+      {!isSelected && (
+        <BottomLabel cell={cell} forecast={forecast} isStrongMissing={isStrongMissing} />
+      )}
 
       <DotIndicators cell={cell} />
     </button>
@@ -131,13 +139,25 @@ function DayCell({
 
 interface BottomLabelProps {
   cell: EnrichedCalendarCell;
+  forecast: CalendarMenuForecastSummary | null;
   isStrongMissing: boolean;
 }
 
-function BottomLabel({ cell, isStrongMissing }: BottomLabelProps): React.ReactElement | null {
+function BottomLabel({
+  cell,
+  forecast,
+  isStrongMissing,
+}: BottomLabelProps): React.ReactElement | null {
   if (isStrongMissing) {
     return (
       <span className="absolute bottom-1 left-1 text-[9px] font-semibold text-red-deep">누락</span>
+    );
+  }
+  if (cell.isFuture && forecast && forecast.totalRevenue > 0) {
+    return (
+      <span className="absolute bottom-1 left-1 text-[8px] font-semibold text-blue-deep">
+        예상 {formatNumber(Math.round(forecast.totalRevenue / 10000))}
+      </span>
     );
   }
   if (cell.revenue !== null && cell.revenue > 0) {

--- a/src/features/calendar/lib/menu-forecast-calendar.ts
+++ b/src/features/calendar/lib/menu-forecast-calendar.ts
@@ -1,0 +1,55 @@
+import { localIsoDate } from "@/lib/utils/format";
+import type { MenuDemandForecastView } from "@/features/inventory/hooks/useMenuDemandForecast";
+
+export interface CalendarMenuForecastItem {
+  menuId: string;
+  name: string;
+  price: number;
+  predictedQuantity: number;
+  predictedRevenue: number;
+}
+
+export interface CalendarMenuForecastSummary {
+  date: string;
+  totalQuantity: number;
+  totalRevenue: number;
+  items: CalendarMenuForecastItem[];
+}
+
+export function buildCalendarMenuForecastByDate(
+  forecasts: readonly MenuDemandForecastView[],
+): Map<string, CalendarMenuForecastSummary> {
+  const byDate = new Map<string, CalendarMenuForecastSummary>();
+
+  for (const menu of forecasts) {
+    for (const day of menu.dailyPredictions) {
+      const predictedQuantity = Math.max(0, day.predictedQuantity);
+      if (predictedQuantity <= 0) continue;
+
+      const date = localIsoDate(day.date);
+      const summary = byDate.get(date) ?? {
+        date,
+        totalQuantity: 0,
+        totalRevenue: 0,
+        items: [],
+      };
+      const predictedRevenue = predictedQuantity * menu.price;
+      summary.totalQuantity += predictedQuantity;
+      summary.totalRevenue += predictedRevenue;
+      summary.items.push({
+        menuId: menu.menuId,
+        name: menu.name,
+        price: menu.price,
+        predictedQuantity,
+        predictedRevenue,
+      });
+      byDate.set(date, summary);
+    }
+  }
+
+  for (const summary of byDate.values()) {
+    summary.items.sort((a, b) => b.predictedRevenue - a.predictedRevenue);
+  }
+
+  return byDate;
+}

--- a/tests/unit/calendar-menu-forecast.test.ts
+++ b/tests/unit/calendar-menu-forecast.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildCalendarMenuForecastByDate } from "@/features/calendar/lib/menu-forecast-calendar";
+import type { MenuDemandForecastView } from "@/features/inventory/hooks/useMenuDemandForecast";
+
+describe("calendar menu forecast summary", () => {
+  it("groups menu demand forecasts by date and sums revenue", () => {
+    const forecasts: MenuDemandForecastView[] = [
+      {
+        menuId: "menu-1",
+        name: "딸기빙수",
+        price: 11_000,
+        tomorrowQuantity: 2,
+        sevenDayTotalQuantity: 2,
+        trend: "normal",
+        isColdStart: false,
+        dailyPredictions: [{ date: new Date("2026-06-20T00:00:00"), predictedQuantity: 2 }],
+        optionGroups: [],
+      },
+      {
+        menuId: "menu-2",
+        name: "망고빙수",
+        price: 12_000,
+        tomorrowQuantity: 1.5,
+        sevenDayTotalQuantity: 1.5,
+        trend: "normal",
+        isColdStart: false,
+        dailyPredictions: [{ date: new Date("2026-06-20T00:00:00"), predictedQuantity: 1.5 }],
+        optionGroups: [],
+      },
+    ];
+
+    const summary = buildCalendarMenuForecastByDate(forecasts).get("2026-06-20");
+
+    expect(summary?.totalQuantity).toBe(3.5);
+    expect(summary?.totalRevenue).toBe(40_000);
+    expect(summary?.items.map((item) => item.name)).toEqual(["딸기빙수", "망고빙수"]);
+  });
+});


### PR DESCRIPTION
## Summary
- show predicted revenue markers on future calendar cells using menu demand forecasts
- add future date detail view with predicted revenue, total menu quantity, and per-menu demand
- share calendar forecast aggregation through a tested utility

## Notes
- past forecast-vs-actual comparison is intentionally left for a follow-up PR because it needs backtest wording and UX
- no database migration

## Tests
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/calendar-menu-forecast.test.ts tests/unit/application.test.ts tests/unit/forecast.test.ts
- npm run build