### PR TITLE
Limit calendar forecasts to short horizon

### DIFF
--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -12,6 +12,7 @@ import {
   buildCalendarMenuForecastByDate,
   type CalendarMenuForecastSummary,
 } from "@/features/calendar/lib/menu-forecast-calendar";
+import { CALENDAR_SHORT_FORECAST_DAYS } from "@/features/calendar/lib/forecast-window";
 import { daysUntilLock, isSaleLocked } from "@/lib/domain/snapshot";
 import { MARGIN_LABEL } from "@/lib/domain/margin";
 import {
@@ -38,10 +39,12 @@ export default function CalendarDateDetailPage(): React.ReactElement {
   const month = parsedDate ? parsedDate.getMonth() + 1 : null;
   const todayIso = useTodayIso();
   const today = todayIso ? (parseLocalDateFromIso(todayIso) ?? new Date()) : new Date();
-  const isFutureDate = parsedDate ? differenceInCalendarDays(parsedDate, today) > 0 : false;
-  const forecastHorizonDays = parsedDate
-    ? Math.min(365, Math.max(7, differenceInCalendarDays(parsedDate, today) + 1))
-    : 7;
+  const daysFromToday = parsedDate ? differenceInCalendarDays(parsedDate, today) : 0;
+  const isFutureDate = daysFromToday > 0;
+  const isShortForecastDate = isFutureDate && daysFromToday <= CALENDAR_SHORT_FORECAST_DAYS;
+  const forecastHorizonDays = isShortForecastDate
+    ? Math.max(CALENDAR_SHORT_FORECAST_DAYS, daysFromToday + 1)
+    : CALENDAR_SHORT_FORECAST_DAYS;
   const calendarQuery = useCalendarMonth(year, month);
   const saleQuery = useSaleByDate(date);
   const menuForecastQuery = useMenuDemandForecast(forecastHorizonDays);
@@ -98,6 +101,7 @@ export default function CalendarDateDetailPage(): React.ReactElement {
           menuBacktest={menuBacktest}
           revenueBacktest={revenueBacktest}
           todayIso={todayIso}
+          isShortForecastDate={isShortForecastDate}
         />
       )}
     </section>
@@ -113,6 +117,7 @@ interface DateDetailBodyProps {
   menuBacktest: MenuBacktestDateSummary | null;
   revenueBacktest: RevenueBacktestDateSummary | null;
   todayIso: string;
+  isShortForecastDate: boolean;
 }
 
 function DateDetailBody({
@@ -124,12 +129,19 @@ function DateDetailBody({
   menuBacktest,
   revenueBacktest,
   todayIso,
+  isShortForecastDate,
 }: DateDetailBodyProps): React.ReactElement {
   const today = parseLocalDateFromIso(todayIso) ?? new Date();
   const daysFromToday = differenceInCalendarDays(parsedDate, today);
 
   if (cell?.isFuture) {
-    return <FutureForecastDetail date={date} forecast={menuForecast} />;
+    return (
+      <FutureForecastDetail
+        date={date}
+        forecast={isShortForecastDate ? menuForecast : null}
+        isShortForecastDate={isShortForecastDate}
+      />
+    );
   }
   if (cell?.isBeforeSignup) {
     return <Notice tone="neutral">가입 전 데이터예요.</Notice>;
@@ -153,10 +165,21 @@ function DateDetailBody({
 function FutureForecastDetail({
   date,
   forecast,
+  isShortForecastDate,
 }: {
   date: string;
   forecast: CalendarMenuForecastSummary | null;
+  isShortForecastDate: boolean;
 }): React.ReactElement {
+  if (!isShortForecastDate) {
+    return (
+      <Notice tone="neutral">
+        캘린더는 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기 예측만 보여줘요. 14일·30일 장기
+        참고치는 메뉴 수요 예측 화면에서 확인해 주세요.
+      </Notice>
+    );
+  }
+
   if (!forecast || forecast.items.length === 0) {
     return (
       <Notice tone="neutral">
@@ -175,7 +198,8 @@ function FutureForecastDetail({
             <Metric label="예상 판매" value={`${formatNumber(forecast.totalQuantity)}개`} />
           </div>
           <Notice tone="neutral">
-            미래 날짜는 판매 입력은 막고, 현재까지의 판매 이력으로 계산한 예측만 보여줘요.
+            캘린더는 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기 예측만 보여줘요. 장기
+            구간은 메뉴 수요 예측 화면에서 참고용으로 확인하세요.
           </Notice>
           <ForecastConfidenceNote forecast={forecast} />
         </div>

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { differenceInCalendarDays } from "date-fns";
 import { useCalendarMonth } from "@/features/calendar/hooks/useCalendarMonth";
 import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
 import { useRevenueForecastAccuracy } from "@/features/inventory/hooks/useRevenueForecastAccuracy";
@@ -11,8 +10,9 @@ import { MonthCumulativeCard } from "@/features/calendar/components/MonthCumulat
 import { CalendarGrid } from "@/features/calendar/components/CalendarGrid";
 import { CalendarLegend } from "@/features/calendar/components/CalendarLegend";
 import { buildCalendarMenuForecastByDate } from "@/features/calendar/lib/menu-forecast-calendar";
+import { CALENDAR_SHORT_FORECAST_DAYS } from "@/features/calendar/lib/forecast-window";
 import { trackEvent } from "@/lib/analytics/ga4";
-import { localIsoDate, parseLocalDateFromIso } from "@/lib/utils/format";
+import { localIsoDate } from "@/lib/utils/format";
 import { useTodayIso } from "@/lib/utils/use-today-iso";
 import type { EnrichedCalendarCell } from "@/features/calendar/lib/consecutive-missing";
 
@@ -31,7 +31,6 @@ export default function CalendarPage(): React.ReactElement {
   const todayIso = useTodayIso();
   const [year, setYear] = useState<number | null>(null);
   const [month, setMonth] = useState<number | null>(null);
-  const forecastHorizonDays = computeForecastHorizonDays(year, month, todayIso);
 
   // 초기 mount 시 클라이언트 시각으로 현재 연/월 세팅 (SSR/CSR drift 차단)
   useEffect(() => {
@@ -41,7 +40,7 @@ export default function CalendarPage(): React.ReactElement {
   }, []);
 
   const query = useCalendarMonth(year, month);
-  const menuForecastQuery = useMenuDemandForecast(forecastHorizonDays);
+  const menuForecastQuery = useMenuDemandForecast(CALENDAR_SHORT_FORECAST_DAYS);
   const revenueAccuracyQuery = useRevenueForecastAccuracy(30);
   const menuForecastByDate = useMemo(
     () => buildCalendarMenuForecastByDate(menuForecastQuery.data ?? []),
@@ -133,15 +132,4 @@ export default function CalendarPage(): React.ReactElement {
       <CalendarLegend />
     </section>
   );
-}
-
-function computeForecastHorizonDays(
-  year: number | null,
-  month: number | null,
-  todayIso: string | null,
-): number {
-  if (year === null || month === null || !todayIso) return 60;
-  const today = parseLocalDateFromIso(todayIso) ?? new Date();
-  const monthEnd = new Date(year, month, 0);
-  return Math.min(365, Math.max(7, differenceInCalendarDays(monthEnd, today) + 1));
 }

--- a/src/app/(main)/menu/menu-forecast/page.tsx
+++ b/src/app/(main)/menu/menu-forecast/page.tsx
@@ -50,6 +50,12 @@ function MenuForecastContent(): React.ReactElement {
         <p className="mt-1 text-caption text-ink-3">
           재료 소진 예측은 이 메뉴 수요와 옵션 선택률을 재료 레시피로 변환해서 계산합니다.
         </p>
+        {horizonDays > 7 && (
+          <p className="mt-3 rounded-2xl border border-amber-soft bg-amber-soft/50 px-3 py-2 text-caption text-amber-deep">
+            14일·30일 예측은 같은 요일 패턴을 반복한 참고용입니다. 실제 발주 판단은 최근 7일 단기
+            예측과 재고 상태를 함께 확인하세요.
+          </p>
+        )}
       </section>
 
       <ForecastPeriodSelector

--- a/src/features/calendar/components/CalendarLegend.tsx
+++ b/src/features/calendar/components/CalendarLegend.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { INTENSITY_LEVELS, INTENSITY_STEP_PCT } from "../lib/intensity";
+import { CALENDAR_SHORT_FORECAST_DAYS } from "../lib/forecast-window";
 
 /**
  * 캘린더 범례 — 인텐시티 5단계 + 매입/누락 도트 설명.
@@ -19,6 +20,9 @@ export function CalendarLegend(): React.ReactElement {
         <DotKey tone="amber" label="매입 있음" />
         <DotKey tone="red" label="판매 미입력" />
       </div>
+      <p className="text-micro text-ink-4">
+        예상 매출은 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기 예측만 표시합니다.
+      </p>
     </section>
   );
 }

--- a/src/features/calendar/lib/forecast-window.ts
+++ b/src/features/calendar/lib/forecast-window.ts
@@ -1,0 +1,1 @@
+export const CALENDAR_SHORT_FORECAST_DAYS = 7;


### PR DESCRIPTION
## Summary
- show calendar forecast tags only for the next 7 days
- show a long-range guidance notice on future date details beyond the 7-day window
- add a menu forecast notice that 14/30 day projections are repeated-pattern reference values

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test