### PR TITLE
Polish forecast accuracy metric labels

### DIFF
--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -349,7 +349,7 @@ function RevenueBacktestComparison({
                 : "bg-blue-soft text-blue-deep",
           )}
         >
-          WAPE{" "}
+          총량오차{" "}
           {summary.weightedAbsolutePercentageError === null
             ? "-"
             : `${Math.round(summary.weightedAbsolutePercentageError * 100)}%`}

--- a/src/features/inventory/components/IngredientForecastAccuracyList.tsx
+++ b/src/features/inventory/components/IngredientForecastAccuracyList.tsx
@@ -38,9 +38,10 @@ export function IngredientForecastAccuracyList({
 
   return (
     <div className="flex flex-col gap-section">
-      <section className="grid grid-cols-3 gap-stack-tight">
-        <SummaryTile label="평균 WAPE" value={formatPercent(summary.meanWape)} />
-        <SummaryTile label="과대예측" value={`${summary.overCount}개`} />
+      <section className="grid grid-cols-2 gap-stack-tight sm:grid-cols-4">
+        <SummaryTile label="평균 총량오차" value={formatPercent(summary.meanWape)} />
+        <SummaryTile label="평균 일수오차" value={formatDayError(summary.meanDayError)} />
+        <SummaryTile label="부족위험일" value={`${summary.underPredictedDayCount}일`} />
         <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
       </section>
 
@@ -91,12 +92,12 @@ function IngredientForecastAccuracyCard({
       </div>
 
       <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
-        <Metric label="WAPE" value={formatPercent(item.weightedAbsolutePercentageError)} />
+        <Metric label="총량오차율" value={formatPercent(item.weightedAbsolutePercentageError)} />
         <Metric
           label="평균 소비오차"
           value={formatNullableAmount(item.meanAbsoluteAmountError, item.unit)}
         />
-        <Metric label="비교일" value={`${item.evaluatedDayCount}일`} />
+        <Metric label="일수오차" value={formatDayError(item.meanAbsoluteDayEquivalentError)} />
       </dl>
 
       <TuningHint item={item} />
@@ -200,7 +201,8 @@ function PriorityNotice({
   return (
     <section className="rounded-[24px] border border-amber/30 bg-amber-soft px-4 py-3 shadow-soft">
       <p className="text-body text-amber-deep">
-        우선 확인: {item.name} · WAPE {formatPercent(item.weightedAbsolutePercentageError)}
+        우선 확인: {item.name} · 부족위험 {item.underPredictedDayCount}일 · 일수오차{" "}
+        {formatDayError(item.meanAbsoluteDayEquivalentError)}
       </p>
       <p className="mt-1 text-caption text-ink-3">{buildTuningHint(item)}</p>
     </section>
@@ -234,24 +236,30 @@ function DiagnosticReasons({ reasons }: { reasons: readonly string[] }): React.R
 
 function buildSummary(items: readonly IngredientForecastAccuracyView[]): {
   meanWape: number | null;
-  overCount: number;
+  meanDayError: number | null;
   underCount: number;
+  underPredictedDayCount: number;
   priorityItem: IngredientForecastAccuracyView | null;
 } {
   const valid = items.filter((item) => item.weightedAbsolutePercentageError !== null);
+  const dayErrorItems = items.filter((item) => item.meanAbsoluteDayEquivalentError !== null);
   return {
     meanWape:
       valid.length > 0
         ? valid.reduce((sum, item) => sum + (item.weightedAbsolutePercentageError ?? 0), 0) /
           valid.length
         : null,
-    overCount: items.filter((item) => item.bias === "over").length,
+    meanDayError:
+      dayErrorItems.length > 0
+        ? dayErrorItems.reduce((sum, item) => sum + (item.meanAbsoluteDayEquivalentError ?? 0), 0) /
+          dayErrorItems.length
+        : null,
     underCount: items.filter((item) => item.bias === "under").length,
+    underPredictedDayCount: items.reduce((sum, item) => sum + item.underPredictedDayCount, 0),
     priorityItem:
-      valid.length > 0
-        ? ([...valid].sort(
-            (a, b) =>
-              (b.weightedAbsolutePercentageError ?? 0) - (a.weightedAbsolutePercentageError ?? 0),
+      items.length > 0
+        ? ([...items].sort(
+            (a, b) => (b.riskAdjustedDayError ?? -1) - (a.riskAdjustedDayError ?? -1),
           )[0] ?? null)
         : null,
   };
@@ -292,6 +300,10 @@ function formatNullableAmount(
 
 function formatPercent(value: number | null): string {
   return value === null ? "-" : `${Math.round(value * 100)}%`;
+}
+
+function formatDayError(value: number | null): string {
+  return value === null ? "-" : `±${Number(value.toFixed(1))}일`;
 }
 
 function formatShortDate(date: Date): string {

--- a/src/features/inventory/components/MenuDemandForecastList.tsx
+++ b/src/features/inventory/components/MenuDemandForecastList.tsx
@@ -117,7 +117,7 @@ function MenuDemandForecastCard({
 
 function AccuracyBadge({ accuracy }: { accuracy: MenuForecastAccuracyView }): React.ReactElement {
   const wape = accuracy.weightedAbsolutePercentageError;
-  const label = wape === null ? "정확도 수집 중" : `WAPE ${formatPercent(wape)}`;
+  const label = wape === null ? "정확도 수집 중" : `총량오차 ${formatPercent(wape)}`;
 
   return (
     <Link

--- a/src/features/inventory/components/MenuForecastAccuracyList.tsx
+++ b/src/features/inventory/components/MenuForecastAccuracyList.tsx
@@ -38,7 +38,7 @@ export function MenuForecastAccuracyList({
   return (
     <div className="flex flex-col gap-section">
       <section className="grid grid-cols-3 gap-stack-tight">
-        <SummaryTile label="평균 WAPE" value={formatPercent(summary.meanWape)} />
+        <SummaryTile label="평균 총량오차" value={formatPercent(summary.meanWape)} />
         <SummaryTile label="과대예측" value={`${summary.overCount}개`} />
         <SummaryTile label="과소예측" value={`${summary.underCount}개`} />
       </section>
@@ -90,7 +90,7 @@ function MenuForecastAccuracyCard({
       </div>
 
       <dl className="mt-stack grid grid-cols-3 gap-stack-tight">
-        <Metric label="WAPE" value={formatPercent(item.weightedAbsolutePercentageError)} />
+        <Metric label="총량오차율" value={formatPercent(item.weightedAbsolutePercentageError)} />
         <Metric
           label="평균 수량오차"
           value={formatNullableQuantity(item.meanAbsoluteQuantityError)}
@@ -199,7 +199,7 @@ function PriorityNotice({
   return (
     <section className="rounded-[24px] border border-amber/30 bg-amber-soft px-4 py-3 shadow-soft">
       <p className="text-body text-amber-deep">
-        우선 확인: {item.name} · WAPE {formatPercent(item.weightedAbsolutePercentageError)}
+        우선 확인: {item.name} · 총량오차율 {formatPercent(item.weightedAbsolutePercentageError)}
       </p>
       <p className="mt-1 text-caption text-ink-3">{buildTuningHint(item)}</p>
     </section>

--- a/src/features/inventory/components/RevenueForecastAccuracyCard.tsx
+++ b/src/features/inventory/components/RevenueForecastAccuracyCard.tsx
@@ -40,8 +40,11 @@ export function RevenueForecastAccuracyCard({
 
   return (
     <div className="flex flex-col gap-section">
-      <section className="grid gap-stack-tight sm:grid-cols-4">
-        <SummaryTile label="WAPE" value={formatPercent(data.weightedAbsolutePercentageError)} />
+      <section className="grid gap-stack-tight sm:grid-cols-3">
+        <SummaryTile
+          label="총량오차율"
+          value={formatPercent(data.weightedAbsolutePercentageError)}
+        />
         <SummaryTile
           label="평균 금액오차"
           value={`${formatWon(data.meanAbsoluteWonError ?? 0)}원`}
@@ -65,8 +68,8 @@ export function RevenueForecastAccuracyCard({
         </div>
 
         <p className="mt-stack rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
-          WAPE는 전체 실제 매출 대비 총 오차입니다. 매출이 작은 날 하나에 흔들리는 MAPE보다 운영
-          판단용으로 더 안정적입니다.
+          총량오차율은 비교 기간 전체 실제 매출 대비 총 오차입니다. 하루 매출이 작아 생기는
+          극단값보다 전체 운영 흐름을 더 안정적으로 보여줍니다.
         </p>
 
         <ol className="mt-stack grid grid-cols-7 gap-1.5">


### PR DESCRIPTION
## Summary
- replace exposed WAPE wording with operator-friendly 총량오차 labels
- surface ingredient shortage-risk days and day-equivalent error in the accuracy summary
- align calendar/menu/revenue accuracy badges with the new metric language

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test