### PR TITLE
Show accuracy summaries on forecast pages

### DIFF
--- a/src/app/(main)/inventory/menu-forecast/page.tsx
+++ b/src/app/(main)/inventory/menu-forecast/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { ForecastPeriodSelector } from "@/features/inventory/components/ForecastPeriodSelector";
 import { MenuDemandForecastList } from "@/features/inventory/components/MenuDemandForecastList";
 import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
+import { useMenuForecastAccuracy } from "@/features/inventory/hooks/useMenuForecastAccuracy";
 import { PageHeader } from "@/components/ui/page-header";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
@@ -24,6 +25,7 @@ function MenuForecastContent(): React.ReactElement {
   const searchParams = useSearchParams();
   const horizonDays = parseOption(searchParams.get("horizon"), HORIZON_OPTIONS, 7);
   const query = useMenuDemandForecast(horizonDays);
+  const accuracyQuery = useMenuForecastAccuracy(14);
 
   return (
     <section className="flex flex-col gap-section">
@@ -61,7 +63,9 @@ function MenuForecastContent(): React.ReactElement {
 
       {query.isLoading && <LoadingText />}
       {query.error && <ErrorAlert message={query.error.message} />}
-      {query.data && <MenuDemandForecastList items={query.data} />}
+      {query.data && (
+        <MenuDemandForecastList items={query.data} accuracyItems={accuracyQuery.data ?? []} />
+      )}
     </section>
   );
 }

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -121,7 +121,7 @@ function IngredientRow({
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
             <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
             {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
-            {accuracy && <AccuracyRiskBadge accuracy={accuracy} />}
+            {accuracy && <AccuracyBadge accuracy={accuracy} />}
           </div>
           <button
             type="button"
@@ -203,37 +203,36 @@ function OrderFactor({ label, value }: { label: string; value: string }): React.
   );
 }
 
-function AccuracyRiskBadge({
+function AccuracyBadge({
   accuracy,
 }: {
   accuracy: IngredientForecastAccuracyView;
-}): React.ReactElement | null {
-  const risk = getAccuracyRisk(accuracy);
-  if (!risk) return null;
+}): React.ReactElement {
+  const label = formatAccuracyLabel(accuracy);
 
   return (
     <Link
-      href="/inventory/forecast-accuracy"
+      href="/inventory/forecast-accuracy?tab=ingredient"
       className={cn(
         "rounded-full px-2 py-0.5 text-micro shadow-soft",
-        risk.tone === "red" ? "bg-red-soft text-red-deep" : "bg-amber-soft text-amber-deep",
+        accuracy.reliability === "good"
+          ? "bg-blue-soft text-blue-deep"
+          : accuracy.reliability === "watch"
+            ? "bg-amber-soft text-amber-deep"
+            : accuracy.reliability === "low"
+              ? "bg-red-soft text-red-deep"
+              : "bg-bg text-ink-3",
       )}
     >
-      {risk.label}
+      {label}
     </Link>
   );
 }
 
-function getAccuracyRisk(accuracy: IngredientForecastAccuracyView): {
-  label: string;
-  tone: "red" | "amber";
-} | null {
-  if (accuracy.evaluatedDayCount < 3) return { label: "예측 데이터 부족", tone: "amber" };
+function formatAccuracyLabel(accuracy: IngredientForecastAccuracyView): string {
   const mape = accuracy.meanAbsolutePercentageError;
-  if (mape === null) return null;
-  if (mape >= 0.8) return { label: "예측 신뢰도 낮음", tone: "red" };
-  if (mape >= 0.5 || accuracy.bias === "under") return { label: "발주량 확인 필요", tone: "amber" };
-  return null;
+  if (mape === null || accuracy.evaluatedDayCount < 3) return "정확도 수집 중";
+  return `오차 ${Math.round(mape * 100)}%`;
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {

--- a/src/features/inventory/components/MenuDemandForecastList.tsx
+++ b/src/features/inventory/components/MenuDemandForecastList.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { formatNumber, WEEKDAY_KO } from "@/lib/utils/format";
 import type { MenuDemandForecastView } from "../hooks/useMenuDemandForecast";
+import type { MenuForecastAccuracyView } from "../hooks/useMenuForecastAccuracy";
 
 interface MenuDemandForecastListProps {
   items: readonly MenuDemandForecastView[];
+  accuracyItems?: readonly MenuForecastAccuracyView[];
 }
 
 const TREND_LABEL: Record<MenuDemandForecastView["trend"], string> = {
@@ -21,7 +24,10 @@ const CONFIDENCE_LABEL: Record<MenuDemandForecastView["basis"]["confidenceLevel"
   collecting: "데이터 수집 중",
 };
 
-export function MenuDemandForecastList({ items }: MenuDemandForecastListProps): React.ReactElement {
+export function MenuDemandForecastList({
+  items,
+  accuracyItems = [],
+}: MenuDemandForecastListProps): React.ReactElement {
   if (items.length === 0) {
     return (
       <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
@@ -30,16 +36,28 @@ export function MenuDemandForecastList({ items }: MenuDemandForecastListProps): 
     );
   }
 
+  const accuracyByMenu = new Map(accuracyItems.map((accuracy) => [accuracy.menuId, accuracy]));
+
   return (
     <div className="flex flex-col gap-stack">
       {items.map((item) => (
-        <MenuDemandForecastCard key={item.menuId} item={item} />
+        <MenuDemandForecastCard
+          key={item.menuId}
+          item={item}
+          accuracy={accuracyByMenu.get(item.menuId)}
+        />
       ))}
     </div>
   );
 }
 
-function MenuDemandForecastCard({ item }: { item: MenuDemandForecastView }): React.ReactElement {
+function MenuDemandForecastCard({
+  item,
+  accuracy,
+}: {
+  item: MenuDemandForecastView;
+  accuracy?: MenuForecastAccuracyView;
+}): React.ReactElement {
   const maxDailyQuantity = Math.max(
     1,
     ...item.dailyPredictions.map((day) => day.predictedQuantity),
@@ -58,6 +76,7 @@ function MenuDemandForecastCard({ item }: { item: MenuDemandForecastView }): Rea
         <div className="flex shrink-0 flex-col items-end gap-1">
           <TrendBadge trend={item.trend} isColdStart={item.isColdStart} />
           <ConfidenceBadge level={item.basis.confidenceLevel} />
+          {accuracy && <AccuracyBadge accuracy={accuracy} />}
         </div>
       </div>
 
@@ -93,6 +112,29 @@ function MenuDemandForecastCard({ item }: { item: MenuDemandForecastView }): Rea
         </div>
       )}
     </article>
+  );
+}
+
+function AccuracyBadge({ accuracy }: { accuracy: MenuForecastAccuracyView }): React.ReactElement {
+  const mape = accuracy.meanAbsolutePercentageError;
+  const label = mape === null ? "정확도 수집 중" : `오차 ${formatPercent(mape)}`;
+
+  return (
+    <Link
+      href="/inventory/forecast-accuracy?tab=menu"
+      className={cn(
+        "rounded-full px-2 py-0.5 text-micro shadow-soft",
+        accuracy.reliability === "good"
+          ? "bg-blue-soft text-blue-deep"
+          : accuracy.reliability === "watch"
+            ? "bg-amber-soft text-amber-deep"
+            : accuracy.reliability === "low"
+              ? "bg-red-soft text-red-deep"
+              : "bg-bg text-ink-3",
+      )}
+    >
+      {label}
+    </Link>
   );
 }
 
@@ -194,6 +236,10 @@ function formatQuantity(value: number): string {
 }
 
 function formatRate(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
 }
 


### PR DESCRIPTION
## Summary
- show recent menu forecast error badges on the menu demand forecast page
- show simple ingredient forecast error badges on the ingredient forecast page
- link badges to the matching accuracy tab for detailed review

## Tests
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test

## Migration
- none