### PR TITLE
Fix stale cache after write mutations

### DIFF
--- a/src/features/inventory/hooks/useApplyStockCount.ts
+++ b/src/features/inventory/hooks/useApplyStockCount.ts
@@ -4,8 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import { applyStockCount, type ApplyStockCountResult } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
-import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
-import { invalidateMenuCaches } from "@/features/menu/hooks/useMenus";
+import { invalidateIngredientWriteRelatedQueries } from "@/lib/query-invalidation";
 import type { ApplyStockCountInput } from "../schemas";
 
 async function submit(input: ApplyStockCountInput): Promise<ApplyStockCountResult> {
@@ -39,9 +38,7 @@ export function useApplyStockCount(): UseMutationResult<
         loss_amount: result.weeklyLossAmount,
         item_count: result.itemDifferences.length,
       });
-      // invalidateMenuCaches가 menu + forecast 둘 다 처리. 재료 목록만 추가.
-      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
-      invalidateMenuCaches(queryClient);
+      invalidateIngredientWriteRelatedQueries(queryClient);
     },
   });
 }

--- a/src/features/menu/hooks/useCloneTemplate.ts
+++ b/src/features/menu/hooks/useCloneTemplate.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import { cloneMenuTemplate } from "@/lib/supabase/rpc";
 import { trackEvent } from "@/lib/analytics/ga4";
-import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
+import { invalidateIngredientWriteRelatedQueries } from "@/lib/query-invalidation";
 import { invalidateMenuCaches } from "./useMenus";
 import type { CloneTemplateInput } from "../schemas";
 
@@ -39,8 +39,7 @@ export function useCloneTemplate(): UseMutationResult<CloneResult, Error, CloneT
         new_menus: result.newMenuCount,
       });
       invalidateMenuCaches(queryClient);
-      // 템플릿은 메뉴 + 재료를 함께 생성 → 재료 목록도 무효화.
-      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
+      invalidateIngredientWriteRelatedQueries(queryClient);
     },
   });
 }

--- a/src/features/menu/hooks/useMenuMutations.ts
+++ b/src/features/menu/hooks/useMenuMutations.ts
@@ -4,15 +4,13 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import type { MenuInput } from "../schemas";
 import { createMenu, removeMenu, updateMenu, type EditMenuInput } from "@/lib/application/menu";
-import { invalidateMenuCaches, menuListQueryKey } from "./useMenus";
+import { invalidateMenuCaches } from "./useMenus";
 
 interface EditMenuVariables {
   menuId: string;
   values: MenuInput;
 }
 
-// 신규 메뉴는 sale·consumption이 없으므로 forecast 캐시는 그대로 — menuList만 invalidate.
-// 편집/삭제는 recipe 구성이 바뀌어 forecast 영향 → invalidateMenuCaches로 함께 처리.
 export function useCreateMenu(): UseMutationResult<string, Error, MenuInput> {
   const queryClient = useQueryClient();
   return useMutation({
@@ -20,7 +18,7 @@ export function useCreateMenu(): UseMutationResult<string, Error, MenuInput> {
       const supabase = createClient();
       return createMenu(supabase, values);
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: menuListQueryKey }),
+    onSuccess: () => invalidateMenuCaches(queryClient),
   });
 }
 

