### PR TITLE
Show operational accuracy hints on forecast cards

### DIFF
--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -319,6 +319,7 @@ interface RevenueBacktestDateSummary {
   actualRevenue: number;
   predictedRevenue: number;
   absoluteWonError: number;
+  meanAbsoluteWonError: number | null;
   weightedAbsolutePercentageError: number | null;
   reliability: MenuForecastAccuracyView["reliability"];
   bias: "over" | "under" | "balanced" | "insufficient_data";
@@ -349,16 +350,13 @@ function RevenueBacktestComparison({
                 : "bg-blue-soft text-blue-deep",
           )}
         >
-          총량오차{" "}
-          {summary.weightedAbsolutePercentageError === null
-            ? "-"
-            : `${Math.round(summary.weightedAbsolutePercentageError * 100)}%`}
+          평균 {formatAverageWonError(summary.meanAbsoluteWonError)} 오차
         </span>
       </div>
       <div className="grid grid-cols-3 gap-stack">
         <Metric label="실제 매출" value={`${formatWon(summary.actualRevenue)}원`} />
         <Metric label="예측 매출" value={`${formatWon(summary.predictedRevenue)}원`} />
-        <Metric label="오차" value={`${formatWon(summary.absoluteWonError)}원`} />
+        <Metric label="당일 오차" value={`${formatWon(summary.absoluteWonError)}원`} />
       </div>
     </article>
   );
