### PR TITLE
Surface forecast confidence context

### DIFF
--- a/src/features/inventory/components/IngredientForecastAccuracyList.tsx
+++ b/src/features/inventory/components/IngredientForecastAccuracyList.tsx
@@ -15,6 +15,13 @@ const BIAS_LABEL: Record<IngredientForecastAccuracyView["bias"], string> = {
   insufficient_data: "데이터 부족",
 };
 
+const RELIABILITY_LABEL: Record<IngredientForecastAccuracyView["reliability"], string> = {
+  good: "신뢰도 좋음",
+  watch: "주의",
+  low: "신뢰도 낮음",
+  insufficient_data: "데이터 부족",
+};
+
 export function IngredientForecastAccuracyList({
   items,
 }: IngredientForecastAccuracyListProps): React.ReactElement {
@@ -77,7 +84,10 @@ function IngredientForecastAccuracyCard({
             {formatAmount(item.predictedTotalAmount, item.unit)}
           </p>
         </div>
-        <BiasBadge bias={item.bias} />
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <ReliabilityBadge reliability={item.reliability} />
+          <BiasBadge bias={item.bias} />
+        </div>
       </div>
 
       <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
@@ -156,6 +166,29 @@ function BiasBadge({ bias }: { bias: IngredientForecastAccuracyView["bias"] }): 
   );
 }
 
+function ReliabilityBadge({
+  reliability,
+}: {
+  reliability: IngredientForecastAccuracyView["reliability"];
+}): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full px-2.5 py-1 text-micro shadow-soft",
+        reliability === "good"
+          ? "bg-blue-soft text-blue-deep"
+          : reliability === "watch"
+            ? "bg-amber-soft text-amber-deep"
+            : reliability === "low"
+              ? "bg-red-soft text-red-deep"
+              : "bg-bg text-ink-3",
+      )}
+    >
+      {RELIABILITY_LABEL[reliability]}
+    </span>
+  );
+}
+
 function PriorityNotice({
   item,
 }: {
@@ -208,6 +241,10 @@ function buildSummary(items: readonly IngredientForecastAccuracyView[]): {
 function buildTuningHint(item: IngredientForecastAccuracyView): string {
   if (item.evaluatedDayCount < 3)
     return "소비 비교일이 적습니다. 판매 데이터가 더 쌓인 뒤 판단하세요.";
+  if (item.reliability === "low")
+    return "오차율이 매우 큽니다. 옵션 선택률, 레시피 변경, 이벤트성 판매를 먼저 확인하세요.";
+  if (item.reliability === "watch")
+    return "예측을 참고하되 발주 전 최근 1주 소비 흐름을 한 번 더 확인하세요.";
   if (item.bias === "under")
     return "실제 소비가 예측보다 큽니다. 발주량 부족 위험을 먼저 확인하세요.";
   if (item.bias === "over")

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -115,6 +115,7 @@ function IngredientRow({
           </span>
           <span className="text-caption text-ink-3">{formatLeadTimeSource(item)}</span>
           <span className="text-caption text-ink-3">{formatForecastSource(item)}</span>
+          <span className="text-caption text-ink-3">{formatForecastBasis(item)}</span>
         </div>
         <div className="flex items-center gap-stack-tight">
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
@@ -212,6 +213,19 @@ function formatForecastSource(item: IngredientForecastView): string {
   }
   return "최근 재료 사용량 기준";
 }
+
+function formatForecastBasis(item: IngredientForecastView): string {
+  const confidence = Math.round(item.basis.averageWeekdayConfidence * 100);
+  const label = CONFIDENCE_LABEL[item.basis.confidenceLevel];
+  return `${label} · 데이터 ${item.basis.usableSampleCount}일 · 요일 보정 ${confidence}%`;
+}
+
+const CONFIDENCE_LABEL: Record<IngredientForecastView["basis"]["confidenceLevel"], string> = {
+  high: "예측 신뢰도 높음",
+  medium: "예측 신뢰도 보통",
+  low: "예측 신뢰도 낮음",
+  collecting: "예측 데이터 수집 중",
+};
 
 const STATUS_TONE: Record<DepletionStatus, string> = {
   critical: "text-red-deep",

--- a/src/features/inventory/components/MenuDemandForecastList.tsx
+++ b/src/features/inventory/components/MenuDemandForecastList.tsx
@@ -14,6 +14,13 @@ const TREND_LABEL: Record<MenuDemandForecastView["trend"], string> = {
   normal: "보통",
 };
 
+const CONFIDENCE_LABEL: Record<MenuDemandForecastView["basis"]["confidenceLevel"], string> = {
+  high: "신뢰도 높음",
+  medium: "신뢰도 보통",
+  low: "신뢰도 낮음",
+  collecting: "데이터 수집 중",
+};
+
 export function MenuDemandForecastList({ items }: MenuDemandForecastListProps): React.ReactElement {
   if (items.length === 0) {
     return (
@@ -48,8 +55,15 @@ function MenuDemandForecastCard({ item }: { item: MenuDemandForecastView }): Rea
             {formatQuantity(item.tomorrowQuantity)}
           </p>
         </div>
-        <TrendBadge trend={item.trend} isColdStart={item.isColdStart} />
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <TrendBadge trend={item.trend} isColdStart={item.isColdStart} />
+          <ConfidenceBadge level={item.basis.confidenceLevel} />
+        </div>
       </div>
+
+      <p className="mt-stack-tight rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
+        {formatForecastBasis(item)}
+      </p>
 
       <ol className="mt-stack grid grid-cols-7 gap-1.5">
         {item.dailyPredictions.map((day) => (
@@ -80,6 +94,37 @@ function MenuDemandForecastCard({ item }: { item: MenuDemandForecastView }): Rea
       )}
     </article>
   );
+}
+
+function ConfidenceBadge({
+  level,
+}: {
+  level: MenuDemandForecastView["basis"]["confidenceLevel"];
+}): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "rounded-full px-2 py-0.5 text-micro shadow-soft",
+        level === "high"
+          ? "bg-blue-soft text-blue-deep"
+          : level === "medium"
+            ? "bg-bg text-ink-3"
+            : level === "low"
+              ? "bg-amber-soft text-amber-deep"
+              : "bg-bg text-ink-4",
+      )}
+    >
+      {CONFIDENCE_LABEL[level]}
+    </span>
+  );
+}
+
+function formatForecastBasis(item: MenuDemandForecastView): string {
+  const weekdayConfidence = Math.round(item.basis.averageWeekdayConfidence * 100);
+  if (item.isColdStart) {
+    return `판매 데이터 ${item.basis.usableSampleCount}일 기반 · 가입 초기라 예측을 수집 중입니다.`;
+  }
+  return `판매 데이터 ${item.basis.usableSampleCount}일 기반 · 월~목/금/주말 그룹 평균에 개별요일 보정 ${weekdayConfidence}%를 섞어 계산합니다.`;
 }
 
 function OptionGroupSummary({

--- a/src/features/inventory/components/MenuForecastAccuracyList.tsx
+++ b/src/features/inventory/components/MenuForecastAccuracyList.tsx
@@ -15,6 +15,13 @@ const BIAS_LABEL: Record<MenuForecastAccuracyView["bias"], string> = {
   insufficient_data: "데이터 부족",
 };
 
+const RELIABILITY_LABEL: Record<MenuForecastAccuracyView["reliability"], string> = {
+  good: "신뢰도 좋음",
+  watch: "주의",
+  low: "신뢰도 낮음",
+  insufficient_data: "데이터 부족",
+};
+
 export function MenuForecastAccuracyList({
   items,
 }: MenuForecastAccuracyListProps): React.ReactElement {
@@ -76,7 +83,10 @@ function MenuForecastAccuracyCard({
             {formatQuantity(item.predictedTotalQuantity)}
           </p>
         </div>
-        <BiasBadge bias={item.bias} />
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <ReliabilityBadge reliability={item.reliability} />
+          <BiasBadge bias={item.bias} />
+        </div>
       </div>
 
       <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
@@ -152,6 +162,29 @@ function BiasBadge({ bias }: { bias: MenuForecastAccuracyView["bias"] }): React.
   );
 }
 
+function ReliabilityBadge({
+  reliability,
+}: {
+  reliability: MenuForecastAccuracyView["reliability"];
+}): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full px-2.5 py-1 text-micro shadow-soft",
+        reliability === "good"
+          ? "bg-blue-soft text-blue-deep"
+          : reliability === "watch"
+            ? "bg-amber-soft text-amber-deep"
+            : reliability === "low"
+              ? "bg-red-soft text-red-deep"
+              : "bg-bg text-ink-3",
+      )}
+    >
+      {RELIABILITY_LABEL[reliability]}
+    </span>
+  );
+}
+
 function PriorityNotice({
   item,
 }: {
@@ -203,6 +236,10 @@ function buildSummary(items: readonly MenuForecastAccuracyView[]): {
 
 function buildTuningHint(item: MenuForecastAccuracyView): string {
   if (item.evaluatedDayCount < 3) return "판매 비교일이 적습니다. 데이터가 더 쌓인 뒤 판단하세요.";
+  if (item.reliability === "low")
+    return "오차율이 매우 큽니다. 이벤트성 판매, 메뉴 옵션, 최근 레시피 변경을 먼저 확인하세요.";
+  if (item.reliability === "watch")
+    return "예측을 참고하되 발주 전 최근 1주 판매 흐름을 한 번 더 확인하세요.";
   if (item.bias === "under")
     return "실제 판매가 예측보다 많습니다. 발주량 부족 위험을 먼저 확인하세요.";
   if (item.bias === "over")

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -1,5 +1,6 @@
 import {
   classifyStatus,
+  computeForecastBasis,
   forecastIngredientDemandFromMenus,
   forecastIngredient,
   forecastMenuDemand,
@@ -7,6 +8,7 @@ import {
   type DailyConsumption,
   type DailyMenuDemand,
   type ForecastResult,
+  type ForecastBasis,
   type IngredientDemandForecast,
   type PurchaseRecommendationResult,
 } from "@/lib/domain/forecast";
@@ -47,6 +49,7 @@ export interface MenuDemandForecastView {
   sevenDayTotalQuantity: number;
   trend: "rising" | "falling" | "normal";
   isColdStart: boolean;
+  basis: ForecastBasis;
   dailyPredictions: Array<{
     date: Date;
     predictedQuantity: number;
@@ -69,6 +72,7 @@ export interface MenuForecastAccuracyView {
   name: string;
   averageAbsoluteError: number | null;
   meanAbsolutePercentageError: number | null;
+  reliability: ForecastReliability;
   bias: "over" | "under" | "balanced" | "insufficient_data";
   evaluatedDayCount: number;
   actualTotalQuantity: number;
@@ -88,6 +92,7 @@ export interface IngredientForecastAccuracyView {
   unit: "g" | "ml" | "piece";
   averageAbsoluteError: number | null;
   meanAbsolutePercentageError: number | null;
+  reliability: ForecastReliability;
   bias: "over" | "under" | "balanced" | "insufficient_data";
   evaluatedDayCount: number;
   actualTotalAmount: number;
@@ -100,6 +105,8 @@ export interface IngredientForecastAccuracyView {
     absolutePercentageError: number | null;
   }>;
 }
+
+export type ForecastReliability = "good" | "watch" | "low" | "insufficient_data";
 
 export async function loadDepletionForecast(client: RpcClient): Promise<IngredientForecastView[]> {
   const { data, error } = await getDepletionForecast(client);
@@ -125,6 +132,8 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       today,
       sensitivity: row.forecastSensitivity,
     });
+    const basis =
+      forecast.basis ?? computeForecastBasis(samples, row.regularDaysOff, row.forecastSensitivity);
     return {
       ingredientId: row.ingredientId,
       name: row.name,
@@ -139,6 +148,7 @@ export async function loadDepletionForecast(client: RpcClient): Promise<Ingredie
       forecastSource: "consumption_history" as const,
       purchaseRecommendation: null,
       ...forecast,
+      basis,
     };
   });
 
@@ -214,6 +224,7 @@ export async function loadMenuDemandForecastViews(
         ),
         trend: forecast.trend,
         isColdStart: forecast.isColdStart,
+        basis: forecast.basis,
         dailyPredictions,
         optionGroups: row.optionGroups.map((group) => ({
           optionGroupId: group.optionGroupId,
@@ -298,6 +309,7 @@ export async function loadMenuForecastAccuracyViews(
         name: row.name,
         averageAbsoluteError,
         meanAbsolutePercentageError,
+        reliability: classifyForecastReliability(meanAbsolutePercentageError, evaluated.length),
         bias: classifyForecastBias(actualTotalQuantity, predictedTotalQuantity, evaluated.length),
         evaluatedDayCount: evaluated.length,
         actualTotalQuantity,
@@ -422,6 +434,7 @@ export async function loadIngredientForecastAccuracyViews(
         unit: ingredient.unit,
         averageAbsoluteError,
         meanAbsolutePercentageError,
+        reliability: classifyForecastReliability(meanAbsolutePercentageError, evaluated.length),
         bias: classifyForecastBias(actualTotalAmount, predictedTotalAmount, evaluated.length),
         evaluatedDayCount: evaluated.length,
         actualTotalAmount,
@@ -525,6 +538,16 @@ function classifyForecastBias(
   if (ratio >= 1.15) return "over";
   if (ratio <= 0.85) return "under";
   return "balanced";
+}
+
+function classifyForecastReliability(
+  meanAbsolutePercentageError: number | null,
+  evaluatedDayCount: number,
+): ForecastReliability {
+  if (evaluatedDayCount < 3 || meanAbsolutePercentageError === null) return "insufficient_data";
+  if (meanAbsolutePercentageError >= 0.8) return "low";
+  if (meanAbsolutePercentageError >= 0.35) return "watch";
+  return "good";
 }
 
 export interface ApplyInventoryReplayInput {

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -35,6 +35,7 @@ export type DepletionStatus = "safe" | "caution" | "order_needed" | "critical";
 export type ConsumptionTrend = "normal" | "rising" | "falling";
 export type BusinessDayType = "weekday" | "friday" | "weekend";
 export type ForecastSensitivity = "stable" | "balanced" | "responsive";
+export type ForecastConfidenceLevel = "high" | "medium" | "low" | "collecting";
 
 export interface ForecastTuning {
   recencyDecayDays: number;
@@ -138,6 +139,15 @@ export interface ForecastResult {
   status: DepletionStatus;
   trend: ConsumptionTrend;
   isColdStart: boolean;
+  basis: ForecastBasis;
+}
+
+export interface ForecastBasis {
+  model: "hierarchical_weekday";
+  usableSampleCount: number;
+  averageWeekdayConfidence: number;
+  maxWeekdayConfidence: number;
+  confidenceLevel: ForecastConfidenceLevel;
 }
 
 export interface PurchaseRecommendationInput {
@@ -176,6 +186,7 @@ export interface MenuDemandForecastResult {
   fallbackDailyQuantity: number;
   trend: ConsumptionTrend;
   isColdStart: boolean;
+  basis: ForecastBasis;
 }
 
 export interface UsageForecastModel {
@@ -538,6 +549,51 @@ export function computeTrendFactor(samples: readonly DailyConsumption[], today: 
   return clamp(last7Avg.dividedBy(last30Avg).toNumber(), TREND_FACTOR_MIN, TREND_FACTOR_MAX);
 }
 
+export function computeForecastBasis(
+  samples: readonly DailyConsumption[],
+  daysOff: readonly Weekday[],
+  sensitivity: ForecastSensitivity = "balanced",
+): ForecastBasis {
+  const tuning = FORECAST_TUNING_PRESETS[sensitivity];
+  const weekdayCounts = new Map<Weekday, number>();
+  let usableSampleCount = 0;
+
+  for (const sample of samples) {
+    if (sample.amount <= 0 || isRegularDayOff(sample.date, daysOff)) continue;
+    usableSampleCount += 1;
+    const weekday = weekdayOf(sample.date);
+    weekdayCounts.set(weekday, (weekdayCounts.get(weekday) ?? 0) + 1);
+  }
+
+  const confidences = Array.from(weekdayCounts.values()).map((count) =>
+    Math.min(count / (count + tuning.weekdayPriorStrength), tuning.maxWeekdayConfidence),
+  );
+  const averageWeekdayConfidence =
+    confidences.length > 0
+      ? confidences.reduce((sum, confidence) => sum + confidence, 0) / confidences.length
+      : 0;
+  const maxWeekdayConfidence =
+    confidences.length > 0 ? Math.max(...confidences) : tuning.maxWeekdayConfidence;
+
+  return {
+    model: "hierarchical_weekday",
+    usableSampleCount,
+    averageWeekdayConfidence,
+    maxWeekdayConfidence,
+    confidenceLevel: classifyForecastConfidence(usableSampleCount, averageWeekdayConfidence),
+  };
+}
+
+function classifyForecastConfidence(
+  usableSampleCount: number,
+  averageWeekdayConfidence: number,
+): ForecastConfidenceLevel {
+  if (usableSampleCount < COLD_START_DAYS) return "collecting";
+  if (usableSampleCount < 14 || averageWeekdayConfidence < 0.35) return "low";
+  if (usableSampleCount < 30 || averageWeekdayConfidence < 0.65) return "medium";
+  return "high";
+}
+
 function averageOverDays(
   samples: readonly DailyConsumption[],
   today: Date,
@@ -554,12 +610,14 @@ function averageOverDays(
  * 한 재료의 예측 합성 함수 — 호출 측 (UI / RPC) 진입점.
  */
 export function forecastIngredient(input: ForecastInput): ForecastResult {
+  const basis = computeForecastBasis(input.consumptionSamples, input.daysOff, input.sensitivity);
   if (isColdStart(input.signupDate, input.today)) {
     return {
       expectedDepletionDate: null,
       status: "safe",
       trend: "normal",
       isColdStart: true,
+      basis,
     };
   }
 
@@ -583,6 +641,7 @@ export function forecastIngredient(input: ForecastInput): ForecastResult {
     status: classifyStatus(depletionDate, input.leadTimeDays, input.safetyBufferDays, input.today),
     trend,
     isColdStart: false,
+    basis,
   };
 }
 
@@ -595,19 +654,21 @@ export function forecastIngredient(input: ForecastInput): ForecastResult {
  */
 export function forecastMenuDemand(input: MenuDemandForecastInput): MenuDemandForecastResult {
   const horizonDays = input.horizonDays ?? 7;
+  const consumptionLikeSamples = input.demandSamples.map((sample) => ({
+    date: sample.date,
+    amount: sample.quantity,
+  }));
+  const basis = computeForecastBasis(consumptionLikeSamples, input.daysOff, input.sensitivity);
   if (isColdStart(input.signupDate, input.today)) {
     return {
       dailyPredictions: buildZeroMenuDemandDays(input.today, horizonDays, input.daysOff),
       fallbackDailyQuantity: 0,
       trend: "normal",
       isColdStart: true,
+      basis,
     };
   }
 
-  const consumptionLikeSamples = input.demandSamples.map((sample) => ({
-    date: sample.date,
-    amount: sample.quantity,
-  }));
   const model = computeBusinessDayUsageModel(
     consumptionLikeSamples,
     input.daysOff,
@@ -642,6 +703,7 @@ export function forecastMenuDemand(input: MenuDemandForecastInput): MenuDemandFo
     fallbackDailyQuantity: model.fallbackDailyUsage.toNumber(),
     trend,
     isColdStart: false,
+    basis,
   };
 }
 

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -291,6 +291,13 @@ describe("application layer", () => {
           isColdStart: false,
           forecastSource: "consumption_history",
           purchaseRecommendation: null,
+          basis: {
+            model: "hierarchical_weekday",
+            usableSampleCount: 1,
+            averageWeekdayConfidence: 1 / 13,
+            maxWeekdayConfidence: 1 / 13,
+            confidenceLevel: "collecting",
+          },
         },
       ]);
 

--- a/tests/unit/calendar-menu-forecast.test.ts
+++ b/tests/unit/calendar-menu-forecast.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "vitest";
 import { buildCalendarMenuForecastByDate } from "@/features/calendar/lib/menu-forecast-calendar";
 import type { MenuDemandForecastView } from "@/features/inventory/hooks/useMenuDemandForecast";
 
+const basis: MenuDemandForecastView["basis"] = {
+  model: "hierarchical_weekday",
+  usableSampleCount: 30,
+  averageWeekdayConfidence: 0.6,
+  maxWeekdayConfidence: 0.85,
+  confidenceLevel: "medium",
+};
+
 describe("calendar menu forecast summary", () => {
   it("groups menu demand forecasts by date and sums revenue", () => {
     const forecasts: MenuDemandForecastView[] = [
@@ -13,6 +21,7 @@ describe("calendar menu forecast summary", () => {
         sevenDayTotalQuantity: 2,
         trend: "normal",
         isColdStart: false,
+        basis,
         dailyPredictions: [{ date: new Date("2026-06-20T00:00:00"), predictedQuantity: 2 }],
         optionGroups: [],
       },
@@ -24,6 +33,7 @@ describe("calendar menu forecast summary", () => {
         sevenDayTotalQuantity: 1.5,
         trend: "normal",
         isColdStart: false,
+        basis,
         dailyPredictions: [{ date: new Date("2026-06-20T00:00:00"), predictedQuantity: 1.5 }],
         optionGroups: [],
       },

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -15,10 +15,19 @@ import {
   recommendPurchaseQuantity,
   type DailyConsumption,
   type DailyMenuDemand,
+  type ForecastBasis,
 } from "@/lib/domain/forecast";
 
 const ONE_DAY = 24 * 60 * 60 * 1000;
 const today = new Date("2026-04-30T00:00:00");
+
+const forecastBasis: ForecastBasis = {
+  model: "hierarchical_weekday",
+  usableSampleCount: 30,
+  averageWeekdayConfidence: 0.6,
+  maxWeekdayConfidence: 0.85,
+  confidenceLevel: "medium",
+};
 
 function daysAgo(days: number): Date {
   return new Date(today.getTime() - days * ONE_DAY);
@@ -657,6 +666,7 @@ describe("forecastIngredientDemandFromMenus", () => {
           fallbackDailyQuantity: 100,
           trend: "normal",
           isColdStart: false,
+          basis: forecastBasis,
         },
       },
     ]);
@@ -711,6 +721,7 @@ describe("forecastIngredientDemandFromMenus", () => {
           fallbackDailyQuantity: 90,
           trend: "normal",
           isColdStart: false,
+          basis: forecastBasis,
         },
       },
     ]);
@@ -763,6 +774,7 @@ describe("forecastIngredientDemandFromMenus", () => {
           fallbackDailyQuantity: 10,
           trend: "normal",
           isColdStart: false,
+          basis: forecastBasis,
         },
       },
     ]);


### PR DESCRIPTION
## Summary
- add forecast basis metadata: usable sample count, weekday confidence, confidence level
- show forecast confidence and calculation context on menu demand and ingredient depletion views
- add backtest reliability labels for menu and ingredient forecast accuracy cards

## Tests
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/forecast.test.ts tests/unit/application.test.ts tests/unit/calendar-menu-forecast.test.ts
- npm run test
- npm run build

## Migration
- none