--- a/src/features/menu/hooks/useMenus.ts
+++ b/src/features/menu/hooks/useMenus.ts
@@ -3,7 +3,7 @@
 import { useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
 import { loadMenus, type LookupClient, type MenuRowWithRecipe } from "@/lib/application/lookups";
-import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
+import { invalidateMenuWriteRelatedQueries } from "@/lib/query-invalidation";
 
 /**
  * 사용자 메뉴 + 레시피 + 재료 단가를 한 번에 fetch.
@@ -39,6 +39,5 @@ export function useMenus(): UseQueryResult<MenuRowWithRecipe[]> {
  * 어디서든 같은 패턴 일관 사용.
  */
 export function invalidateMenuCaches(queryClient: ReturnType<typeof useQueryClient>): void {
-  void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
-  void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
+  invalidateMenuWriteRelatedQueries(queryClient);
 }

--- a/src/features/purchase/hooks/useIngredients.ts
+++ b/src/features/purchase/hooks/useIngredients.ts
@@ -10,7 +10,7 @@ import {
 import { createClient } from "@/lib/supabase/client";
 import { loadIngredients, type IngredientRow, type LookupClient } from "@/lib/application/lookups";
 import { deleteIngredient, saveIngredient } from "@/lib/supabase/rpc";
-import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
+import { invalidateIngredientWriteRelatedQueries } from "@/lib/query-invalidation";
 import type { IngredientInput } from "../schemas";
 
 export type { IngredientRow } from "@/lib/application/lookups";
@@ -44,9 +44,7 @@ async function createIngredient(input: IngredientInput): Promise<IngredientRow> 
 }
 
 function invalidateIngredientCaches(queryClient: ReturnType<typeof useQueryClient>): void {
-  // 재료 목록 + 소진 예측 둘 다 무효화 — 두 쿼리는 모두 ingredients 테이블에 의존.
-  void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
-  void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
+  invalidateIngredientWriteRelatedQueries(queryClient);
 }
 
 export function useCreateIngredient(): UseMutationResult<IngredientRow, Error, IngredientInput> {

--- a/src/features/purchase/hooks/usePurchaseSubmit.ts
+++ b/src/features/purchase/hooks/usePurchaseSubmit.ts
@@ -3,16 +3,12 @@
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
 import { trackEvent } from "@/lib/analytics/ga4";
+import { invalidatePurchaseWriteRelatedQueries } from "@/lib/query-invalidation";
 import { submitPurchase, type SubmitPurchaseInput } from "@/lib/application/purchase";
 import {
   linkOrderRecommendationSnapshotPurchase,
   type SavePurchaseResult,
 } from "@/lib/supabase/rpc";
-import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
-import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
-import { orderRecommendationReportQueryKey } from "@/features/inventory/hooks/useOrderRecommendationReport";
-import { todayDashboardQueryKey } from "@/features/dashboard/hooks/useTodayDashboard";
-import { ingredientListQueryKey } from "./useIngredients";
 import type { SavePurchaseInput } from "../schemas";
 
 interface SubmitVariables extends SavePurchaseInput {
@@ -51,13 +47,7 @@ export function usePurchaseSubmit(): UseMutationResult<SavePurchaseResult, Error
           alert_count: result.priceChangeAlerts.length,
         });
       }
-      // 매입은 가중 이동 평균법으로 ingredient 단가 + 재고 갱신 → 소진 예측 / 메뉴
-      // 마진 / 재료 목록 모두 stale. 일관 무효화.
-      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
-      void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
-      void queryClient.invalidateQueries({ queryKey: orderRecommendationReportQueryKey });
-      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
-      void queryClient.invalidateQueries({ queryKey: todayDashboardQueryKey });
+      invalidatePurchaseWriteRelatedQueries(queryClient);
     },
   });
 }

--- a/src/features/purchase/hooks/useVendors.ts
+++ b/src/features/purchase/hooks/useVendors.ts
@@ -10,7 +10,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/client";
 import { loadVendors, type LookupClient, type VendorRow } from "@/lib/application/lookups";
-import { invalidateSettingsRelatedQueries } from "@/features/settings/hooks/useSettingsMutations";
+import { invalidateVendorWriteRelatedQueries } from "@/lib/query-invalidation";
 import { saveVendor } from "@/lib/supabase/rpc";
 import type { Database } from "@/lib/supabase/types";
 import type { VendorInput } from "../schemas";
@@ -70,9 +70,8 @@ export function useCreateVendor(): UseMutationResult<VendorRow, Error, VendorInp
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createVendor,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: vendorListQueryKey });
-      await invalidateSettingsRelatedQueries(queryClient);
+    onSuccess: () => {
+      invalidateVendorWriteRelatedQueries(queryClient);
     },
   });
 }
@@ -85,9 +84,8 @@ export function useUpdateVendorLeadTime(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateVendorLeadTime,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: vendorListQueryKey });
-      await invalidateSettingsRelatedQueries(queryClient);
+    onSuccess: () => {
+      invalidateVendorWriteRelatedQueries(queryClient);
     },
   });
 }

--- a/src/features/sale/hooks/useSaleEdit.ts
+++ b/src/features/sale/hooks/useSaleEdit.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
 import { trackEvent } from "@/lib/analytics/ga4";
