### PR TITLE
Add revenue forecast accuracy

### DIFF
--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import { useCalendarMonth } from "@/features/calendar/hooks/useCalendarMonth";
 import { useMenuForecastAccuracy } from "@/features/inventory/hooks/useMenuForecastAccuracy";
 import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
+import { useRevenueForecastAccuracy } from "@/features/inventory/hooks/useRevenueForecastAccuracy";
 import { useSaleByDate, type SaleWithItems } from "@/features/sale/hooks/useSaleByDate";
 import {
   buildCalendarMenuForecastByDate,
@@ -25,6 +26,7 @@ import { Metric } from "@/components/ui/metric";
 import { cn } from "@/lib/utils";
 import type { EnrichedCalendarCell } from "@/features/calendar/lib/consecutive-missing";
 import type { MenuForecastAccuracyView } from "@/features/inventory/hooks/useMenuForecastAccuracy";
+import type { RevenueForecastAccuracyView } from "@/features/inventory/hooks/useRevenueForecastAccuracy";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -44,6 +46,7 @@ export default function CalendarDateDetailPage(): React.ReactElement {
   const saleQuery = useSaleByDate(date);
   const menuForecastQuery = useMenuDemandForecast(forecastHorizonDays);
   const menuAccuracyQuery = useMenuForecastAccuracy(30);
+  const revenueAccuracyQuery = useRevenueForecastAccuracy(30, !isFutureDate);
 
   if (!parsedDate) {
     return (
@@ -58,6 +61,7 @@ export default function CalendarDateDetailPage(): React.ReactElement {
   const menuForecast =
     buildCalendarMenuForecastByDate(menuForecastQuery.data ?? []).get(date) ?? null;
   const menuBacktest = buildMenuBacktestSummaryForDate(date, menuAccuracyQuery.data ?? []);
+  const revenueBacktest = buildRevenueBacktestSummaryForDate(date, revenueAccuracyQuery.data);
   const prevDate = addDaysIso(parsedDate, -1);
   const nextDate = addDaysIso(parsedDate, 1);
 
@@ -92,6 +96,7 @@ export default function CalendarDateDetailPage(): React.ReactElement {
           sale={saleQuery.data ?? null}
           menuForecast={menuForecast}
           menuBacktest={menuBacktest}
+          revenueBacktest={revenueBacktest}
           todayIso={todayIso}
         />
       )}
@@ -106,6 +111,7 @@ interface DateDetailBodyProps {
   sale: SaleWithItems | null;
   menuForecast: CalendarMenuForecastSummary | null;
   menuBacktest: MenuBacktestDateSummary | null;
+  revenueBacktest: RevenueBacktestDateSummary | null;
   todayIso: string;
 }
 
@@ -116,6 +122,7 @@ function DateDetailBody({
   sale,
   menuForecast,
   menuBacktest,
+  revenueBacktest,
   todayIso,
 }: DateDetailBodyProps): React.ReactElement {
   const today = parseLocalDateFromIso(todayIso) ?? new Date();
@@ -136,6 +143,7 @@ function DateDetailBody({
         sale={sale}
         hasPurchase={cell?.hasPurchase ?? false}
         menuBacktest={menuBacktest}
+        revenueBacktest={revenueBacktest}
       />
     );
   }
@@ -225,12 +233,14 @@ interface ExistingSaleDetailProps {
   sale: SaleWithItems;
   hasPurchase: boolean;
   menuBacktest: MenuBacktestDateSummary | null;
+  revenueBacktest: RevenueBacktestDateSummary | null;
 }
 
 function ExistingSaleDetail({
   sale,
   hasPurchase,
   menuBacktest,
+  revenueBacktest,
 }: ExistingSaleDetailProps): React.ReactElement {
   const totalRevenue = sale.total_revenue;
   const totalCost = sale.total_cost_snapshot;
@@ -263,6 +273,7 @@ function ExistingSaleDetail({
         )}
       </article>
 
+      {revenueBacktest && <RevenueBacktestComparison summary={revenueBacktest} />}
       {menuBacktest && <MenuBacktestComparison summary={menuBacktest} />}
 
       <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
@@ -277,6 +288,55 @@ function ExistingSaleDetail({
         </ul>
       </article>
     </div>
+  );
+}
+
+interface RevenueBacktestDateSummary {
+  actualRevenue: number;
+  predictedRevenue: number;
+  absoluteError: number;
+  absolutePercentageError: number | null;
+  reliability: MenuForecastAccuracyView["reliability"];
+  bias: "over" | "under" | "balanced" | "insufficient_data";
+}
+
+function RevenueBacktestComparison({
+  summary,
+}: {
+  summary: RevenueBacktestDateSummary;
+}): React.ReactElement {
+  return (
+    <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
+      <div className="flex items-start justify-between gap-stack">
+        <div>
+          <h2 className="text-title-md text-ink-1">매출 예측 vs 실제</h2>
+          <p className="mt-1 text-caption text-ink-3">
+            백테스트 기준 · {RELIABILITY_LABEL[summary.reliability]} ·{" "}
+            {REVENUE_BIAS_LABEL[summary.bias]}
+          </p>
+        </div>
+        <span
+          className={cn(
+            "rounded-full px-2.5 py-1 text-micro",
+            summary.reliability === "low"
+              ? "bg-red-soft text-red-deep"
+              : summary.reliability === "watch"
+                ? "bg-amber-soft text-amber-deep"
+                : "bg-blue-soft text-blue-deep",
+          )}
+        >
+          오차율{" "}
+          {summary.absolutePercentageError === null
+            ? "-"
+            : `${Math.round(summary.absolutePercentageError * 100)}%`}
+        </span>
+      </div>
+      <div className="grid grid-cols-3 gap-stack">
+        <Metric label="실제 매출" value={`${formatWon(summary.actualRevenue)}원`} />
+        <Metric label="예측 매출" value={`${formatWon(summary.predictedRevenue)}원`} />
+        <Metric label="오차" value={`${formatWon(summary.absoluteError)}원`} />
+      </div>
+    </article>
   );
 }
 
@@ -519,6 +579,34 @@ function buildMenuBacktestSummaryForDate(
   };
 }
 
+function buildRevenueBacktestSummaryForDate(
+  date: string,
+  data: RevenueForecastAccuracyView | undefined,
+): RevenueBacktestDateSummary | null {
+  const result = data?.dailyResults.find((day) => localIsoDate(day.date) === date);
+  if (!result || result.actualRevenue <= 0) return null;
+
+  return {
+    actualRevenue: result.actualRevenue,
+    predictedRevenue: result.predictedRevenue,
+    absoluteError: result.absoluteError,
+    absolutePercentageError: result.absolutePercentageError,
+    reliability: classifyDateBacktestReliability(result.absolutePercentageError, 1),
+    bias: classifyRevenueBias(result.actualRevenue, result.predictedRevenue),
+  };
+}
+
+function classifyRevenueBias(
+  actualRevenue: number,
+  predictedRevenue: number,
+): RevenueBacktestDateSummary["bias"] {
+  if (actualRevenue <= 0) return "insufficient_data";
+  const ratio = predictedRevenue / actualRevenue;
+  if (ratio >= 1.15) return "over";
+  if (ratio <= 0.85) return "under";
+  return "balanced";
+}
+
 function classifyDateBacktestReliability(
   meanAbsolutePercentageError: number | null,
   evaluatedItemCount: number,
@@ -540,6 +628,13 @@ const RELIABILITY_LABEL: Record<MenuForecastAccuracyView["reliability"], string>
   good: "신뢰도 좋음",
   watch: "주의",
   low: "신뢰도 낮음",
+  insufficient_data: "데이터 부족",
+};
+
+const REVENUE_BIAS_LABEL: Record<RevenueBacktestDateSummary["bias"], string> = {
+  over: "과대예측",
+  under: "과소예측",
+  balanced: "균형",
   insufficient_data: "데이터 부족",
 };
 

--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -273,9 +273,6 @@ function ExistingSaleDetail({
         )}
       </article>
 
-      {revenueBacktest && <RevenueBacktestComparison summary={revenueBacktest} />}
-      {menuBacktest && <MenuBacktestComparison summary={menuBacktest} />}
-
       <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
         <div className="flex items-center justify-between gap-stack">
           <h2 className="text-title-md text-ink-1">판매 내역</h2>
@@ -287,6 +284,9 @@ function ExistingSaleDetail({
           ))}
         </ul>
       </article>
+
+      {revenueBacktest && <RevenueBacktestComparison summary={revenueBacktest} />}
+      {menuBacktest && <MenuBacktestComparison summary={menuBacktest} />}
     </div>
   );
 }

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -5,13 +5,14 @@ import { useRouter } from "next/navigation";
 import { differenceInCalendarDays } from "date-fns";
 import { useCalendarMonth } from "@/features/calendar/hooks/useCalendarMonth";
 import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
+import { useRevenueForecastAccuracy } from "@/features/inventory/hooks/useRevenueForecastAccuracy";
 import { MonthHeader } from "@/features/calendar/components/MonthHeader";
 import { MonthCumulativeCard } from "@/features/calendar/components/MonthCumulativeCard";
 import { CalendarGrid } from "@/features/calendar/components/CalendarGrid";
 import { CalendarLegend } from "@/features/calendar/components/CalendarLegend";
 import { buildCalendarMenuForecastByDate } from "@/features/calendar/lib/menu-forecast-calendar";
 import { trackEvent } from "@/lib/analytics/ga4";
-import { parseLocalDateFromIso } from "@/lib/utils/format";
+import { localIsoDate, parseLocalDateFromIso } from "@/lib/utils/format";
 import { useTodayIso } from "@/lib/utils/use-today-iso";
 import type { EnrichedCalendarCell } from "@/features/calendar/lib/consecutive-missing";
 
@@ -41,10 +42,18 @@ export default function CalendarPage(): React.ReactElement {
 
   const query = useCalendarMonth(year, month);
   const menuForecastQuery = useMenuDemandForecast(forecastHorizonDays);
+  const revenueAccuracyQuery = useRevenueForecastAccuracy(30);
   const menuForecastByDate = useMemo(
     () => buildCalendarMenuForecastByDate(menuForecastQuery.data ?? []),
     [menuForecastQuery.data],
   );
+  const revenueErrorByDate = useMemo(() => {
+    const map = new Map<string, number | null>();
+    for (const day of revenueAccuracyQuery.data?.dailyResults ?? []) {
+      map.set(localIsoDate(day.date), day.absolutePercentageError);
+    }
+    return map;
+  }, [revenueAccuracyQuery.data]);
 
   // primitive deps로 month 변경 + operating_days 변경에만 발화. 동일 데이터 refetch엔 skip.
   const operatingDays = query.data?.cumulative.operatingDays ?? null;
@@ -116,6 +125,7 @@ export default function CalendarPage(): React.ReactElement {
         month={month}
         cells={query.data.cells}
         menuForecastByDate={menuForecastByDate}
+        revenueErrorByDate={revenueErrorByDate}
         selectedDate={null}
         todayIso={todayIso}
         onSelect={handleSelect}

--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -6,15 +6,17 @@ import { useSearchParams } from "next/navigation";
 import { ForecastPeriodSelector } from "@/features/inventory/components/ForecastPeriodSelector";
 import { IngredientForecastAccuracyList } from "@/features/inventory/components/IngredientForecastAccuracyList";
 import { MenuForecastAccuracyList } from "@/features/inventory/components/MenuForecastAccuracyList";
+import { RevenueForecastAccuracyCard } from "@/features/inventory/components/RevenueForecastAccuracyCard";
 import { useIngredientForecastAccuracy } from "@/features/inventory/hooks/useIngredientForecastAccuracy";
 import { useMenuForecastAccuracy } from "@/features/inventory/hooks/useMenuForecastAccuracy";
+import { useRevenueForecastAccuracy } from "@/features/inventory/hooks/useRevenueForecastAccuracy";
 import { PageHeader } from "@/components/ui/page-header";
 import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 import { cn } from "@/lib/utils";
 
 const BACKTEST_OPTIONS = [14, 30, 60] as const;
-const ACCURACY_TABS = ["menu", "ingredient"] as const;
+const ACCURACY_TABS = ["revenue", "menu", "ingredient"] as const;
 
 type AccuracyTab = (typeof ACCURACY_TABS)[number];
 
@@ -30,6 +32,7 @@ function ForecastAccuracyContent(): React.ReactElement {
   const searchParams = useSearchParams();
   const backtestDays = parseOption(searchParams.get("days"), BACKTEST_OPTIONS, 14);
   const activeTab = parseTab(searchParams.get("tab"));
+  const revenueQuery = useRevenueForecastAccuracy(backtestDays, activeTab === "revenue");
   const menuQuery = useMenuForecastAccuracy(backtestDays, activeTab === "menu");
   const ingredientQuery = useIngredientForecastAccuracy(backtestDays, activeTab === "ingredient");
 
@@ -46,8 +49,7 @@ function ForecastAccuracyContent(): React.ReactElement {
 
       <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
         <p className="text-body text-ink-1">
-          최근 {backtestDays}일 기준으로 {activeTab === "menu" ? "메뉴 판매" : "재료 소비"} 예측과
-          실제값을 비교합니다.
+          최근 {backtestDays}일 기준으로 {getTabNoun(activeTab)} 예측과 실제값을 비교합니다.
         </p>
         <p className="mt-1 text-caption text-ink-3">
           각 날짜의 예측은 그 전날까지의 판매 이력만 사용해 다시 계산합니다.
@@ -66,7 +68,16 @@ function ForecastAccuracyContent(): React.ReactElement {
         extraParams={{ tab: activeTab }}
       />
 
-      {activeTab === "menu" ? (
+      {activeTab === "revenue" ? (
+        <AccuracySection
+          title="매출 예측 정확도"
+          description="메뉴 수요 예측으로 환산한 예상 매출과 실제 매출을 비교합니다."
+        >
+          {revenueQuery.isLoading && <LoadingText />}
+          {revenueQuery.error && <ErrorAlert message={revenueQuery.error.message} />}
+          {revenueQuery.data && <RevenueForecastAccuracyCard data={revenueQuery.data} />}
+        </AccuracySection>
+      ) : activeTab === "menu" ? (
         <AccuracySection
           title="메뉴 예측 정확도"
           description="메뉴별 예상 판매량과 실제 판매량을 비교합니다."
@@ -95,7 +106,13 @@ function parseOption<T extends number>(raw: string | null, options: readonly T[]
 }
 
 function parseTab(raw: string | null): AccuracyTab {
-  return ACCURACY_TABS.includes(raw as AccuracyTab) ? (raw as AccuracyTab) : "menu";
+  return ACCURACY_TABS.includes(raw as AccuracyTab) ? (raw as AccuracyTab) : "revenue";
+}
+
+function getTabNoun(tab: AccuracyTab): string {
+  if (tab === "revenue") return "매출";
+  if (tab === "menu") return "메뉴 판매";
+  return "재료 소비";
 }
 
 function AccuracyTabNav({
@@ -108,8 +125,15 @@ function AccuracyTabNav({
   return (
     <nav
       aria-label="예측 정확도 종류"
-      className="grid gap-stack-tight rounded-[24px] border border-border bg-card p-2 shadow-soft sm:grid-cols-2"
+      className="grid gap-stack-tight rounded-[24px] border border-border bg-card p-2 shadow-soft md:grid-cols-3"
     >
+      <AccuracyTabLink
+        tab="revenue"
+        activeTab={activeTab}
+        backtestDays={backtestDays}
+        title="매출 예측"
+        description="운영 판단 기준"
+      />
       <AccuracyTabLink
         tab="menu"
         activeTab={activeTab}

--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -41,7 +41,7 @@ function ForecastAccuracyContent(): React.ReactElement {
       <PageHeader
         title="예측 정확도"
         action={
-          <Link href="/inventory/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
+          <Link href="/menu/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
             메뉴 예측
           </Link>
         }

--- a/src/app/(main)/inventory/menu-forecast/page.tsx
+++ b/src/app/(main)/inventory/menu-forecast/page.tsx
@@ -33,7 +33,7 @@ function MenuForecastContent(): React.ReactElement {
         title="메뉴 수요 예측"
         action={
           <div className="flex gap-stack-tight">
-            <Link href="/inventory/forecast-accuracy" className={SECONDARY_BUTTON_CLASSES}>
+            <Link href="/inventory/forecast-accuracy?tab=menu" className={SECONDARY_BUTTON_CLASSES}>
               정확도
             </Link>
             <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>

--- a/src/app/(main)/menu/menu-forecast/page.tsx
+++ b/src/app/(main)/menu/menu-forecast/page.tsx
@@ -58,7 +58,7 @@ function MenuForecastContent(): React.ReactElement {
         selectedValue={horizonDays}
         options={HORIZON_OPTIONS}
         suffix="일"
-        pathname="/inventory/menu-forecast"
+        pathname="/menu/menu-forecast"
       />
 
       {query.isLoading && <LoadingText />}

--- a/src/app/(main)/menu/page.tsx
+++ b/src/app/(main)/menu/page.tsx
@@ -17,7 +17,7 @@ export default function MenuPage(): React.ReactElement {
         title="메뉴"
         action={
           <div className="flex gap-stack-tight">
-            <Link href="/inventory/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
+            <Link href="/menu/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
               메뉴 예측
             </Link>
             <Link href="/menu/new" className={SECONDARY_BUTTON_CLASSES}>

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -146,6 +146,7 @@ function DayCell({
 
 interface CellStatus {
   label: string;
+  subLabel?: string;
   tone: "red" | "blue" | "ink";
 }
 
@@ -163,7 +164,8 @@ function getCellStatus(
   }
   if (cell.revenue !== null && cell.revenue > 0 && revenueError !== null) {
     return {
-      label: `오차 ${Math.round(revenueError * 100)}%`,
+      label: `${formatNumber(Math.round(cell.revenue / 10000))}만`,
+      subLabel: `오차 ${Math.round(revenueError * 100)}%`,
       tone: revenueError >= 0.35 ? "red" : "blue",
     };
   }
@@ -177,7 +179,7 @@ function CellStatusBadge({ status }: { status: CellStatus }): React.ReactElement
   return (
     <span
       className={cn(
-        "w-fit rounded-full px-2 py-1 text-[10px] font-semibold leading-none shadow-soft sm:text-micro",
+        "flex w-fit flex-col gap-0.5 rounded-xl px-2 py-1 text-[10px] font-semibold leading-none shadow-soft sm:text-micro",
         status.tone === "red"
           ? "bg-red-soft text-red-deep"
           : status.tone === "blue"
@@ -185,7 +187,10 @@ function CellStatusBadge({ status }: { status: CellStatus }): React.ReactElement
             : "bg-white/90 text-ink-1",
       )}
     >
-      {status.label}
+      <span>{status.label}</span>
+      {status.subLabel && (
+        <span className="text-[9px] opacity-80 sm:text-[10px]">{status.subLabel}</span>
+      )}
     </span>
   );
 }

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -11,6 +11,7 @@ interface CalendarGridProps {
   month: number;
   cells: readonly EnrichedCalendarCell[];
   menuForecastByDate?: ReadonlyMap<string, CalendarMenuForecastSummary>;
+  revenueErrorByDate?: ReadonlyMap<string, number | null>;
   selectedDate: string | null;
   todayIso: string | null;
   onSelect: (cell: EnrichedCalendarCell) => void;
@@ -28,6 +29,7 @@ export function CalendarGrid({
   month,
   cells,
   menuForecastByDate,
+  revenueErrorByDate,
   selectedDate,
   todayIso,
   onSelect,
@@ -49,6 +51,7 @@ export function CalendarGrid({
             key={cell.date}
             cell={cell}
             forecast={menuForecastByDate?.get(cell.date) ?? null}
+            revenueError={revenueErrorByDate?.get(cell.date) ?? null}
             maxRevenue={maxRevenue}
             isSelected={cell.date === selectedDate}
             isToday={cell.date === todayIso}
@@ -82,6 +85,7 @@ function BlankCell(): React.ReactElement {
 interface DayCellProps {
   cell: EnrichedCalendarCell;
   forecast: CalendarMenuForecastSummary | null;
+  revenueError: number | null;
   maxRevenue: number;
   isSelected: boolean;
   isToday: boolean;
@@ -91,6 +95,7 @@ interface DayCellProps {
 function DayCell({
   cell,
   forecast,
+  revenueError,
   maxRevenue,
   isSelected,
   isToday,
@@ -102,7 +107,7 @@ function DayCell({
   const weekday = date.getDay();
   const isInactive = cell.isFuture || cell.isBeforeSignup || cell.isRegularDayOff;
   const intensityPct = computeIntensityPercent(cell.revenue ?? 0, maxRevenue, isInactive);
-  const status = getCellStatus(cell, forecast);
+  const status = getCellStatus(cell, forecast, revenueError);
 
   return (
     <button
@@ -147,12 +152,19 @@ interface CellStatus {
 function getCellStatus(
   cell: EnrichedCalendarCell,
   forecast: CalendarMenuForecastSummary | null,
+  revenueError: number | null,
 ): CellStatus | null {
   if (cell.isMissing) return { label: "누락", tone: "red" };
   if (cell.isFuture && forecast && forecast.totalRevenue > 0) {
     return {
       label: `예상 ${formatNumber(Math.round(forecast.totalRevenue / 10000))}만`,
       tone: "blue",
+    };
+  }
+  if (cell.revenue !== null && cell.revenue > 0 && revenueError !== null) {
+    return {
+      label: `오차 ${Math.round(revenueError * 100)}%`,
+      tone: revenueError >= 0.35 ? "red" : "blue",
     };
   }
   if (cell.revenue !== null && cell.revenue > 0) {

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -107,7 +107,7 @@ function DayCell({
   const weekday = date.getDay();
   const isInactive = cell.isFuture || cell.isBeforeSignup || cell.isRegularDayOff;
   const intensityPct = computeIntensityPercent(cell.revenue ?? 0, maxRevenue, isInactive);
-  const status = getCellStatus(cell, forecast, revenueError);
+  const tags = getCellTags(cell, forecast, revenueError);
 
   return (
     <button
@@ -139,58 +139,63 @@ function DayCell({
         <TopBadges cell={cell} />
       </div>
 
-      {!isSelected && status && <CellStatusBadge status={status} />}
+      {!isSelected && tags.length > 0 && <CellStatusTags tags={tags} />}
     </button>
   );
 }
 
-interface CellStatus {
+interface CellStatusTag {
   label: string;
-  subLabel?: string;
   tone: "red" | "blue" | "ink";
 }
 
-function getCellStatus(
+function getCellTags(
   cell: EnrichedCalendarCell,
   forecast: CalendarMenuForecastSummary | null,
   revenueError: number | null,
-): CellStatus | null {
-  if (cell.isMissing) return { label: "누락", tone: "red" };
+): CellStatusTag[] {
+  if (cell.isMissing) return [{ label: "누락", tone: "red" }];
   if (cell.isFuture && forecast && forecast.totalRevenue > 0) {
-    return {
-      label: `예상 ${formatNumber(Math.round(forecast.totalRevenue / 10000))}만`,
-      tone: "blue",
-    };
+    return [
+      {
+        label: `예상 ${formatNumber(Math.round(forecast.totalRevenue / 10000))}만`,
+        tone: "blue",
+      },
+    ];
   }
   if (cell.revenue !== null && cell.revenue > 0 && revenueError !== null) {
-    return {
-      label: `${formatNumber(Math.round(cell.revenue / 10000))}만`,
-      subLabel: `오차 ${Math.round(revenueError * 100)}%`,
-      tone: revenueError >= 0.35 ? "red" : "blue",
-    };
+    return [
+      { label: `매출 ${formatNumber(Math.round(cell.revenue / 10000))}만`, tone: "ink" },
+      {
+        label: `오차 ${Math.round(revenueError * 100)}%`,
+        tone: revenueError >= 0.35 ? "red" : "blue",
+      },
+    ];
   }
   if (cell.revenue !== null && cell.revenue > 0) {
-    return { label: `${formatNumber(Math.round(cell.revenue / 10000))}만`, tone: "ink" };
+    return [{ label: `매출 ${formatNumber(Math.round(cell.revenue / 10000))}만`, tone: "ink" }];
   }
-  return null;
+  return [];
 }
 
-function CellStatusBadge({ status }: { status: CellStatus }): React.ReactElement {
+function CellStatusTags({ tags }: { tags: readonly CellStatusTag[] }): React.ReactElement {
   return (
-    <span
-      className={cn(
-        "flex w-fit flex-col gap-0.5 rounded-xl px-2 py-1 text-[10px] font-semibold leading-none shadow-soft sm:text-micro",
-        status.tone === "red"
-          ? "bg-red-soft text-red-deep"
-          : status.tone === "blue"
-            ? "bg-blue-soft text-blue-deep"
-            : "bg-white/90 text-ink-1",
-      )}
-    >
-      <span>{status.label}</span>
-      {status.subLabel && (
-        <span className="text-[9px] opacity-80 sm:text-[10px]">{status.subLabel}</span>
-      )}
+    <span className="flex flex-col items-start gap-1">
+      {tags.map((tag) => (
+        <span
+          key={tag.label}
+          className={cn(
+            "w-fit rounded-full px-2 py-1 text-[10px] font-semibold leading-none shadow-soft sm:text-micro",
+            tag.tone === "red"
+              ? "bg-red-soft text-red-deep"
+              : tag.tone === "blue"
+                ? "bg-blue-soft text-blue-deep"
+                : "bg-white/90 text-ink-1",
+          )}
+        >
+          {tag.label}
+        </span>
+      ))}
     </span>
   );
 }

--- a/src/features/inventory/components/RevenueForecastAccuracyCard.tsx
+++ b/src/features/inventory/components/RevenueForecastAccuracyCard.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatDateKoFromIso, formatWon, localIsoDate } from "@/lib/utils/format";
+import type { RevenueForecastAccuracyView } from "../hooks/useRevenueForecastAccuracy";
+
+interface RevenueForecastAccuracyCardProps {
+  data: RevenueForecastAccuracyView;
+}
+
+const RELIABILITY_LABEL: Record<RevenueForecastAccuracyView["reliability"], string> = {
+  good: "신뢰도 좋음",
+  watch: "주의",
+  low: "신뢰도 낮음",
+  insufficient_data: "데이터 부족",
+};
+
+const BIAS_LABEL: Record<RevenueForecastAccuracyView["bias"], string> = {
+  over: "과대예측",
+  under: "과소예측",
+  balanced: "균형",
+  insufficient_data: "데이터 부족",
+};
+
+export function RevenueForecastAccuracyCard({
+  data,
+}: RevenueForecastAccuracyCardProps): React.ReactElement {
+  const maxRevenue = Math.max(
+    1,
+    ...data.dailyResults.flatMap((day) => [day.actualRevenue, day.predictedRevenue]),
+  );
+
+  if (data.dailyResults.length === 0 || data.evaluatedDayCount === 0) {
+    return (
+      <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
+        아직 비교할 매출 이력이 없어요. 판매 데이터가 쌓이면 매출 예측 정확도를 확인할 수 있습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-section">
+      <section className="grid gap-stack-tight sm:grid-cols-4">
+        <SummaryTile label="WAPE" value={formatPercent(data.weightedAbsolutePercentageError)} />
+        <SummaryTile label="MAPE" value={formatPercent(data.meanAbsolutePercentageError)} />
+        <SummaryTile label="평균 오차" value={`${formatWon(data.averageAbsoluteError ?? 0)}원`} />
+        <SummaryTile label="비교일" value={`${data.evaluatedDayCount}일`} />
+      </section>
+
+      <article className="glow-panel rounded-[28px] border border-border bg-card px-tile py-stack shadow-card">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-title-md text-ink-1">매출 예측 요약</h2>
+            <p className="mt-1 text-caption text-ink-3">
+              실제 {formatWon(data.actualTotalRevenue)}원 · 예측{" "}
+              {formatWon(data.predictedTotalRevenue)}원
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-1 sm:justify-end">
+            <ReliabilityBadge reliability={data.reliability} />
+            <BiasBadge bias={data.bias} />
+          </div>
+        </div>
+
+        <p className="mt-stack rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
+          WAPE는 전체 실제 매출 대비 총 오차입니다. 매출이 작은 날 하나에 흔들리는 MAPE보다 운영
+          판단용으로 더 안정적입니다.
+        </p>
+
+        <ol className="mt-stack grid grid-cols-7 gap-1.5">
+          {data.dailyResults.slice(-14).map((day) => (
+            <li key={day.date.toISOString()} className="flex min-w-0 flex-col items-center gap-1">
+              <span className="text-micro text-ink-4">{formatShortDate(day.date)}</span>
+              <div className="flex h-16 w-full items-end justify-center gap-0.5 rounded-xl bg-bg px-1">
+                <div
+                  title="실제"
+                  className="w-1/2 rounded-lg bg-blue shadow-soft"
+                  style={{ height: `${barHeight(day.actualRevenue, maxRevenue)}%` }}
+                />
+                <div
+                  title="예측"
+                  className="w-1/2 rounded-lg bg-amber shadow-soft"
+                  style={{ height: `${barHeight(day.predictedRevenue, maxRevenue)}%` }}
+                />
+              </div>
+              <span className="text-micro text-ink-3 tabular-nums">
+                {formatPercent(day.absolutePercentageError)}
+              </span>
+            </li>
+          ))}
+        </ol>
+
+        <div className="mt-stack flex items-center gap-3 text-micro text-ink-3">
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-blue" />
+            실제
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-amber" />
+            예측
+          </span>
+        </div>
+      </article>
+
+      <ul className="flex flex-col gap-stack-tight">
+        {data.dailyResults
+          .filter((day) => day.actualRevenue > 0)
+          .slice(-7)
+          .map((day) => (
+            <li
+              key={day.date.toISOString()}
+              className="rounded-2xl border border-border bg-card px-4 py-3 shadow-soft"
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-body font-semibold text-ink-1">
+                    {formatDateKoFromIso(localIsoDate(day.date))}
+                  </p>
+                  <p className="text-caption text-ink-3">
+                    실제 {formatWon(day.actualRevenue)}원 · 예측 {formatWon(day.predictedRevenue)}원
+                  </p>
+                </div>
+                <span className="rounded-full bg-bg px-3 py-1.5 text-caption font-semibold text-ink-2">
+                  오차 {formatWon(day.absoluteError)}원 ·{" "}
+                  {formatPercent(day.absolutePercentageError)}
+                </span>
+              </div>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}
+
+function SummaryTile({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="rounded-2xl border border-border bg-card px-3 py-3 text-center shadow-soft">
+      <p className="text-micro text-ink-4">{label}</p>
+      <p className="mt-1 text-title-md text-ink-1">{value}</p>
+    </div>
+  );
+}
+
+function ReliabilityBadge({
+  reliability,
+}: {
+  reliability: RevenueForecastAccuracyView["reliability"];
+}): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "rounded-full px-2.5 py-1 text-micro shadow-soft",
+        reliability === "good"
+          ? "bg-blue-soft text-blue-deep"
+          : reliability === "watch"
+            ? "bg-amber-soft text-amber-deep"
+            : reliability === "low"
+              ? "bg-red-soft text-red-deep"
+              : "bg-bg text-ink-3",
+      )}
+    >
+      {RELIABILITY_LABEL[reliability]}
+    </span>
+  );
+}
+
+function BiasBadge({ bias }: { bias: RevenueForecastAccuracyView["bias"] }): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        "rounded-full px-2.5 py-1 text-micro shadow-soft",
+        bias === "over"
+          ? "bg-red-soft text-red-deep"
+          : bias === "under"
+            ? "bg-amber-soft text-amber-deep"
+            : bias === "balanced"
+              ? "bg-blue-soft text-blue-deep"
+              : "bg-bg text-ink-3",
+      )}
+    >
+      {BIAS_LABEL[bias]}
+    </span>
+  );
+}
+
+function barHeight(value: number, maxRevenue: number): number {
+  if (value <= 0) return 4;
+  return Math.max(6, (value / maxRevenue) * 100);
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return "-";
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatShortDate(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()}`;
+}

--- a/src/features/inventory/hooks/useRevenueForecastAccuracy.ts
+++ b/src/features/inventory/hooks/useRevenueForecastAccuracy.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  loadRevenueForecastAccuracyView,
+  type RevenueForecastAccuracyView,
+} from "@/lib/application/inventory";
+import { createClient } from "@/lib/supabase/client";
+
+export const revenueForecastAccuracyQueryKey = (backtestDays: number) =>
+  ["inventory", "revenue-forecast-accuracy", backtestDays] as const;
+
+export type { RevenueForecastAccuracyView } from "@/lib/application/inventory";
+
+async function fetchRevenueForecastAccuracy(
+  backtestDays: number,
+): Promise<RevenueForecastAccuracyView> {
+  const supabase = createClient();
+  return loadRevenueForecastAccuracyView(supabase, backtestDays);
+}
+
+export function useRevenueForecastAccuracy(
+  backtestDays: number = 14,
+  enabled: boolean = true,
+): UseQueryResult<RevenueForecastAccuracyView> {
+  return useQuery({
+    queryKey: revenueForecastAccuracyQueryKey(backtestDays),
+    queryFn: () => fetchRevenueForecastAccuracy(backtestDays),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -15,6 +15,7 @@ import {
 import {
   applyInventoryReplay as applyInventoryReplayRpc,
   getDepletionForecast,
+  getCalendarMonth,
   getMenuDemandForecast,
   type ApplyInventoryReplayResult,
 } from "@/lib/supabase/rpc";
@@ -103,6 +104,24 @@ export interface IngredientForecastAccuracyView {
     date: Date;
     actualAmount: number;
     predictedAmount: number;
+    absoluteError: number;
+    absolutePercentageError: number | null;
+  }>;
+}
+
+export interface RevenueForecastAccuracyView {
+  averageAbsoluteError: number | null;
+  meanAbsolutePercentageError: number | null;
+  weightedAbsolutePercentageError: number | null;
+  reliability: ForecastReliability;
+  bias: "over" | "under" | "balanced" | "insufficient_data";
+  evaluatedDayCount: number;
+  actualTotalRevenue: number;
+  predictedTotalRevenue: number;
+  dailyResults: Array<{
+    date: Date;
+    actualRevenue: number;
+    predictedRevenue: number;
     absoluteError: number;
     absolutePercentageError: number | null;
   }>;
@@ -343,6 +362,84 @@ export async function loadMenuForecastAccuracyViews(
     });
 }
 
+export async function loadRevenueForecastAccuracyView(
+  client: RpcClient,
+  backtestDays: number = MENU_FORECAST_BACKTEST_DAYS,
+): Promise<RevenueForecastAccuracyView> {
+  const { data, error } = await getMenuDemandForecast(client);
+  if (error) throw new Error(error.message);
+
+  const menus = data ?? [];
+  const latestSampleDate =
+    menus
+      .flatMap((row) => row.demandSamples.map((sample) => startOfDay(new Date(sample.date))))
+      .sort((a, b) => a.getTime() - b.getTime())
+      .at(-1) ?? startOfDay(new Date());
+  const targetDates = Array.from({ length: backtestDays }, (_, index) =>
+    addDays(latestSampleDate, index - backtestDays + 1),
+  );
+  const actualRevenueByDate = await loadActualRevenueByDate(client, targetDates);
+
+  const dailyResults = targetDates.map((targetDate) => {
+    const trainUntil = addDays(targetDate, -1);
+    const predictedRevenue = sumBy(menus, (row) => {
+      const demandSamples: DailyMenuDemand[] = row.demandSamples
+        .map((sample) => ({
+          date: startOfDay(new Date(sample.date)),
+          quantity: Number(sample.quantity),
+        }))
+        .filter((sample) => sample.date.getTime() <= trainUntil.getTime());
+      const forecast = forecastMenuDemand({
+        demandSamples,
+        daysOff: row.regularDaysOff,
+        signupDate: new Date(row.signedUpAt),
+        today: trainUntil,
+        horizonDays: 1,
+        sensitivity: row.forecastSensitivity,
+      });
+      return (forecast.dailyPredictions[0]?.predictedQuantity ?? 0) * row.price;
+    });
+    const actualRevenue = actualRevenueByDate.get(dateKey(targetDate)) ?? 0;
+    const absoluteError = Math.abs(predictedRevenue - actualRevenue);
+    return {
+      date: targetDate,
+      actualRevenue,
+      predictedRevenue,
+      absoluteError,
+      absolutePercentageError:
+        actualRevenue > 0 ? absoluteError / Math.max(1, actualRevenue) : null,
+    };
+  });
+
+  const evaluated = dailyResults.filter((result) => result.actualRevenue > 0);
+  const actualTotalRevenue = sumBy(dailyResults, (result) => result.actualRevenue);
+  const predictedTotalRevenue = sumBy(dailyResults, (result) => result.predictedRevenue);
+  const averageAbsoluteError =
+    evaluated.length > 0
+      ? sumBy(evaluated, (result) => result.absoluteError) / evaluated.length
+      : null;
+  const meanAbsolutePercentageError =
+    evaluated.length > 0
+      ? sumBy(evaluated, (result) => result.absolutePercentageError ?? 0) / evaluated.length
+      : null;
+  const weightedAbsolutePercentageError =
+    actualTotalRevenue > 0
+      ? sumBy(dailyResults, (result) => result.absoluteError) / actualTotalRevenue
+      : null;
+
+  return {
+    averageAbsoluteError,
+    meanAbsolutePercentageError,
+    weightedAbsolutePercentageError,
+    reliability: classifyForecastReliability(meanAbsolutePercentageError, evaluated.length),
+    bias: classifyForecastBias(actualTotalRevenue, predictedTotalRevenue, evaluated.length),
+    evaluatedDayCount: evaluated.length,
+    actualTotalRevenue,
+    predictedTotalRevenue,
+    dailyResults,
+  };
+}
+
 export async function loadIngredientForecastAccuracyViews(
   client: RpcClient,
   backtestDays: number = MENU_FORECAST_BACKTEST_DAYS,
@@ -481,6 +578,38 @@ export async function loadIngredientForecastAccuracyViews(
       if (b.meanAbsolutePercentageError === null) return -1;
       return b.meanAbsolutePercentageError - a.meanAbsolutePercentageError;
     });
+}
+
+async function loadActualRevenueByDate(
+  client: RpcClient,
+  targetDates: readonly Date[],
+): Promise<Map<string, number>> {
+  const months = uniqueMonths(targetDates);
+  const results = await Promise.all(
+    months.map(({ year, month }) => getCalendarMonth(client, { year, month })),
+  );
+  const revenueByDate = new Map<string, number>();
+  for (const result of results) {
+    if (result.error) throw new Error(result.error.message);
+    for (const cell of result.data?.cells ?? []) {
+      revenueByDate.set(cell.date, cell.revenue ?? 0);
+    }
+  }
+  return revenueByDate;
+}
+
+function uniqueMonths(dates: readonly Date[]): Array<{ year: number; month: number }> {
+  const seen = new Set<string>();
+  const months: Array<{ year: number; month: number }> = [];
+  for (const date of dates) {
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const key = `${year}-${month}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    months.push({ year, month });
+  }
+  return months;
 }
 
 export async function loadMenuBasedIngredientDemandForecast(


### PR DESCRIPTION
## Summary
- add revenue forecast backtest calculation using menu demand forecasts and actual calendar revenue
- add Revenue tab to forecast accuracy page with MAPE, WAPE, bias, and daily comparison
- show revenue forecast error on calendar past cells and date detail pages

## Tests
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test
- npm run build

## Migration
- none