@@ -609,17 +607,24 @@ function buildRevenueBacktestSummaryForDate(
   date: string,
   data: RevenueForecastAccuracyView | undefined,
 ): RevenueBacktestDateSummary | null {
-  const result = data?.dailyResults.find((day) => localIsoDate(day.date) === date);
+  if (!data) return null;
+  const result = data.dailyResults.find((day) => localIsoDate(day.date) === date);
   if (!result || result.actualRevenue <= 0) return null;
 
   return {
     actualRevenue: result.actualRevenue,
     predictedRevenue: result.predictedRevenue,
     absoluteWonError: result.absoluteWonError,
+    meanAbsoluteWonError: data.meanAbsoluteWonError,
     weightedAbsolutePercentageError: result.weightedAbsolutePercentageError,
     reliability: classifyDateBacktestReliability(result.weightedAbsolutePercentageError, 1),
     bias: classifyRevenueBias(result.actualRevenue, result.predictedRevenue),
   };
+}
+
+function formatAverageWonError(value: number | null): string {
+  if (value === null) return "-";
+  return `${formatNumber(Number((value / 10000).toFixed(1)))}만원`;
 }
 
 function classifyRevenueBias(

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -47,9 +47,15 @@ export default function CalendarPage(): React.ReactElement {
     [menuForecastQuery.data],
   );
   const revenueErrorByDate = useMemo(() => {
-    const map = new Map<string, number | null>();
+    const map = new Map<
+      string,
+      { absoluteWonError: number; weightedAbsolutePercentageError: number | null }
+    >();
     for (const day of revenueAccuracyQuery.data?.dailyResults ?? []) {
-      map.set(localIsoDate(day.date), day.weightedAbsolutePercentageError);
+      map.set(localIsoDate(day.date), {
+        absoluteWonError: day.absoluteWonError,
+        weightedAbsolutePercentageError: day.weightedAbsolutePercentageError,
+      });
     }
     return map;
   }, [revenueAccuracyQuery.data]);

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -11,10 +11,15 @@ interface CalendarGridProps {
   month: number;
   cells: readonly EnrichedCalendarCell[];
   menuForecastByDate?: ReadonlyMap<string, CalendarMenuForecastSummary>;
-  revenueErrorByDate?: ReadonlyMap<string, number | null>;
+  revenueErrorByDate?: ReadonlyMap<string, CalendarRevenueAccuracySummary>;
   selectedDate: string | null;
   todayIso: string | null;
   onSelect: (cell: EnrichedCalendarCell) => void;
+}
+
+export interface CalendarRevenueAccuracySummary {
+  absoluteWonError: number;
+  weightedAbsolutePercentageError: number | null;
 }
 
 /**
@@ -85,7 +90,7 @@ function BlankCell(): React.ReactElement {
 interface DayCellProps {
   cell: EnrichedCalendarCell;
   forecast: CalendarMenuForecastSummary | null;
-  revenueError: number | null;
+  revenueError: CalendarRevenueAccuracySummary | null;
   maxRevenue: number;
   isSelected: boolean;
   isToday: boolean;
@@ -152,7 +157,7 @@ interface CellStatusTag {
 function getCellTags(
   cell: EnrichedCalendarCell,
   forecast: CalendarMenuForecastSummary | null,
-  revenueError: number | null,
+  revenueError: CalendarRevenueAccuracySummary | null,
 ): CellStatusTag[] {
   if (cell.isMissing) return [{ label: "누락", tone: "red" }];
   if (cell.isFuture && forecast && forecast.totalRevenue > 0) {
@@ -167,8 +172,8 @@ function getCellTags(
     return [
       { label: `매출 ${formatNumber(Math.round(cell.revenue / 10000))}만`, tone: "ink" },
       {
-        label: `오차 ${Math.round(revenueError * 100)}%`,
-        tone: revenueError >= 0.35 ? "red" : "blue",
+        label: `오차 ${formatNumber(Math.round(revenueError.absoluteWonError / 10000))}만`,
+        tone: (revenueError.weightedAbsolutePercentageError ?? 0) >= 0.35 ? "red" : "blue",
       },
     ];
   }

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -121,7 +121,7 @@ function IngredientRow({
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
             <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
             {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
-            {accuracy && <AccuracyBadge accuracy={accuracy} />}
+            {accuracy && <AccuracyBadge item={item} accuracy={accuracy} />}
           </div>
           <button
             type="button"
@@ -204,11 +204,13 @@ function OrderFactor({ label, value }: { label: string; value: string }): React.
 }
 
 function AccuracyBadge({
+  item,
   accuracy,
 }: {
+  item: IngredientForecastView;
   accuracy: IngredientForecastAccuracyView;
 }): React.ReactElement {
-  const label = formatAccuracyLabel(accuracy);
+  const label = formatAccuracyLabel(item, accuracy);
 
   return (
     <Link
@@ -229,10 +231,16 @@ function AccuracyBadge({
   );
 }
 
-function formatAccuracyLabel(accuracy: IngredientForecastAccuracyView): string {
+function formatAccuracyLabel(
+  item: IngredientForecastView,
+  accuracy: IngredientForecastAccuracyView,
+): string {
   const dayError = accuracy.meanAbsoluteDayEquivalentError;
   if (dayError === null || accuracy.evaluatedDayCount < 3) return "정확도 수집 중";
-  return `평균 ±${Number(dayError.toFixed(1))}일`;
+  const days = daysUntilDate(item.expectedDepletionDate);
+  if (days === null) return `보통 ±${Number(dayError.toFixed(1))}일`;
+  const earliestDays = Math.max(0, days - Math.ceil(dayError));
+  return `보통 ±${Number(dayError.toFixed(1))}일 · 빠르면 ${earliestDays}일`;
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {

--- a/src/features/inventory/components/MenuDemandForecastList.tsx
+++ b/src/features/inventory/components/MenuDemandForecastList.tsx
@@ -116,8 +116,10 @@ function MenuDemandForecastCard({
 }
 
 function AccuracyBadge({ accuracy }: { accuracy: MenuForecastAccuracyView }): React.ReactElement {
-  const wape = accuracy.weightedAbsolutePercentageError;
-  const label = wape === null ? "정확도 수집 중" : `총량오차 ${formatPercent(wape)}`;
+  const label =
+    accuracy.meanAbsoluteQuantityError === null || accuracy.evaluatedDayCount < 3
+      ? "정확도 수집 중"
+      : `평균 ${formatQuantity(accuracy.meanAbsoluteQuantityError)} 오차`;
 
   return (
     <Link
@@ -236,10 +238,6 @@ function formatQuantity(value: number): string {
 }
 
 function formatRate(value: number): string {
-  return `${Math.round(value * 100)}%`;
-}
-
-function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
 }
 


### PR DESCRIPTION
## Summary
- show menu forecast accuracy as average quantity error on menu forecast cards
- show ingredient forecast accuracy as normal day range and earliest depletion hint
- show calendar revenue backtest error in won amount and date detail average won error

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test