+import { invalidateSaleWriteRelatedQueries } from "@/lib/query-invalidation";
 import {
   editSale as editSaleUseCase,
   removeSale,
@@ -10,9 +11,6 @@ import {
   type EditSaleResult,
   type SaleClient,
 } from "@/lib/application/sale";
-import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
-import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
-import { salesQueryKey } from "./_keys";
 
 async function edit(input: EditSaleUseCaseInput): Promise<EditSaleResult> {
   const supabase = createClient() as unknown as SaleClient;
@@ -22,9 +20,7 @@ async function edit(input: EditSaleUseCaseInput): Promise<EditSaleResult> {
 // sale 편집/삭제도 재료 재고 보정 + price_history insert를 RPC가 수행하므로 sale 키
 // 단독 무효화는 inventory 페이지 stale을 만든다 (useSaleSubmit과 동일 패턴).
 function invalidateSaleAndIngredientCaches(queryClient: ReturnType<typeof useQueryClient>): void {
-  void queryClient.invalidateQueries({ queryKey: salesQueryKey });
-  void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
-  void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
+  invalidateSaleWriteRelatedQueries(queryClient);
 }
 
 export function useSaleEdit(): UseMutationResult<EditSaleResult, Error, EditSaleUseCaseInput> {

--- a/src/features/sale/hooks/useSaleSubmit.ts
+++ b/src/features/sale/hooks/useSaleSubmit.ts
@@ -4,16 +4,13 @@ import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/r
 import { createClient } from "@/lib/supabase/client";
 import { trackEvent } from "@/lib/analytics/ga4";
 import { requestPushPermissionAndSubscribe } from "@/lib/push/client";
+import { invalidateSaleWriteRelatedQueries } from "@/lib/query-invalidation";
 import {
   submitSale,
   type SaleClient,
   type SubmitSaleInput,
   type SubmitSaleResult,
 } from "@/lib/application/sale";
-import { menuListQueryKey } from "@/features/menu/hooks/useMenus";
-import { ingredientListQueryKey } from "@/features/purchase/hooks/useIngredients";
-import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
-import { salesQueryKey } from "./_keys";
 import type { SaveSaleInput } from "../schemas";
 
 interface SubmitVariables extends SaveSaleInput {
@@ -49,12 +46,7 @@ export function useSaleSubmit(): UseMutationResult<SubmitSaleResult, Error, Subm
         trackEvent("retroactive_sale_complete", { sold_at: input.soldAt });
       }
 
-      // sale 저장은 재료 재고 차감 + 단가 history insert까지 트리거 → menu 캐시 외에
-      // ingredient/forecast도 함께 무효화해야 inventory 페이지가 즉시 반영.
-      void queryClient.invalidateQueries({ queryKey: menuListQueryKey });
-      void queryClient.invalidateQueries({ queryKey: ingredientListQueryKey });
-      void queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey });
-      void queryClient.invalidateQueries({ queryKey: salesQueryKey });
+      invalidateSaleWriteRelatedQueries(queryClient);
     },
   });
 }

--- a/src/features/settings/hooks/useSettingsMutations.ts
+++ b/src/features/settings/hooks/useSettingsMutations.ts
@@ -8,8 +8,7 @@ import {
 } from "@tanstack/react-query";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/client";
-import { depletionForecastQueryKey } from "@/features/inventory/hooks/useDepletionForecast";
-import { todayDashboardQueryKey } from "@/features/dashboard/hooks/useTodayDashboard";
+import { invalidateSettingsWriteRelatedQueries } from "@/lib/query-invalidation";
 import type { Weekday } from "@/lib/domain/regular-days-off";
 import type { ForecastSensitivity } from "@/lib/domain/forecast";
 import { updateRegularDaysOff } from "@/lib/supabase/rpc";
@@ -39,12 +38,8 @@ interface UpdateForecastSensitivityInput {
   forecastSensitivity: ForecastSensitivity;
 }
 
-export async function invalidateSettingsRelatedQueries(queryClient: QueryClient): Promise<void> {
-  await Promise.all([
-    queryClient.invalidateQueries({ queryKey: todayDashboardQueryKey }),
-    queryClient.invalidateQueries({ queryKey: depletionForecastQueryKey }),
-    queryClient.invalidateQueries({ queryKey: ["calendar"] }),
-  ]);
+export function invalidateSettingsRelatedQueries(queryClient: QueryClient): void {
+  invalidateSettingsWriteRelatedQueries(queryClient);
 }
 
 async function updateStoreName(input: UpdateStoreNameInput): Promise<string> {
@@ -128,8 +123,8 @@ export function useUpdateStoreName(): UseMutationResult<string, Error, UpdateSto
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateStoreName,
-    onSuccess: async () => {
-      await invalidateSettingsRelatedQueries(queryClient);
+    onSuccess: () => {
+      invalidateSettingsRelatedQueries(queryClient);
     },
   });
 }
