### PR TITLE
Replace forecast MAPE with operational metrics

### DIFF
--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -318,8 +318,8 @@ function ExistingSaleDetail({
 interface RevenueBacktestDateSummary {
   actualRevenue: number;
   predictedRevenue: number;
-  absoluteError: number;
-  absolutePercentageError: number | null;
+  absoluteWonError: number;
+  weightedAbsolutePercentageError: number | null;
   reliability: MenuForecastAccuracyView["reliability"];
   bias: "over" | "under" | "balanced" | "insufficient_data";
 }
@@ -349,16 +349,16 @@ function RevenueBacktestComparison({
                 : "bg-blue-soft text-blue-deep",
           )}
         >
-          오차율{" "}
-          {summary.absolutePercentageError === null
+          WAPE{" "}
+          {summary.weightedAbsolutePercentageError === null
             ? "-"
-            : `${Math.round(summary.absolutePercentageError * 100)}%`}
+            : `${Math.round(summary.weightedAbsolutePercentageError * 100)}%`}
         </span>
       </div>
       <div className="grid grid-cols-3 gap-stack">
         <Metric label="실제 매출" value={`${formatWon(summary.actualRevenue)}원`} />
         <Metric label="예측 매출" value={`${formatWon(summary.predictedRevenue)}원`} />
-        <Metric label="오차" value={`${formatWon(summary.absoluteError)}원`} />
+        <Metric label="오차" value={`${formatWon(summary.absoluteWonError)}원`} />
       </div>
     </article>
   );
@@ -388,10 +388,10 @@ function MenuBacktestComparison({
                 : "bg-blue-soft text-blue-deep",
           )}
         >
-          오차율{" "}
-          {summary.meanAbsolutePercentageError === null
+          평균 수량오차{" "}
+          {summary.meanAbsoluteQuantityError === null
             ? "-"
-            : `${Math.round(summary.meanAbsolutePercentageError * 100)}%`}
+            : `${formatNumber(Number(summary.meanAbsoluteQuantityError.toFixed(1)))}개`}
         </span>
       </div>
       <div className="grid grid-cols-2 gap-stack">
@@ -410,7 +410,7 @@ function MenuBacktestComparison({
                 </p>
               </div>
               <p className="text-caption text-ink-3">
-                오차 {formatNumber(Number(item.absoluteError.toFixed(1)))}개
+                오차 {formatNumber(Number(item.absoluteQuantityError.toFixed(1)))}개
               </p>
             </div>
           </li>
@@ -553,14 +553,14 @@ function Notice({ tone, children }: NoticeProps): React.ReactElement {
 interface MenuBacktestDateSummary {
   actualTotalQuantity: number;
   predictedTotalQuantity: number;
-  meanAbsolutePercentageError: number | null;
+  meanAbsoluteQuantityError: number | null;
   reliability: MenuForecastAccuracyView["reliability"];
   items: Array<{
     menuId: string;
     name: string;
     actualQuantity: number;
     predictedQuantity: number;
-    absoluteError: number;
+    absoluteQuantityError: number;
   }>;
 }
 
@@ -577,8 +577,7 @@ function buildMenuBacktestSummaryForDate(
         name: item.name,
         actualQuantity: result.actualQuantity,
         predictedQuantity: result.predictedQuantity,
-        absoluteError: result.absoluteError,
-        absolutePercentageError: result.absolutePercentageError,
+        absoluteQuantityError: result.absoluteQuantityError,
       };
     })
     .filter((item): item is NonNullable<typeof item> => item !== null);
@@ -588,18 +587,21 @@ function buildMenuBacktestSummaryForDate(
   const actualTotalQuantity = results.reduce((sum, item) => sum + item.actualQuantity, 0);
   const predictedTotalQuantity = results.reduce((sum, item) => sum + item.predictedQuantity, 0);
   const evaluated = results.filter((item) => item.actualQuantity > 0);
-  const meanAbsolutePercentageError =
+  const meanAbsoluteQuantityError =
     evaluated.length > 0
-      ? evaluated.reduce((sum, item) => sum + (item.absolutePercentageError ?? 0), 0) /
-        evaluated.length
+      ? evaluated.reduce((sum, item) => sum + item.absoluteQuantityError, 0) / evaluated.length
+      : null;
+  const wape =
+    actualTotalQuantity > 0
+      ? results.reduce((sum, item) => sum + item.absoluteQuantityError, 0) / actualTotalQuantity
       : null;
 
   return {
     actualTotalQuantity,
     predictedTotalQuantity,
-    meanAbsolutePercentageError,
-    reliability: classifyDateBacktestReliability(meanAbsolutePercentageError, evaluated.length),
-    items: results.sort((a, b) => b.absoluteError - a.absoluteError),
+    meanAbsoluteQuantityError,
+    reliability: classifyDateBacktestReliability(wape, evaluated.length),
+    items: results.sort((a, b) => b.absoluteQuantityError - a.absoluteQuantityError),
   };
 }
 
@@ -613,9 +615,9 @@ function buildRevenueBacktestSummaryForDate(
   return {
     actualRevenue: result.actualRevenue,
     predictedRevenue: result.predictedRevenue,
-    absoluteError: result.absoluteError,
-    absolutePercentageError: result.absolutePercentageError,
-    reliability: classifyDateBacktestReliability(result.absolutePercentageError, 1),
+    absoluteWonError: result.absoluteWonError,
+    weightedAbsolutePercentageError: result.weightedAbsolutePercentageError,
+    reliability: classifyDateBacktestReliability(result.weightedAbsolutePercentageError, 1),
     bias: classifyRevenueBias(result.actualRevenue, result.predictedRevenue),
   };
 }
@@ -632,12 +634,14 @@ function classifyRevenueBias(
 }
 
 function classifyDateBacktestReliability(
-  meanAbsolutePercentageError: number | null,
+  weightedAbsolutePercentageError: number | null,
   evaluatedItemCount: number,
 ): MenuForecastAccuracyView["reliability"] {
-  if (evaluatedItemCount === 0 || meanAbsolutePercentageError === null) return "insufficient_data";
-  if (meanAbsolutePercentageError >= 0.8) return "low";
-  if (meanAbsolutePercentageError >= 0.35) return "watch";
+  if (evaluatedItemCount === 0 || weightedAbsolutePercentageError === null) {
+    return "insufficient_data";
+  }
+  if (weightedAbsolutePercentageError >= 0.8) return "low";
+  if (weightedAbsolutePercentageError >= 0.35) return "watch";
   return "good";
 }
 

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -49,7 +49,7 @@ export default function CalendarPage(): React.ReactElement {
   const revenueErrorByDate = useMemo(() => {
     const map = new Map<string, number | null>();
     for (const day of revenueAccuracyQuery.data?.dailyResults ?? []) {
-      map.set(localIsoDate(day.date), day.absolutePercentageError);
+      map.set(localIsoDate(day.date), day.weightedAbsolutePercentageError);
     }
     return map;
   }, [revenueAccuracyQuery.data]);

--- a/src/features/inventory/components/IngredientForecastAccuracyList.tsx
+++ b/src/features/inventory/components/IngredientForecastAccuracyList.tsx
@@ -39,7 +39,7 @@ export function IngredientForecastAccuracyList({
   return (
     <div className="flex flex-col gap-section">
       <section className="grid grid-cols-3 gap-stack-tight">
-        <SummaryTile label="평균 오차율" value={formatPercent(summary.meanMape)} />
+        <SummaryTile label="평균 WAPE" value={formatPercent(summary.meanWape)} />
         <SummaryTile label="과대예측" value={`${summary.overCount}개`} />
         <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
       </section>
@@ -91,10 +91,10 @@ function IngredientForecastAccuracyCard({
       </div>
 
       <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
-        <Metric label="오차율" value={formatPercent(item.meanAbsolutePercentageError)} />
+        <Metric label="WAPE" value={formatPercent(item.weightedAbsolutePercentageError)} />
         <Metric
-          label="평균 오차"
-          value={formatNullableAmount(item.averageAbsoluteError, item.unit)}
+          label="평균 소비오차"
+          value={formatNullableAmount(item.meanAbsoluteAmountError, item.unit)}
         />
         <Metric label="비교일" value={`${item.evaluatedDayCount}일`} />
       </dl>
@@ -195,12 +195,12 @@ function PriorityNotice({
 }: {
   item: IngredientForecastAccuracyView | null;
 }): React.ReactElement | null {
-  if (!item || item.meanAbsolutePercentageError === null) return null;
+  if (!item || item.weightedAbsolutePercentageError === null) return null;
 
   return (
     <section className="rounded-[24px] border border-amber/30 bg-amber-soft px-4 py-3 shadow-soft">
       <p className="text-body text-amber-deep">
-        우선 확인: {item.name} · 오차율 {formatPercent(item.meanAbsolutePercentageError)}
+        우선 확인: {item.name} · WAPE {formatPercent(item.weightedAbsolutePercentageError)}
       </p>
       <p className="mt-1 text-caption text-ink-3">{buildTuningHint(item)}</p>
     </section>
@@ -233,16 +233,16 @@ function DiagnosticReasons({ reasons }: { reasons: readonly string[] }): React.R
 }
 
 function buildSummary(items: readonly IngredientForecastAccuracyView[]): {
-  meanMape: number | null;
+  meanWape: number | null;
   overCount: number;
   underCount: number;
   priorityItem: IngredientForecastAccuracyView | null;
 } {
-  const valid = items.filter((item) => item.meanAbsolutePercentageError !== null);
+  const valid = items.filter((item) => item.weightedAbsolutePercentageError !== null);
   return {
-    meanMape:
+    meanWape:
       valid.length > 0
-        ? valid.reduce((sum, item) => sum + (item.meanAbsolutePercentageError ?? 0), 0) /
+        ? valid.reduce((sum, item) => sum + (item.weightedAbsolutePercentageError ?? 0), 0) /
           valid.length
         : null,
     overCount: items.filter((item) => item.bias === "over").length,
@@ -250,7 +250,8 @@ function buildSummary(items: readonly IngredientForecastAccuracyView[]): {
     priorityItem:
       valid.length > 0
         ? ([...valid].sort(
-            (a, b) => (b.meanAbsolutePercentageError ?? 0) - (a.meanAbsolutePercentageError ?? 0),
+            (a, b) =>
+              (b.weightedAbsolutePercentageError ?? 0) - (a.weightedAbsolutePercentageError ?? 0),
           )[0] ?? null)
         : null,
   };
@@ -260,15 +261,15 @@ function buildTuningHint(item: IngredientForecastAccuracyView): string {
   if (item.evaluatedDayCount < 3)
     return "소비 비교일이 적습니다. 판매 데이터가 더 쌓인 뒤 판단하세요.";
   if (item.reliability === "low")
-    return "오차율이 매우 큽니다. 옵션 선택률, 레시피 변경, 이벤트성 판매를 먼저 확인하세요.";
+    return "총량 기준 오차가 매우 큽니다. 옵션 선택률, 레시피 변경, 이벤트성 판매를 먼저 확인하세요.";
   if (item.reliability === "watch")
     return "예측을 참고하되 발주 전 최근 1주 소비 흐름을 한 번 더 확인하세요.";
   if (item.bias === "under")
     return "실제 소비가 예측보다 큽니다. 발주량 부족 위험을 먼저 확인하세요.";
   if (item.bias === "over")
     return "예측 소비가 실제보다 큽니다. 과발주 가능성이 있어 최근 판매 둔화를 확인하세요.";
-  if ((item.meanAbsolutePercentageError ?? 0) >= 0.5) {
-    return "오차율이 큽니다. 옵션 선택률, 레시피 변경, 주말/평일 편차를 확인하세요.";
+  if ((item.weightedAbsolutePercentageError ?? 0) >= 0.5) {
+    return "총량 기준 오차가 큽니다. 옵션 선택률, 레시피 변경, 주말/평일 편차를 확인하세요.";
   }
   return "예측 방향은 안정적입니다. 현재 발주 추천을 그대로 참고해도 됩니다.";
 }

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -230,9 +230,9 @@ function AccuracyBadge({
 }
 
 function formatAccuracyLabel(accuracy: IngredientForecastAccuracyView): string {
-  const mape = accuracy.meanAbsolutePercentageError;
-  if (mape === null || accuracy.evaluatedDayCount < 3) return "정확도 수집 중";
-  return `오차 ${Math.round(mape * 100)}%`;
+  const dayError = accuracy.meanAbsoluteDayEquivalentError;
+  if (dayError === null || accuracy.evaluatedDayCount < 3) return "정확도 수집 중";
+  return `평균 ±${Number(dayError.toFixed(1))}일`;
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {

--- a/src/features/inventory/components/MenuDemandForecastList.tsx
+++ b/src/features/inventory/components/MenuDemandForecastList.tsx
@@ -116,8 +116,8 @@ function MenuDemandForecastCard({
 }
 
 function AccuracyBadge({ accuracy }: { accuracy: MenuForecastAccuracyView }): React.ReactElement {
-  const mape = accuracy.meanAbsolutePercentageError;
-  const label = mape === null ? "정확도 수집 중" : `오차 ${formatPercent(mape)}`;
+  const wape = accuracy.weightedAbsolutePercentageError;
+  const label = wape === null ? "정확도 수집 중" : `WAPE ${formatPercent(wape)}`;
 
   return (
     <Link

--- a/src/features/inventory/components/MenuForecastAccuracyList.tsx
+++ b/src/features/inventory/components/MenuForecastAccuracyList.tsx
@@ -38,7 +38,7 @@ export function MenuForecastAccuracyList({
   return (
     <div className="flex flex-col gap-section">
       <section className="grid grid-cols-3 gap-stack-tight">
-        <SummaryTile label="평균 오차율" value={formatPercent(summary.meanMape)} />
+        <SummaryTile label="평균 WAPE" value={formatPercent(summary.meanWape)} />
         <SummaryTile label="과대예측" value={`${summary.overCount}개`} />
         <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
       </section>
@@ -90,8 +90,11 @@ function MenuForecastAccuracyCard({
       </div>
 
       <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
-        <Metric label="오차율" value={formatPercent(item.meanAbsolutePercentageError)} />
-        <Metric label="평균 오차" value={formatNullableQuantity(item.averageAbsoluteError)} />
+        <Metric label="WAPE" value={formatPercent(item.weightedAbsolutePercentageError)} />
+        <Metric
+          label="평균 수량오차"
+          value={formatNullableQuantity(item.meanAbsoluteQuantityError)}
+        />
         <Metric label="비교일" value={`${item.evaluatedDayCount}일`} />
       </dl>
 
@@ -191,12 +194,12 @@ function PriorityNotice({
 }: {
   item: MenuForecastAccuracyView | null;
 }): React.ReactElement | null {
-  if (!item || item.meanAbsolutePercentageError === null) return null;
+  if (!item || item.weightedAbsolutePercentageError === null) return null;
 
   return (
     <section className="rounded-[24px] border border-amber/30 bg-amber-soft px-4 py-3 shadow-soft">
       <p className="text-body text-amber-deep">
-        우선 확인: {item.name} · 오차율 {formatPercent(item.meanAbsolutePercentageError)}
+        우선 확인: {item.name} · WAPE {formatPercent(item.weightedAbsolutePercentageError)}
       </p>
       <p className="mt-1 text-caption text-ink-3">{buildTuningHint(item)}</p>
     </section>
@@ -229,16 +232,16 @@ function DiagnosticReasons({ reasons }: { reasons: readonly string[] }): React.R
 }
 
 function buildSummary(items: readonly MenuForecastAccuracyView[]): {
-  meanMape: number | null;
+  meanWape: number | null;
   overCount: number;
   underCount: number;
   priorityItem: MenuForecastAccuracyView | null;
 } {
-  const valid = items.filter((item) => item.meanAbsolutePercentageError !== null);
+  const valid = items.filter((item) => item.weightedAbsolutePercentageError !== null);
   return {
-    meanMape:
+    meanWape:
       valid.length > 0
-        ? valid.reduce((sum, item) => sum + (item.meanAbsolutePercentageError ?? 0), 0) /
+        ? valid.reduce((sum, item) => sum + (item.weightedAbsolutePercentageError ?? 0), 0) /
           valid.length
         : null,
     overCount: items.filter((item) => item.bias === "over").length,
@@ -246,7 +249,8 @@ function buildSummary(items: readonly MenuForecastAccuracyView[]): {
     priorityItem:
       valid.length > 0
         ? ([...valid].sort(
-            (a, b) => (b.meanAbsolutePercentageError ?? 0) - (a.meanAbsolutePercentageError ?? 0),
+            (a, b) =>
+              (b.weightedAbsolutePercentageError ?? 0) - (a.weightedAbsolutePercentageError ?? 0),
           )[0] ?? null)
         : null,
   };
@@ -255,15 +259,15 @@ function buildSummary(items: readonly MenuForecastAccuracyView[]): {
 function buildTuningHint(item: MenuForecastAccuracyView): string {
   if (item.evaluatedDayCount < 3) return "판매 비교일이 적습니다. 데이터가 더 쌓인 뒤 판단하세요.";
   if (item.reliability === "low")
-    return "오차율이 매우 큽니다. 이벤트성 판매, 메뉴 옵션, 최근 레시피 변경을 먼저 확인하세요.";
+    return "총량 기준 오차가 매우 큽니다. 이벤트성 판매, 메뉴 옵션, 최근 레시피 변경을 먼저 확인하세요.";
   if (item.reliability === "watch")
     return "예측을 참고하되 발주 전 최근 1주 판매 흐름을 한 번 더 확인하세요.";
   if (item.bias === "under")
     return "실제 판매가 예측보다 많습니다. 발주량 부족 위험을 먼저 확인하세요.";
   if (item.bias === "over")
     return "예측이 실제보다 큽니다. 과발주 가능성이 있어 최근 판매 둔화를 확인하세요.";
-  if ((item.meanAbsolutePercentageError ?? 0) >= 0.5) {
-    return "오차율이 큽니다. 주말/평일 편차나 최근 이벤트성 판매를 확인하세요.";
+  if ((item.weightedAbsolutePercentageError ?? 0) >= 0.5) {
+    return "총량 기준 오차가 큽니다. 주말/평일 편차나 최근 이벤트성 판매를 확인하세요.";
   }
   return "예측 방향은 안정적입니다. 큰 조정 없이 추이를 계속 보세요.";
 }

--- a/src/features/inventory/components/RevenueForecastAccuracyCard.tsx
+++ b/src/features/inventory/components/RevenueForecastAccuracyCard.tsx
@@ -42,8 +42,10 @@ export function RevenueForecastAccuracyCard({
     <div className="flex flex-col gap-section">
       <section className="grid gap-stack-tight sm:grid-cols-4">
         <SummaryTile label="WAPE" value={formatPercent(data.weightedAbsolutePercentageError)} />
-        <SummaryTile label="MAPE" value={formatPercent(data.meanAbsolutePercentageError)} />
-        <SummaryTile label="평균 오차" value={`${formatWon(data.averageAbsoluteError ?? 0)}원`} />
+        <SummaryTile
+          label="평균 금액오차"
+          value={`${formatWon(data.meanAbsoluteWonError ?? 0)}원`}
+        />
         <SummaryTile label="비교일" value={`${data.evaluatedDayCount}일`} />
       </section>
 
@@ -84,7 +86,7 @@ export function RevenueForecastAccuracyCard({
                 />
               </div>
               <span className="text-micro text-ink-3 tabular-nums">
-                {formatPercent(day.absolutePercentageError)}
+                {formatPercent(day.weightedAbsolutePercentageError)}
               </span>
             </li>
           ))}
@@ -121,8 +123,8 @@ export function RevenueForecastAccuracyCard({
                   </p>
                 </div>
                 <span className="rounded-full bg-bg px-3 py-1.5 text-caption font-semibold text-ink-2">
-                  오차 {formatWon(day.absoluteError)}원 ·{" "}
-                  {formatPercent(day.absolutePercentageError)}
+                  오차 {formatWon(day.absoluteWonError)}원 ·{" "}
+                  {formatPercent(day.weightedAbsolutePercentageError)}
                 </span>
               </div>
             </li>

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -71,8 +71,8 @@ export interface MenuDemandForecastView {
 export interface MenuForecastAccuracyView {
   menuId: string;
   name: string;
-  averageAbsoluteError: number | null;
-  meanAbsolutePercentageError: number | null;
+  meanAbsoluteQuantityError: number | null;
+  weightedAbsolutePercentageError: number | null;
   reliability: ForecastReliability;
   diagnosticReasons: string[];
   bias: "over" | "under" | "balanced" | "insufficient_data";
@@ -83,8 +83,8 @@ export interface MenuForecastAccuracyView {
     date: Date;
     actualQuantity: number;
     predictedQuantity: number;
-    absoluteError: number;
-    absolutePercentageError: number | null;
+    absoluteQuantityError: number;
+    signedQuantityError: number;
   }>;
 }
 
@@ -92,8 +92,12 @@ export interface IngredientForecastAccuracyView {
   ingredientId: string;
   name: string;
   unit: "g" | "ml" | "piece";
-  averageAbsoluteError: number | null;
-  meanAbsolutePercentageError: number | null;
+  meanAbsoluteAmountError: number | null;
+  weightedAbsolutePercentageError: number | null;
+  meanAbsoluteDayEquivalentError: number | null;
+  riskAdjustedDayError: number | null;
+  underPredictedDayCount: number;
+  overPredictedDayCount: number;
   reliability: ForecastReliability;
   diagnosticReasons: string[];
   bias: "over" | "under" | "balanced" | "insufficient_data";
@@ -104,14 +108,14 @@ export interface IngredientForecastAccuracyView {
     date: Date;
     actualAmount: number;
     predictedAmount: number;
-    absoluteError: number;
-    absolutePercentageError: number | null;
+    absoluteAmountError: number;
+    signedAmountError: number;
+    dayEquivalentError: number | null;
   }>;
 }
 
 export interface RevenueForecastAccuracyView {
-  averageAbsoluteError: number | null;
-  meanAbsolutePercentageError: number | null;
+  meanAbsoluteWonError: number | null;
   weightedAbsolutePercentageError: number | null;
   reliability: ForecastReliability;
   bias: "over" | "under" | "balanced" | "insufficient_data";
@@ -122,8 +126,9 @@ export interface RevenueForecastAccuracyView {
     date: Date;
     actualRevenue: number;
     predictedRevenue: number;
-    absoluteError: number;
-    absolutePercentageError: number | null;
+    absoluteWonError: number;
+    signedWonError: number;
+    weightedAbsolutePercentageError: number | null;
   }>;
 }
 
@@ -301,31 +306,31 @@ export async function loadMenuForecastAccuracyViews(
         });
         const actualQuantity = sampleByDate.get(dateKey(targetDate))?.quantity ?? 0;
         const predictedQuantity = forecast.dailyPredictions[0]?.predictedQuantity ?? 0;
-        const absoluteError = Math.abs(predictedQuantity - actualQuantity);
+        const signedQuantityError = predictedQuantity - actualQuantity;
+        const absoluteQuantityError = Math.abs(signedQuantityError);
 
         return {
           date: targetDate,
           actualQuantity,
           predictedQuantity,
-          absoluteError,
-          absolutePercentageError:
-            actualQuantity > 0 ? absoluteError / Math.max(1, actualQuantity) : null,
+          absoluteQuantityError,
+          signedQuantityError,
         };
       });
 
       const evaluated = dailyResults.filter((result) => result.actualQuantity > 0);
       const actualTotalQuantity = sumBy(dailyResults, (result) => result.actualQuantity);
       const predictedTotalQuantity = sumBy(dailyResults, (result) => result.predictedQuantity);
-      const averageAbsoluteError =
+      const meanAbsoluteQuantityError =
         evaluated.length > 0
-          ? sumBy(evaluated, (result) => result.absoluteError) / evaluated.length
+          ? sumBy(evaluated, (result) => result.absoluteQuantityError) / evaluated.length
           : null;
-      const meanAbsolutePercentageError =
-        evaluated.length > 0
-          ? sumBy(evaluated, (result) => result.absolutePercentageError ?? 0) / evaluated.length
-          : null;
+      const weightedAbsolutePercentageError = computeWape(
+        sumBy(dailyResults, (result) => result.absoluteQuantityError),
+        actualTotalQuantity,
+      );
       const reliability = classifyForecastReliability(
-        meanAbsolutePercentageError,
+        weightedAbsolutePercentageError,
         evaluated.length,
       );
       const bias = classifyForecastBias(
@@ -337,8 +342,8 @@ export async function loadMenuForecastAccuracyViews(
       return {
         menuId: row.menuId,
         name: row.name,
-        averageAbsoluteError,
-        meanAbsolutePercentageError,
+        meanAbsoluteQuantityError,
+        weightedAbsolutePercentageError,
         reliability,
         diagnosticReasons: buildForecastDiagnostics({
           kind: "menu",
@@ -354,10 +359,10 @@ export async function loadMenuForecastAccuracyViews(
       };
     })
     .sort((a, b) => {
-      if (a.meanAbsolutePercentageError === null) return 1;
-      if (b.meanAbsolutePercentageError === null) return -1;
-      const aError = a.meanAbsolutePercentageError;
-      const bError = b.meanAbsolutePercentageError;
+      if (a.weightedAbsolutePercentageError === null) return 1;
+      if (b.weightedAbsolutePercentageError === null) return -1;
+      const aError = a.weightedAbsolutePercentageError;
+      const bError = b.weightedAbsolutePercentageError;
       return bError - aError;
     });
 }
@@ -400,38 +405,34 @@ export async function loadRevenueForecastAccuracyView(
       return (forecast.dailyPredictions[0]?.predictedQuantity ?? 0) * row.price;
     });
     const actualRevenue = actualRevenueByDate.get(dateKey(targetDate)) ?? 0;
-    const absoluteError = Math.abs(predictedRevenue - actualRevenue);
+    const signedWonError = predictedRevenue - actualRevenue;
+    const absoluteWonError = Math.abs(signedWonError);
     return {
       date: targetDate,
       actualRevenue,
       predictedRevenue,
-      absoluteError,
-      absolutePercentageError:
-        actualRevenue > 0 ? absoluteError / Math.max(1, actualRevenue) : null,
+      absoluteWonError,
+      signedWonError,
+      weightedAbsolutePercentageError: actualRevenue > 0 ? absoluteWonError / actualRevenue : null,
     };
   });
 
   const evaluated = dailyResults.filter((result) => result.actualRevenue > 0);
   const actualTotalRevenue = sumBy(dailyResults, (result) => result.actualRevenue);
   const predictedTotalRevenue = sumBy(dailyResults, (result) => result.predictedRevenue);
-  const averageAbsoluteError =
+  const meanAbsoluteWonError =
     evaluated.length > 0
-      ? sumBy(evaluated, (result) => result.absoluteError) / evaluated.length
+      ? sumBy(evaluated, (result) => result.absoluteWonError) / evaluated.length
       : null;
-  const meanAbsolutePercentageError =
-    evaluated.length > 0
-      ? sumBy(evaluated, (result) => result.absolutePercentageError ?? 0) / evaluated.length
-      : null;
-  const weightedAbsolutePercentageError =
-    actualTotalRevenue > 0
-      ? sumBy(dailyResults, (result) => result.absoluteError) / actualTotalRevenue
-      : null;
+  const weightedAbsolutePercentageError = computeWape(
+    sumBy(dailyResults, (result) => result.absoluteWonError),
+    actualTotalRevenue,
+  );
 
   return {
-    averageAbsoluteError,
-    meanAbsolutePercentageError,
+    meanAbsoluteWonError,
     weightedAbsolutePercentageError,
-    reliability: classifyForecastReliability(meanAbsolutePercentageError, evaluated.length),
+    reliability: classifyForecastReliability(weightedAbsolutePercentageError, evaluated.length),
     bias: classifyForecastBias(actualTotalRevenue, predictedTotalRevenue, evaluated.length),
     evaluatedDayCount: evaluated.length,
     actualTotalRevenue,
@@ -520,29 +521,50 @@ export async function loadIngredientForecastAccuracyViews(
         const key = dateKey(date);
         const actualAmount = actualDaily.get(key) ?? 0;
         const predictedAmount = predictedDaily.get(key) ?? 0;
-        const absoluteError = Math.abs(predictedAmount - actualAmount);
+        const signedAmountError = predictedAmount - actualAmount;
+        const absoluteAmountError = Math.abs(signedAmountError);
+        const demandBasis = Math.max(actualAmount, predictedAmount);
         return {
           date,
           actualAmount,
           predictedAmount,
-          absoluteError,
-          absolutePercentageError:
-            actualAmount > 0 ? absoluteError / Math.max(1, actualAmount) : null,
+          absoluteAmountError,
+          signedAmountError,
+          dayEquivalentError: demandBasis > 0 ? absoluteAmountError / demandBasis : null,
         };
       });
       const evaluated = dailyResults.filter((result) => result.actualAmount > 0);
       const actualTotalAmount = sumBy(dailyResults, (result) => result.actualAmount);
       const predictedTotalAmount = sumBy(dailyResults, (result) => result.predictedAmount);
-      const averageAbsoluteError =
+      const meanAbsoluteAmountError =
         evaluated.length > 0
-          ? sumBy(evaluated, (result) => result.absoluteError) / evaluated.length
+          ? sumBy(evaluated, (result) => result.absoluteAmountError) / evaluated.length
           : null;
-      const meanAbsolutePercentageError =
-        evaluated.length > 0
-          ? sumBy(evaluated, (result) => result.absolutePercentageError ?? 0) / evaluated.length
+      const weightedAbsolutePercentageError = computeWape(
+        sumBy(dailyResults, (result) => result.absoluteAmountError),
+        actualTotalAmount,
+      );
+      const dayErrorSamples = evaluated.filter((result) => result.dayEquivalentError !== null);
+      const meanAbsoluteDayEquivalentError =
+        dayErrorSamples.length > 0
+          ? sumBy(dayErrorSamples, (result) => result.dayEquivalentError ?? 0) /
+            dayErrorSamples.length
           : null;
+      const riskAdjustedDayError =
+        dayErrorSamples.length > 0
+          ? sumBy(dayErrorSamples, (result) => {
+              const weight = result.signedAmountError < 0 ? 2 : 1;
+              return (result.dayEquivalentError ?? 0) * weight;
+            }) / dayErrorSamples.length
+          : null;
+      const underPredictedDayCount = evaluated.filter(
+        (result) => result.signedAmountError < 0,
+      ).length;
+      const overPredictedDayCount = evaluated.filter(
+        (result) => result.signedAmountError > 0,
+      ).length;
       const reliability = classifyForecastReliability(
-        meanAbsolutePercentageError,
+        weightedAbsolutePercentageError,
         evaluated.length,
       );
       const bias = classifyForecastBias(actualTotalAmount, predictedTotalAmount, evaluated.length);
@@ -551,8 +573,12 @@ export async function loadIngredientForecastAccuracyViews(
         ingredientId: ingredient.ingredientId,
         name: ingredient.name,
         unit: ingredient.unit,
-        averageAbsoluteError,
-        meanAbsolutePercentageError,
+        meanAbsoluteAmountError,
+        weightedAbsolutePercentageError,
+        meanAbsoluteDayEquivalentError,
+        riskAdjustedDayError,
+        underPredictedDayCount,
+        overPredictedDayCount,
         reliability,
         diagnosticReasons: buildForecastDiagnostics({
           kind: "ingredient",
@@ -562,8 +588,8 @@ export async function loadIngredientForecastAccuracyViews(
             date: result.date,
             actualQuantity: result.actualAmount,
             predictedQuantity: result.predictedAmount,
-            absoluteError: result.absoluteError,
-            absolutePercentageError: result.absolutePercentageError,
+            absoluteQuantityError: result.absoluteAmountError,
+            signedQuantityError: result.signedAmountError,
           })),
         }),
         bias,
@@ -574,9 +600,9 @@ export async function loadIngredientForecastAccuracyViews(
       };
     })
     .sort((a, b) => {
-      if (a.meanAbsolutePercentageError === null) return 1;
-      if (b.meanAbsolutePercentageError === null) return -1;
-      return b.meanAbsolutePercentageError - a.meanAbsolutePercentageError;
+      if (a.riskAdjustedDayError === null) return 1;
+      if (b.riskAdjustedDayError === null) return -1;
+      return b.riskAdjustedDayError - a.riskAdjustedDayError;
     });
 }
 
@@ -690,6 +716,10 @@ function sumBy<T>(items: readonly T[], selector: (item: T) => number): number {
   return items.reduce((sum, item) => sum + selector(item), 0);
 }
 
+function computeWape(absoluteErrorTotal: number, actualTotal: number): number | null {
+  return actualTotal > 0 ? absoluteErrorTotal / actualTotal : null;
+}
+
 function classifyForecastBias(
   actualTotalQuantity: number,
   predictedTotalQuantity: number,
@@ -704,12 +734,14 @@ function classifyForecastBias(
 }
 
 function classifyForecastReliability(
-  meanAbsolutePercentageError: number | null,
+  weightedAbsolutePercentageError: number | null,
   evaluatedDayCount: number,
 ): ForecastReliability {
-  if (evaluatedDayCount < 3 || meanAbsolutePercentageError === null) return "insufficient_data";
-  if (meanAbsolutePercentageError >= 0.8) return "low";
-  if (meanAbsolutePercentageError >= 0.35) return "watch";
+  if (evaluatedDayCount < 3 || weightedAbsolutePercentageError === null) {
+    return "insufficient_data";
+  }
+  if (weightedAbsolutePercentageError >= 0.8) return "low";
+  if (weightedAbsolutePercentageError >= 0.35) return "watch";
   return "good";
 }
 
@@ -726,8 +758,8 @@ function buildForecastDiagnostics({
     date: Date;
     actualQuantity: number;
     predictedQuantity: number;
-    absoluteError: number;
-    absolutePercentageError: number | null;
+    absoluteQuantityError: number;
+    signedQuantityError: number;
   }[];
 }): string[] {
   const reasons: string[] = [];
@@ -740,9 +772,9 @@ function buildForecastDiagnostics({
   }
 
   if (reliability === "low") {
-    reasons.push("오차율이 80% 이상이라 예측 신뢰도가 낮습니다.");
+    reasons.push("총량 기준 오차가 80% 이상이라 예측 신뢰도가 낮습니다.");
   } else if (reliability === "watch") {
-    reasons.push("오차율이 35% 이상이라 발주 전 재확인이 필요합니다.");
+    reasons.push("총량 기준 오차가 35% 이상이라 발주 전 재확인이 필요합니다.");
   }
 
   if (bias === "under") {
@@ -770,13 +802,13 @@ function buildForecastDiagnostics({
 }
 
 function findLargestWeekdayError(
-  dailyResults: readonly { date: Date; absoluteError: number }[],
+  dailyResults: readonly { date: Date; absoluteQuantityError: number }[],
 ): string | null {
   const byWeekday = new Map<number, { error: number; count: number }>();
   for (const result of dailyResults) {
     const weekday = result.date.getDay();
     const bucket = byWeekday.get(weekday) ?? { error: 0, count: 0 };
-    bucket.error += result.absoluteError;
+    bucket.error += result.absoluteQuantityError;
     bucket.count += 1;
     byWeekday.set(weekday, bucket);
   }

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -566,7 +566,8 @@ describe("application layer", () => {
       expect(result?.evaluatedDayCount).toBe(7);
       expect(result?.actualTotalQuantity).toBe(70);
       expect(result?.predictedTotalQuantity).toBeGreaterThan(0);
-      expect(result?.meanAbsolutePercentageError).not.toBeNull();
+      expect(result?.weightedAbsolutePercentageError).not.toBeNull();
+      expect(result?.meanAbsoluteQuantityError).not.toBeNull();
       expect(result?.bias).not.toBe("insufficient_data");
     });
 
@@ -620,7 +621,9 @@ describe("application layer", () => {
       expect(result?.evaluatedDayCount).toBe(7);
       expect(result?.actualTotalAmount).toBe(7000);
       expect(result?.predictedTotalAmount).toBeGreaterThan(0);
-      expect(result?.meanAbsolutePercentageError).not.toBeNull();
+      expect(result?.weightedAbsolutePercentageError).not.toBeNull();
+      expect(result?.meanAbsoluteAmountError).not.toBeNull();
+      expect(result?.meanAbsoluteDayEquivalentError).not.toBeNull();
       expect(result?.bias).not.toBe("insufficient_data");
     });
   });


### PR DESCRIPTION
## Summary
- replace menu/revenue MAPE with WAPE and absolute operational errors
- add ingredient day-equivalent and shortage-risk adjusted accuracy metrics
- update forecast accuracy UI/tests to use the new metric names

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test