@@ -142,8 +137,8 @@ export function useUpdateRegularDaysOff(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: persistRegularDaysOff,
-    onSuccess: async () => {
-      await invalidateSettingsRelatedQueries(queryClient);
+    onSuccess: () => {
+      invalidateSettingsRelatedQueries(queryClient);
     },
   });
 }
@@ -156,8 +151,8 @@ export function useUpdateSafetyBufferDays(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateSafetyBufferDays,
-    onSuccess: async () => {
-      await invalidateSettingsRelatedQueries(queryClient);
+    onSuccess: () => {
+      invalidateSettingsRelatedQueries(queryClient);
     },
   });
 }
@@ -170,8 +165,8 @@ export function useUpdatePurchaseCoverageDays(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updatePurchaseCoverageDays,
-    onSuccess: async () => {
-      await invalidateSettingsRelatedQueries(queryClient);
+    onSuccess: () => {
+      invalidateSettingsRelatedQueries(queryClient);
     },
   });
 }
@@ -184,8 +179,8 @@ export function useUpdateForecastSensitivity(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateForecastSensitivity,
-    onSuccess: async () => {
-      await invalidateSettingsRelatedQueries(queryClient);
+    onSuccess: () => {
+      invalidateSettingsRelatedQueries(queryClient);
     },
   });
 }

--- a/src/lib/query-invalidation.ts
+++ b/src/lib/query-invalidation.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import type { QueryClient } from "@tanstack/react-query";
+
+function invalidate(queryClient: QueryClient, queryKey: readonly unknown[]): void {
+  void queryClient.invalidateQueries({ queryKey });
+}
+
+export function invalidateForecastQueries(queryClient: QueryClient): void {
+  invalidate(queryClient, ["inventory", "forecast"]);
+  invalidate(queryClient, ["inventory", "menu-demand-forecast"]);
+  invalidate(queryClient, ["inventory", "order-report"]);
+  invalidate(queryClient, ["inventory", "menu-forecast-accuracy"]);
+  invalidate(queryClient, ["inventory", "ingredient-forecast-accuracy"]);
+  invalidate(queryClient, ["inventory", "revenue-forecast-accuracy"]);
+}
+
+export function invalidateSaleWriteRelatedQueries(queryClient: QueryClient): void {
+  invalidate(queryClient, ["sales"]);
+  invalidate(queryClient, ["calendar"]);
+  invalidate(queryClient, ["dashboard"]);
+  invalidate(queryClient, ["menus"]);
+  invalidate(queryClient, ["ingredients"]);
+  invalidateForecastQueries(queryClient);
+}
+
+export function invalidatePurchaseWriteRelatedQueries(queryClient: QueryClient): void {
+  invalidate(queryClient, ["purchases"]);
+  invalidate(queryClient, ["calendar"]);
+  invalidate(queryClient, ["dashboard"]);
+  invalidate(queryClient, ["menus"]);
+  invalidate(queryClient, ["ingredients"]);
+  invalidateForecastQueries(queryClient);
+}
+
+export function invalidateMenuWriteRelatedQueries(queryClient: QueryClient): void {
+  invalidate(queryClient, ["dashboard"]);
+  invalidate(queryClient, ["calendar"]);
+  invalidate(queryClient, ["menus"]);
+  invalidateForecastQueries(queryClient);
+}
+
+export function invalidateIngredientWriteRelatedQueries(queryClient: QueryClient): void {
+  invalidate(queryClient, ["dashboard"]);
+  invalidate(queryClient, ["menus"]);
+  invalidate(queryClient, ["ingredients"]);
+  invalidateForecastQueries(queryClient);
+}
+
+export function invalidateSettingsWriteRelatedQueries(queryClient: QueryClient): void {
+  invalidate(queryClient, ["dashboard"]);
+  invalidate(queryClient, ["calendar"]);
+  invalidateForecastQueries(queryClient);
+}
+
+export function invalidateVendorWriteRelatedQueries(queryClient: QueryClient): void {
+  invalidate(queryClient, ["vendors"]);
+  invalidateForecastQueries(queryClient);
+}


### PR DESCRIPTION
## Summary
- centralize query invalidation for write mutations
- invalidate calendar, dashboard, forecast, order report, sales/menu/ingredient/vendor prefixes after related writes
- cover sale save/edit/delete, purchase save, menu changes, ingredient changes, vendor lead time, settings, stock count, template clone

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test