### PR TITLE
Improve mobile calendar readability

### DIFF
--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -41,8 +41,8 @@ function ForecastAccuracyContent(): React.ReactElement {
       <PageHeader
         title="예측 정확도"
         action={
-          <Link href="/menu/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
-            메뉴 예측
+          <Link href={`/inventory/forecast?tab=${activeTab}`} className={SECONDARY_BUTTON_CLASSES}>
+            예측 보기
           </Link>
         }
       />

--- a/src/app/(main)/inventory/forecast/page.tsx
+++ b/src/app/(main)/inventory/forecast/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { Suspense, useMemo } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { ForecastPeriodSelector } from "@/features/inventory/components/ForecastPeriodSelector";
+import { IngredientStatusList } from "@/features/inventory/components/IngredientStatusList";
+import { MenuDemandForecastList } from "@/features/inventory/components/MenuDemandForecastList";
+import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
+import { useIngredientForecastAccuracy } from "@/features/inventory/hooks/useIngredientForecastAccuracy";
+import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
+import { useMenuForecastAccuracy } from "@/features/inventory/hooks/useMenuForecastAccuracy";
+import { PageHeader } from "@/components/ui/page-header";
+import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
+import { cn } from "@/lib/utils";
+import { formatNumber, formatWon, WEEKDAY_KO } from "@/lib/utils/format";
+
+const FORECAST_TABS = ["revenue", "menu", "ingredient"] as const;
+const HORIZON_OPTIONS = [7, 14, 30] as const;
+
+type ForecastTab = (typeof FORECAST_TABS)[number];
+
+export default function ForecastPage(): React.ReactElement {
+  return (
+    <Suspense fallback={<LoadingText />}>
+      <ForecastContent />
+    </Suspense>
+  );
+}
+
+function ForecastContent(): React.ReactElement {
+  const searchParams = useSearchParams();
+  const activeTab = parseTab(searchParams.get("tab"));
+  const horizonDays = parseOption(searchParams.get("horizon"), HORIZON_OPTIONS, 7);
+  const menuQuery = useMenuDemandForecast(horizonDays);
+  const menuAccuracyQuery = useMenuForecastAccuracy(14);
+  const ingredientQuery = useDepletionForecast();
+  const ingredientAccuracyQuery = useIngredientForecastAccuracy(14);
+  const revenueDays = useMemo(
+    () => buildRevenueForecastDays(menuQuery.data ?? []),
+    [menuQuery.data],
+  );
+
+  return (
+    <section className="flex flex-col gap-section">
+      <PageHeader
+        title="예측"
+        action={
+          <Link
+            href={`/inventory/forecast-accuracy?tab=${activeTab}`}
+            className="whitespace-nowrap rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
+          >
+            정확도
+          </Link>
+        }
+      />
+
+      <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
+        <p className="text-body text-ink-1">{getIntro(activeTab, horizonDays)}</p>
+        <p className="mt-1 text-caption text-ink-3">
+          메뉴 수요 예측을 기준으로 매출과 재료 소진을 함께 계산합니다.
+        </p>
+      </section>
+
+      <ForecastTabNav activeTab={activeTab} horizonDays={horizonDays} />
+
+      <ForecastPeriodSelector
+        label="예측 기간"
+        queryKey="horizon"
+        selectedValue={horizonDays}
+        options={HORIZON_OPTIONS}
+        suffix="일"
+        pathname="/inventory/forecast"
+        extraParams={{ tab: activeTab }}
+      />
+
+      {activeTab === "revenue" ? (
+        <ForecastSection
+          title="매출 예측"
+          description="메뉴별 예상 판매량과 가격으로 일별 매출을 합산합니다."
+        >
+          {menuQuery.isLoading && <LoadingText />}
+          {menuQuery.error && <ErrorAlert message={menuQuery.error.message} />}
+          {menuQuery.data && <RevenueForecastList days={revenueDays} />}
+        </ForecastSection>
+      ) : activeTab === "menu" ? (
+        <ForecastSection
+          title="메뉴 예측"
+          description="앞으로의 메뉴별 예상 판매량과 옵션 선택률을 봅니다."
+        >
+          {menuQuery.isLoading && <LoadingText />}
+          {menuQuery.error && <ErrorAlert message={menuQuery.error.message} />}
+          {menuQuery.data && (
+            <MenuDemandForecastList
+              items={menuQuery.data}
+              accuracyItems={menuAccuracyQuery.data ?? []}
+            />
+          )}
+        </ForecastSection>
+      ) : (
+        <ForecastSection
+          title="재료 예측"
+          description="메뉴 수요 예측을 재료 사용량과 발주 판단으로 변환합니다."
+        >
+          {ingredientQuery.isLoading && <LoadingText />}
+          {ingredientQuery.error && <ErrorAlert message={ingredientQuery.error.message} />}
+          {ingredientQuery.data && (
+            <IngredientStatusList
+              items={ingredientQuery.data}
+              accuracyItems={ingredientAccuracyQuery.data ?? []}
+            />
+          )}
+        </ForecastSection>
+      )}
+    </section>
+  );
+}
+
+function ForecastTabNav({
+  activeTab,
+  horizonDays,
+}: {
+  activeTab: ForecastTab;
+  horizonDays: number;
+}): React.ReactElement {
+  return (
+    <nav
+      aria-label="예측 종류"
+      className="grid gap-stack-tight rounded-[24px] border border-border bg-card p-2 shadow-soft md:grid-cols-3"
+    >
+      <ForecastTabLink
+        tab="revenue"
+        activeTab={activeTab}
+        horizonDays={horizonDays}
+        title="매출 예측"
+        description="일별 예상 매출"
+      />
+      <ForecastTabLink
+        tab="menu"
+        activeTab={activeTab}
+        horizonDays={horizonDays}
+        title="메뉴 예측"
+        description="판매량·옵션 선택률"
+      />
+      <ForecastTabLink
+        tab="ingredient"
+        activeTab={activeTab}
+        horizonDays={horizonDays}
+        title="재료 예측"
+        description="소진·발주 판단"
+      />
+    </nav>
+  );
+}
+
+function ForecastTabLink({
+  tab,
+  activeTab,
+  horizonDays,
+  title,
+  description,
+}: {
+  tab: ForecastTab;
+  activeTab: ForecastTab;
+  horizonDays: number;
+  title: string;
+  description: string;
+}): React.ReactElement {
+  const selected = tab === activeTab;
+  const params = new URLSearchParams({ tab, horizon: String(horizonDays) });
+
+  return (
+    <Link
+      href={`/inventory/forecast?${params.toString()}`}
+      aria-current={selected ? "page" : undefined}
+      className={cn(
+        "rounded-[20px] px-4 py-3 transition",
+        selected
+          ? "bg-blue text-white shadow-card"
+          : "bg-white text-ink-2 shadow-soft hover:bg-blue-soft hover:text-blue-deep",
+      )}
+    >
+      <span className="block text-body font-semibold">{title}</span>
+      <span className={cn("mt-1 block text-caption", selected ? "text-white/80" : "text-ink-3")}>
+        {description}
+      </span>
+    </Link>
+  );
+}
+
+function ForecastSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <section className="flex flex-col gap-stack-tight">
+      <h2 className="text-title-md text-ink-1">{title}</h2>
+      <p className="text-caption text-ink-3">{description}</p>
+      {children}
+    </section>
+  );
+}
+
+interface RevenueForecastDay {
+  date: Date;
+  predictedRevenue: number;
+  predictedQuantity: number;
+}
+
+function RevenueForecastList({
+  days,
+}: {
+  days: readonly RevenueForecastDay[];
+}): React.ReactElement {
+  if (days.length === 0) {
+    return (
+      <p className="glow-panel rounded-2xl border border-border bg-card px-stack py-stack text-body-regular text-ink-3 shadow-soft">
+        판매 이력이 있는 메뉴가 아직 없어요. 판매를 입력하면 예상 매출이 표시됩니다.
+      </p>
+    );
+  }
+
+  const totalRevenue = days.reduce((sum, day) => sum + day.predictedRevenue, 0);
+  const totalQuantity = days.reduce((sum, day) => sum + day.predictedQuantity, 0);
+
+  return (
+    <div className="flex flex-col gap-stack">
+      <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
+        <p className="text-caption text-ink-3">기간 합계</p>
+        <p className="mt-1 text-title-lg text-ink-1">{formatWon(totalRevenue)}원</p>
+        <p className="mt-1 text-caption text-ink-3">
+          예상 판매 {formatNumber(Number(totalQuantity.toFixed(1)))}개
+        </p>
+      </section>
+      <ol className="flex flex-col gap-stack-tight">
+        {days.map((day) => (
+          <li
+            key={day.date.toISOString()}
+            className="flex items-center justify-between gap-stack rounded-[22px] border border-border bg-card px-4 py-3 shadow-soft"
+          >
+            <div>
+              <p className="text-label text-ink-1">{formatDateLabel(day.date)}</p>
+              <p className="mt-1 text-caption text-ink-3">
+                예상 판매 {formatNumber(Number(day.predictedQuantity.toFixed(1)))}개
+              </p>
+            </div>
+            <p className="shrink-0 text-body font-semibold text-blue-deep">
+              {formatWon(day.predictedRevenue)}원
+            </p>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function buildRevenueForecastDays(
+  menus: readonly {
+    price: number;
+    dailyPredictions: readonly { date: Date; predictedQuantity: number }[];
+  }[],
+): RevenueForecastDay[] {
+  const byDate = new Map<string, RevenueForecastDay>();
+  for (const menu of menus) {
+    for (const day of menu.dailyPredictions) {
+      const key = day.date.toISOString();
+      const current = byDate.get(key) ?? {
+        date: day.date,
+        predictedRevenue: 0,
+        predictedQuantity: 0,
+      };
+      current.predictedQuantity += day.predictedQuantity;
+      current.predictedRevenue += day.predictedQuantity * menu.price;
+      byDate.set(key, current);
+    }
+  }
+  return [...byDate.values()].sort((a, b) => a.date.getTime() - b.date.getTime());
+}
+
+function parseOption<T extends number>(raw: string | null, options: readonly T[], fallback: T): T {
+  const value = Number(raw);
+  return options.includes(value as T) ? (value as T) : fallback;
+}
+
+function parseTab(raw: string | null): ForecastTab {
+  return FORECAST_TABS.includes(raw as ForecastTab) ? (raw as ForecastTab) : "revenue";
+}
+
+function getIntro(tab: ForecastTab, horizonDays: number): string {
+  if (tab === "revenue") return `앞으로 ${horizonDays}일간 예상 매출을 보여줍니다.`;
+  if (tab === "menu") return `앞으로 ${horizonDays}일간 메뉴별 예상 판매량을 보여줍니다.`;
+  return "재료별 소진 위험과 권장 발주량을 보여줍니다.";
+}
+
+function formatDateLabel(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()} ${WEEKDAY_KO[date.getDay()]}`;
+}

--- a/src/app/(main)/inventory/orders/page.tsx
+++ b/src/app/(main)/inventory/orders/page.tsx
@@ -37,7 +37,7 @@ export default function InventoryOrdersPage(): React.ReactElement {
             <Link href="/inventory/orders/report" className={SECONDARY_BUTTON_CLASSES}>
               이력
             </Link>
-            <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
+            <Link href="/inventory/forecast?tab=ingredient" className={SECONDARY_BUTTON_CLASSES}>
               재료 예측
             </Link>
             <Link href="/purchase" className={SECONDARY_BUTTON_CLASSES}>

--- a/src/app/(main)/inventory/orders/report/page.tsx
+++ b/src/app/(main)/inventory/orders/report/page.tsx
@@ -24,7 +24,7 @@ export default function OrderRecommendationReportPage(): React.ReactElement {
             <Link href="/inventory/orders" className={SECONDARY_BUTTON_CLASSES}>
               오늘 주문할 것
             </Link>
-            <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
+            <Link href="/inventory/forecast?tab=ingredient" className={SECONDARY_BUTTON_CLASSES}>
               재료 예측
             </Link>
           </div>

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -9,7 +9,6 @@ import { ColdStartNotice } from "@/features/inventory/components/ColdStartNotice
 import { AddIngredientForm } from "@/features/inventory/components/AddIngredientForm";
 import { PageHeader } from "@/components/ui/page-header";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
-import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
 export default function InventoryPage(): React.ReactElement {
   const { data, isLoading, error } = useDepletionForecast();
@@ -34,30 +33,23 @@ export default function InventoryPage(): React.ReactElement {
         }
       />
 
-      <nav aria-label="재료 빠른 작업" className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
-        <div className="flex min-w-max gap-stack-tight sm:min-w-0 sm:flex-wrap">
-          <Link href="/purchase" className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}>
-            + 매입
-          </Link>
-          <Link
-            href="/inventory/orders"
-            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
-          >
-            발주 추천
-          </Link>
-          <Link
-            href="/inventory/stock-count"
-            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
-          >
-            실사
-          </Link>
-          <Link
-            href="/inventory/forecast-accuracy"
-            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
-          >
-            정확도
-          </Link>
-        </div>
+      <nav aria-label="재료 빠른 작업" className="grid gap-stack sm:grid-cols-2">
+        <ActionGroup
+          title="재고 관리"
+          description="실제 재고를 입력하고 맞춥니다."
+          actions={[
+            { href: "/purchase", label: "+ 매입" },
+            { href: "/inventory/stock-count", label: "실사" },
+          ]}
+        />
+        <ActionGroup
+          title="예측 관리"
+          description="발주 판단과 예측 신뢰도를 확인합니다."
+          actions={[
+            { href: "/inventory/orders", label: "발주 추천" },
+            { href: "/inventory/forecast-accuracy", label: "정확도" },
+          ]}
+        />
       </nav>
 
       {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
@@ -68,6 +60,41 @@ export default function InventoryPage(): React.ReactElement {
       {isAllColdStart && <ColdStartNotice />}
 
       {data && <IngredientStatusList items={data} accuracyItems={accuracyQuery.data ?? []} />}
+    </section>
+  );
+}
+
+interface InventoryAction {
+  href: string;
+  label: string;
+}
+
+function ActionGroup({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description: string;
+  actions: readonly InventoryAction[];
+}): React.ReactElement {
+  return (
+    <section className="rounded-[22px] border border-border bg-card px-4 py-4 shadow-soft">
+      <div>
+        <h2 className="text-label text-ink-1">{title}</h2>
+        <p className="mt-1 text-caption text-ink-3">{description}</p>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        {actions.map((action) => (
+          <Link
+            key={action.href}
+            href={action.href}
+            className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-border-strong bg-white px-3 py-2 text-caption font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
+          >
+            {action.label}
+          </Link>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -51,6 +51,12 @@ export default function InventoryPage(): React.ReactElement {
           >
             실사
           </Link>
+          <Link
+            href="/inventory/forecast-accuracy"
+            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
+          >
+            정확도
+          </Link>
         </div>
       </nav>
 

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -35,22 +35,24 @@ export default function InventoryPage(): React.ReactElement {
 
       <nav
         aria-label="재료 빠른 작업"
-        className="rounded-[22px] border border-border bg-card px-4 py-4 shadow-soft"
+        className="rounded-[22px] border border-border bg-card px-4 py-3 shadow-soft"
       >
         <div>
           <h2 className="text-label text-ink-1">빠른 작업</h2>
         </div>
-        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div className="mt-2 grid grid-cols-2 gap-2 lg:grid-cols-4">
           {INVENTORY_ACTIONS.map((action) => (
             <Link
               key={action.href}
               href={action.href}
-              className="group flex min-h-[4.25rem] flex-col justify-center rounded-2xl border border-border-strong bg-white px-4 py-3 text-left shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
+              className="group flex min-h-[3.25rem] flex-col justify-center rounded-2xl border border-border-strong bg-white px-3 py-2 text-left shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
             >
-              <span className="text-label font-semibold text-ink-1 group-hover:text-blue-deep">
+              <span className="text-caption font-semibold text-ink-1 group-hover:text-blue-deep">
                 {action.label}
               </span>
-              <span className="mt-1 text-caption text-ink-3">{action.description}</span>
+              <span className="mt-0.5 truncate text-[11px] leading-snug text-ink-3">
+                {action.description}
+              </span>
             </Link>
           ))}
         </div>
@@ -69,20 +71,20 @@ export default function InventoryPage(): React.ReactElement {
 }
 
 const INVENTORY_ACTIONS = [
-  { href: "/purchase", label: "매입 등록", description: "재료를 사온 내역을 입력합니다." },
+  { href: "/purchase", label: "매입 등록", description: "사온 재료 입력" },
   {
     href: "/inventory/stock-count",
     label: "재고 실사",
-    description: "실제 남은 수량으로 맞춥니다.",
+    description: "실제 수량 맞춤",
   },
   {
     href: "/inventory/orders",
     label: "발주 추천",
-    description: "부족해질 재료와 주문량을 봅니다.",
+    description: "부족 재료 확인",
   },
   {
     href: "/inventory/forecast-accuracy",
     label: "예측 정확도",
-    description: "매출·메뉴·재료 예측이 맞았는지 봅니다.",
+    description: "예측 결과 확인",
   },
 ] as const;

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -39,9 +39,7 @@ export default function InventoryPage(): React.ReactElement {
       >
         <div>
           <h2 className="text-label text-ink-1">빠른 작업</h2>
-          <p className="mt-1 text-caption text-ink-3">
-            재고 입력, 실사, 발주 판단을 바로 처리합니다.
-          </p>
+          <p className="mt-1 text-caption text-ink-3">자주 쓰는 재료 작업을 모아뒀어요.</p>
         </div>
         <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
           {INVENTORY_ACTIONS.map((action) => (

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { ChevronDown } from "lucide-react";
 import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionForecast";
 import { useIngredientForecastAccuracy } from "@/features/inventory/hooks/useIngredientForecastAccuracy";
 import { IngredientStatusList } from "@/features/inventory/components/IngredientStatusList";
@@ -32,8 +33,14 @@ export default function InventoryPage(): React.ReactElement {
               + 재료
             </button>
             <details className="group relative">
-              <summary className="flex cursor-pointer list-none items-center justify-center rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft [&::-webkit-details-marker]:hidden">
-                작업
+              <summary className="flex cursor-pointer list-none items-center justify-center gap-1 rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft [&::-webkit-details-marker]:hidden">
+                <span>작업</span>
+                <ChevronDown
+                  size={16}
+                  strokeWidth={2.2}
+                  aria-hidden="true"
+                  className="transition-transform group-open:rotate-180"
+                />
               </summary>
               <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-44 overflow-hidden rounded-2xl border border-border bg-card p-1 shadow-card">
                 {INVENTORY_ACTIONS.map((action) => (

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -33,15 +33,6 @@ export default function InventoryPage(): React.ReactElement {
         }
       />
 
-      {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
-
-      {isLoading && <LoadingText />}
-      {error && <ErrorAlert message={error.message} />}
-
-      {isAllColdStart && <ColdStartNotice />}
-
-      {data && <IngredientStatusList items={data} accuracyItems={accuracyQuery.data ?? []} />}
-
       <nav
         aria-label="재료 빠른 작업"
         className="rounded-[22px] border border-border bg-card px-4 py-3 shadow-soft"
@@ -66,6 +57,15 @@ export default function InventoryPage(): React.ReactElement {
           ))}
         </div>
       </nav>
+
+      {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
+
+      {isLoading && <LoadingText />}
+      {error && <ErrorAlert message={error.message} />}
+
+      {isAllColdStart && <ColdStartNotice />}
+
+      {data && <IngredientStatusList items={data} accuracyItems={accuracyQuery.data ?? []} />}
     </section>
   );
 }

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -22,41 +22,34 @@ export default function InventoryPage(): React.ReactElement {
       <PageHeader
         title="재료"
         action={
-          <button
-            type="button"
-            onClick={() => setIsAddOpen((v) => !v)}
-            aria-expanded={isAddOpen}
-            className="whitespace-nowrap rounded-2xl bg-blue px-4 py-3 text-body-regular font-semibold text-white shadow-card ring-1 ring-blue-deep/10 transition hover:-translate-y-0.5 hover:bg-blue-deep"
-          >
-            + 재료
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsAddOpen((v) => !v)}
+              aria-expanded={isAddOpen}
+              className="whitespace-nowrap rounded-2xl bg-blue px-4 py-3 text-body-regular font-semibold text-white shadow-card ring-1 ring-blue-deep/10 transition hover:-translate-y-0.5 hover:bg-blue-deep"
+            >
+              + 재료
+            </button>
+            <details className="group relative">
+              <summary className="flex cursor-pointer list-none items-center justify-center rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft [&::-webkit-details-marker]:hidden">
+                작업
+              </summary>
+              <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-44 overflow-hidden rounded-2xl border border-border bg-card p-1 shadow-card">
+                {INVENTORY_ACTIONS.map((action) => (
+                  <Link
+                    key={action.href}
+                    href={action.href}
+                    className="block rounded-xl px-3 py-2.5 text-caption font-semibold text-ink-1 transition hover:bg-blue-soft hover:text-blue-deep"
+                  >
+                    {action.label}
+                  </Link>
+                ))}
+              </div>
+            </details>
+          </div>
         }
       />
-
-      <nav
-        aria-label="재료 빠른 작업"
-        className="rounded-[22px] border border-border bg-card px-4 py-3 shadow-soft"
-      >
-        <div>
-          <h2 className="text-label text-ink-1">빠른 작업</h2>
-        </div>
-        <div className="mt-2 grid grid-cols-2 gap-2 lg:grid-cols-4">
-          {INVENTORY_ACTIONS.map((action) => (
-            <Link
-              key={action.href}
-              href={action.href}
-              className="group flex min-h-[3.25rem] flex-col justify-center rounded-2xl border border-border-strong bg-white px-3 py-2 text-left shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
-            >
-              <span className="text-caption font-semibold text-ink-1 group-hover:text-blue-deep">
-                {action.label}
-              </span>
-              <span className="mt-0.5 truncate text-[11px] leading-snug text-ink-3">
-                {action.description}
-              </span>
-            </Link>
-          ))}
-        </div>
-      </nav>
 
       {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
 
@@ -71,20 +64,8 @@ export default function InventoryPage(): React.ReactElement {
 }
 
 const INVENTORY_ACTIONS = [
-  { href: "/purchase", label: "매입 등록", description: "사온 재료 입력" },
-  {
-    href: "/inventory/stock-count",
-    label: "재고 실사",
-    description: "실제 수량 맞춤",
-  },
-  {
-    href: "/inventory/orders",
-    label: "발주 추천",
-    description: "부족 재료 확인",
-  },
-  {
-    href: "/inventory/forecast-accuracy",
-    label: "예측 정확도",
-    description: "예측 결과 확인",
-  },
+  { href: "/purchase", label: "매입 등록" },
+  { href: "/inventory/stock-count", label: "재고 실사" },
+  { href: "/inventory/orders", label: "발주 추천" },
+  { href: "/inventory/forecast-accuracy", label: "예측 정확도" },
 ] as const;

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -39,16 +39,18 @@ export default function InventoryPage(): React.ReactElement {
       >
         <div>
           <h2 className="text-label text-ink-1">빠른 작업</h2>
-          <p className="mt-1 text-caption text-ink-3">자주 쓰는 재료 작업을 모아뒀어요.</p>
         </div>
-        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
           {INVENTORY_ACTIONS.map((action) => (
             <Link
               key={action.href}
               href={action.href}
-              className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-border-strong bg-white px-3 py-2 text-caption font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
+              className="group flex min-h-[4.25rem] flex-col justify-center rounded-2xl border border-border-strong bg-white px-4 py-3 text-left shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
             >
-              {action.label}
+              <span className="text-label font-semibold text-ink-1 group-hover:text-blue-deep">
+                {action.label}
+              </span>
+              <span className="mt-1 text-caption text-ink-3">{action.description}</span>
             </Link>
           ))}
         </div>
@@ -67,8 +69,20 @@ export default function InventoryPage(): React.ReactElement {
 }
 
 const INVENTORY_ACTIONS = [
-  { href: "/purchase", label: "+ 매입" },
-  { href: "/inventory/stock-count", label: "실사" },
-  { href: "/inventory/orders", label: "발주 추천" },
-  { href: "/inventory/forecast-accuracy", label: "정확도" },
+  { href: "/purchase", label: "매입 등록", description: "재료를 사온 내역을 입력합니다." },
+  {
+    href: "/inventory/stock-count",
+    label: "재고 실사",
+    description: "실제 남은 수량으로 맞춥니다.",
+  },
+  {
+    href: "/inventory/orders",
+    label: "발주 추천",
+    description: "부족해질 재료와 주문량을 봅니다.",
+  },
+  {
+    href: "/inventory/forecast-accuracy",
+    label: "예측 정확도",
+    description: "매출·메뉴·재료 예측이 맞았는지 봅니다.",
+  },
 ] as const;

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -23,30 +23,42 @@ export default function InventoryPage(): React.ReactElement {
       <PageHeader
         title="재료"
         action={
-          <div className="flex gap-stack-tight">
-            <Link href="/inventory/orders" className={SECONDARY_BUTTON_CLASSES}>
-              발주 추천
-            </Link>
-            <Link href="/inventory/forecast-accuracy" className={SECONDARY_BUTTON_CLASSES}>
-              정확도
-            </Link>
-            <Link href="/inventory/stock-count" className={SECONDARY_BUTTON_CLASSES}>
-              실사
-            </Link>
-            <Link href="/purchase" className={SECONDARY_BUTTON_CLASSES}>
-              + 매입
-            </Link>
-            <button
-              type="button"
-              onClick={() => setIsAddOpen((v) => !v)}
-              aria-expanded={isAddOpen}
-              className="rounded-2xl bg-blue px-4 py-3 text-body-regular font-semibold text-white shadow-card ring-1 ring-blue-deep/10 transition hover:-translate-y-0.5 hover:bg-blue-deep"
-            >
-              + 재료
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={() => setIsAddOpen((v) => !v)}
+            aria-expanded={isAddOpen}
+            className="whitespace-nowrap rounded-2xl bg-blue px-4 py-3 text-body-regular font-semibold text-white shadow-card ring-1 ring-blue-deep/10 transition hover:-translate-y-0.5 hover:bg-blue-deep"
+          >
+            + 재료
+          </button>
         }
       />
+
+      <nav aria-label="재료 빠른 작업" className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
+        <div className="flex min-w-max gap-stack-tight sm:min-w-0 sm:flex-wrap">
+          <Link href="/purchase" className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}>
+            + 매입
+          </Link>
+          <Link
+            href="/inventory/orders"
+            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
+          >
+            발주 추천
+          </Link>
+          <Link
+            href="/inventory/stock-count"
+            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
+          >
+            실사
+          </Link>
+          <Link
+            href="/inventory/forecast-accuracy"
+            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
+          >
+            정확도
+          </Link>
+        </div>
+      </nav>
 
       {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
 

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -51,12 +51,6 @@ export default function InventoryPage(): React.ReactElement {
           >
             실사
           </Link>
-          <Link
-            href="/inventory/forecast-accuracy"
-            className={`${SECONDARY_BUTTON_CLASSES} whitespace-nowrap`}
-          >
-            정확도
-          </Link>
         </div>
       </nav>
 

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -33,23 +33,27 @@ export default function InventoryPage(): React.ReactElement {
         }
       />
 
-      <nav aria-label="재료 빠른 작업" className="grid gap-stack sm:grid-cols-2">
-        <ActionGroup
-          title="재고 관리"
-          description="실제 재고를 입력하고 맞춥니다."
-          actions={[
-            { href: "/purchase", label: "+ 매입" },
-            { href: "/inventory/stock-count", label: "실사" },
-          ]}
-        />
-        <ActionGroup
-          title="예측 관리"
-          description="발주 판단과 예측 신뢰도를 확인합니다."
-          actions={[
-            { href: "/inventory/orders", label: "발주 추천" },
-            { href: "/inventory/forecast-accuracy", label: "정확도" },
-          ]}
-        />
+      <nav
+        aria-label="재료 빠른 작업"
+        className="rounded-[22px] border border-border bg-card px-4 py-4 shadow-soft"
+      >
+        <div>
+          <h2 className="text-label text-ink-1">빠른 작업</h2>
+          <p className="mt-1 text-caption text-ink-3">
+            재고 입력, 실사, 발주 판단을 바로 처리합니다.
+          </p>
+        </div>
+        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {INVENTORY_ACTIONS.map((action) => (
+            <Link
+              key={action.href}
+              href={action.href}
+              className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-border-strong bg-white px-3 py-2 text-caption font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
+            >
+              {action.label}
+            </Link>
+          ))}
+        </div>
       </nav>
 
       {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
@@ -64,37 +68,9 @@ export default function InventoryPage(): React.ReactElement {
   );
 }
 
-interface InventoryAction {
-  href: string;
-  label: string;
-}
-
-function ActionGroup({
-  title,
-  description,
-  actions,
-}: {
-  title: string;
-  description: string;
-  actions: readonly InventoryAction[];
-}): React.ReactElement {
-  return (
-    <section className="rounded-[22px] border border-border bg-card px-4 py-4 shadow-soft">
-      <div>
-        <h2 className="text-label text-ink-1">{title}</h2>
-        <p className="mt-1 text-caption text-ink-3">{description}</p>
-      </div>
-      <div className="mt-3 grid grid-cols-2 gap-2">
-        {actions.map((action) => (
-          <Link
-            key={action.href}
-            href={action.href}
-            className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-border-strong bg-white px-3 py-2 text-caption font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft"
-          >
-            {action.label}
-          </Link>
-        ))}
-      </div>
-    </section>
-  );
-}
+const INVENTORY_ACTIONS = [
+  { href: "/purchase", label: "+ 매입" },
+  { href: "/inventory/stock-count", label: "실사" },
+  { href: "/inventory/orders", label: "발주 추천" },
+  { href: "/inventory/forecast-accuracy", label: "정확도" },
+] as const;

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -33,6 +33,15 @@ export default function InventoryPage(): React.ReactElement {
         }
       />
 
+      {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
+
+      {isLoading && <LoadingText />}
+      {error && <ErrorAlert message={error.message} />}
+
+      {isAllColdStart && <ColdStartNotice />}
+
+      {data && <IngredientStatusList items={data} accuracyItems={accuracyQuery.data ?? []} />}
+
       <nav
         aria-label="재료 빠른 작업"
         className="rounded-[22px] border border-border bg-card px-4 py-3 shadow-soft"
@@ -57,15 +66,6 @@ export default function InventoryPage(): React.ReactElement {
           ))}
         </div>
       </nav>
-
-      {isAddOpen && <AddIngredientForm onClose={() => setIsAddOpen(false)} />}
-
-      {isLoading && <LoadingText />}
-      {error && <ErrorAlert message={error.message} />}
-
-      {isAllColdStart && <ColdStartNotice />}
-
-      {data && <IngredientStatusList items={data} accuracyItems={accuracyQuery.data ?? []} />}
     </section>
   );
 }

--- a/src/app/(main)/inventory/page.tsx
+++ b/src/app/(main)/inventory/page.tsx
@@ -74,5 +74,6 @@ const INVENTORY_ACTIONS = [
   { href: "/purchase", label: "매입 등록" },
   { href: "/inventory/stock-count", label: "재고 실사" },
   { href: "/inventory/orders", label: "발주 추천" },
-  { href: "/inventory/forecast-accuracy", label: "예측 정확도" },
+  { href: "/inventory/forecast?tab=ingredient", label: "재료 예측" },
+  { href: "/inventory/forecast-accuracy?tab=ingredient", label: "예측 정확도" },
 ] as const;

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -6,7 +6,7 @@ interface MainLayoutProps {
 
 export default function MainLayout({ children }: MainLayoutProps): React.ReactElement {
   return (
-    <div className="page-shell min-h-screen bg-bg pb-24">
+    <div className="page-shell min-h-screen bg-bg pb-28">
       <main className="mx-auto max-w-screen-md px-screen pb-screen pt-4">{children}</main>
       <BottomTabNav />
     </div>

--- a/src/app/(main)/menu/menu-forecast/page.tsx
+++ b/src/app/(main)/menu/menu-forecast/page.tsx
@@ -36,7 +36,7 @@ function MenuForecastContent(): React.ReactElement {
             <Link href="/inventory/forecast-accuracy?tab=menu" className={SECONDARY_BUTTON_CLASSES}>
               정확도
             </Link>
-            <Link href="/inventory" className={SECONDARY_BUTTON_CLASSES}>
+            <Link href="/inventory/forecast?tab=ingredient" className={SECONDARY_BUTTON_CLASSES}>
               재료 예측
             </Link>
           </div>
@@ -64,7 +64,8 @@ function MenuForecastContent(): React.ReactElement {
         selectedValue={horizonDays}
         options={HORIZON_OPTIONS}
         suffix="일"
-        pathname="/menu/menu-forecast"
+        pathname="/inventory/forecast"
+        extraParams={{ tab: "menu" }}
       />
 
       {query.isLoading && <LoadingText />}

--- a/src/app/(main)/menu/page.tsx
+++ b/src/app/(main)/menu/page.tsx
@@ -60,6 +60,6 @@ export default function MenuPage(): React.ReactElement {
 }
 
 const MENU_ACTIONS = [
-  { href: "/menu/menu-forecast", label: "메뉴 예측" },
+  { href: "/inventory/forecast?tab=menu", label: "메뉴 예측" },
   { href: "/inventory/forecast-accuracy?tab=menu", label: "예측 정확도" },
 ] as const;

--- a/src/app/(main)/menu/page.tsx
+++ b/src/app/(main)/menu/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import { ChevronDown } from "lucide-react";
 import { useMenus } from "@/features/menu/hooks/useMenus";
 import { MenuList } from "@/features/menu/components/MenuList";
 import { TemplateLoadDialog } from "@/features/menu/components/TemplateLoadDialog";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 import { PageHeader } from "@/components/ui/page-header";
-import { SECONDARY_BUTTON_CLASSES } from "@/components/ui/button-classes";
 
 export default function MenuPage(): React.ReactElement {
   const { data, isLoading, error } = useMenus();
@@ -16,13 +16,35 @@ export default function MenuPage(): React.ReactElement {
       <PageHeader
         title="메뉴"
         action={
-          <div className="flex gap-stack-tight">
-            <Link href="/menu/menu-forecast" className={SECONDARY_BUTTON_CLASSES}>
-              메뉴 예측
+          <div className="flex items-center gap-2">
+            <Link
+              href="/menu/new"
+              className="whitespace-nowrap rounded-2xl bg-blue px-4 py-3 text-body-regular font-semibold text-white shadow-card ring-1 ring-blue-deep/10 transition hover:-translate-y-0.5 hover:bg-blue-deep"
+            >
+              + 메뉴
             </Link>
-            <Link href="/menu/new" className={SECONDARY_BUTTON_CLASSES}>
-              + 추가
-            </Link>
+            <details className="group relative">
+              <summary className="flex cursor-pointer list-none items-center justify-center gap-1 rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft [&::-webkit-details-marker]:hidden">
+                <span>작업</span>
+                <ChevronDown
+                  size={16}
+                  strokeWidth={2.2}
+                  aria-hidden="true"
+                  className="transition-transform group-open:rotate-180"
+                />
+              </summary>
+              <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-44 overflow-hidden rounded-2xl border border-border bg-card p-1 shadow-card">
+                {MENU_ACTIONS.map((action) => (
+                  <Link
+                    key={action.href}
+                    href={action.href}
+                    className="block rounded-xl px-3 py-2.5 text-caption font-semibold text-ink-1 transition hover:bg-blue-soft hover:text-blue-deep"
+                  >
+                    {action.label}
+                  </Link>
+                ))}
+              </div>
+            </details>
           </div>
         }
       />
@@ -36,3 +58,8 @@ export default function MenuPage(): React.ReactElement {
     </section>
   );
 }
+
+const MENU_ACTIONS = [
+  { href: "/menu/menu-forecast", label: "메뉴 예측" },
+  { href: "/inventory/forecast-accuracy?tab=menu", label: "예측 정확도" },
+] as const;

--- a/src/app/(main)/today/page.tsx
+++ b/src/app/(main)/today/page.tsx
@@ -100,6 +100,8 @@ export default function TodayPage(): React.ReactElement {
 
       <OrderSummaryCard items={orderItems} isLoading={forecast.isLoading} />
 
+      <ForecastAnalysisCard />
+
       <AlertsCard
         depletionItems={forecast.data ?? []}
         expiryAlerts={data.expiryAlerts}
@@ -113,6 +115,28 @@ export default function TodayPage(): React.ReactElement {
       </nav>
 
       <MarginTop3Card top3={data.top3Menus} lowMargin={data.lowMarginMenu} />
+    </section>
+  );
+}
+
+function ForecastAnalysisCard(): React.ReactElement {
+  return (
+    <section className="rounded-[24px] border border-blue/10 bg-card px-5 py-5 shadow-soft">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-micro uppercase tracking-[0.14em] text-blue-deep">Forecast</p>
+          <h2 className="mt-1 text-title-md text-ink-1">예측 분석</h2>
+          <p className="mt-1 text-caption text-ink-3">
+            매출·메뉴·재료 예측이 실제와 얼마나 맞았는지 한 번에 확인합니다.
+          </p>
+        </div>
+        <Link
+          href="/inventory/forecast-accuracy"
+          className="self-start rounded-2xl border border-border-strong bg-white px-4 py-3 text-label font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft sm:self-auto"
+        >
+          정확도 보기
+        </Link>
+      </div>
     </section>
   );
 }

--- a/src/app/(main)/today/page.tsx
+++ b/src/app/(main)/today/page.tsx
@@ -94,10 +94,10 @@ export default function TodayPage(): React.ReactElement {
               : "오늘 필요한 발주와 마진 변화를 먼저 확인하세요."}
           </p>
           <Link
-            href="/inventory/forecast-accuracy"
+            href="/inventory/forecast?tab=revenue"
             className="mt-3 inline-flex w-fit items-center rounded-full bg-white px-3 py-2 text-caption font-semibold text-blue-deep shadow-soft transition hover:-translate-y-0.5 hover:bg-blue-soft"
           >
-            예측 정확도 보기
+            매출 예측 보기
           </Link>
         </div>
       </header>

--- a/src/app/(main)/today/page.tsx
+++ b/src/app/(main)/today/page.tsx
@@ -93,14 +93,18 @@ export default function TodayPage(): React.ReactElement {
               ? "어제 판매 입력을 먼저 끝내고, 발주가 필요한 재료를 확인하세요."
               : "오늘 필요한 발주와 마진 변화를 먼저 확인하세요."}
           </p>
+          <Link
+            href="/inventory/forecast-accuracy"
+            className="mt-3 inline-flex w-fit items-center rounded-full bg-white px-3 py-2 text-caption font-semibold text-blue-deep shadow-soft transition hover:-translate-y-0.5 hover:bg-blue-soft"
+          >
+            예측 정확도 보기
+          </Link>
         </div>
       </header>
 
       <YesterdayKpiCard yesterday={data.yesterday} weeklyChart={data.weeklyChart} />
 
       <OrderSummaryCard items={orderItems} isLoading={forecast.isLoading} />
-
-      <ForecastAnalysisCard />
 
       <AlertsCard
         depletionItems={forecast.data ?? []}
@@ -115,28 +119,6 @@ export default function TodayPage(): React.ReactElement {
       </nav>
 
       <MarginTop3Card top3={data.top3Menus} lowMargin={data.lowMarginMenu} />
-    </section>
-  );
-}
-
-function ForecastAnalysisCard(): React.ReactElement {
-  return (
-    <section className="rounded-[24px] border border-blue/10 bg-card px-5 py-5 shadow-soft">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <p className="text-micro uppercase tracking-[0.14em] text-blue-deep">Forecast</p>
-          <h2 className="mt-1 text-title-md text-ink-1">예측 분석</h2>
-          <p className="mt-1 text-caption text-ink-3">
-            매출·메뉴·재료 예측이 실제와 얼마나 맞았는지 한 번에 확인합니다.
-          </p>
-        </div>
-        <Link
-          href="/inventory/forecast-accuracy"
-          className="self-start rounded-2xl border border-border-strong bg-white px-4 py-3 text-label font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft sm:self-auto"
-        >
-          정확도 보기
-        </Link>
-      </div>
     </section>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,7 @@ html,
 body {
   margin: 0;
   padding: 0;
+  overflow-x: hidden;
   background: radial-gradient(circle at top, rgba(49, 130, 246, 0.04), transparent 22%), var(--bg);
   color: var(--ink-1);
   font-family: var(--font-pretendard), "Pretendard", ui-sans-serif, system-ui, sans-serif;

--- a/src/components/ui/bottom-tab-nav.tsx
+++ b/src/components/ui/bottom-tab-nav.tsx
@@ -2,8 +2,6 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { createPortal } from "react-dom";
-import { useEffect, useState } from "react";
 import { Calendar, House, Package, ScrollText, ShoppingBasket } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -49,53 +47,13 @@ const TABS: Tab[] = [
 
 export function BottomTabNav(): React.ReactElement {
   const pathname = usePathname();
-  const [mounted, setMounted] = useState(false);
-  const [bottomOffset, setBottomOffset] = useState(12);
-  const [frame, setFrame] = useState({ left: 12, width: 351 });
 
-  useEffect(() => {
-    setMounted(true);
-
-    function syncFrame(): void {
-      const visualViewport = window.visualViewport;
-      const documentWidth = document.documentElement.clientWidth;
-      const maxWidth = 768;
-      const horizontalGap = documentWidth < 640 ? 12 : 0;
-      const navWidth = Math.min(maxWidth, Math.max(0, documentWidth - horizontalGap * 2));
-      const left = Math.max(horizontalGap, Math.round((documentWidth - navWidth) / 2));
-      const hiddenViewportBottom = visualViewport
-        ? Math.max(0, window.innerHeight - visualViewport.height - visualViewport.offsetTop)
-        : 0;
-
-      setFrame({ left, width: navWidth });
-      setBottomOffset(Math.round(hiddenViewportBottom + 12));
-    }
-
-    syncFrame();
-    window.visualViewport?.addEventListener("resize", syncFrame);
-    window.visualViewport?.addEventListener("scroll", syncFrame);
-    window.addEventListener("resize", syncFrame);
-    window.addEventListener("scroll", syncFrame, { passive: true });
-
-    return () => {
-      window.visualViewport?.removeEventListener("resize", syncFrame);
-      window.visualViewport?.removeEventListener("scroll", syncFrame);
-      window.removeEventListener("resize", syncFrame);
-      window.removeEventListener("scroll", syncFrame);
-    };
-  }, []);
-
-  const nav = (
+  return (
     <nav
       aria-label="주요 기능"
-      className="fixed z-[60]"
-      style={{
-        bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))`,
-        left: frame.left,
-        width: frame.width,
-      }}
+      className="fixed inset-x-0 bottom-0 z-[60] px-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
     >
-      <ul className="flex w-full items-stretch overflow-hidden rounded-[22px] border border-border bg-card/95 shadow-card backdrop-blur sm:rounded-[24px]">
+      <ul className="mx-auto flex w-full max-w-screen-md items-stretch overflow-hidden rounded-[22px] border border-border bg-card/95 shadow-card backdrop-blur sm:rounded-[24px]">
         {TABS.map(({ label, href, Icon, match }) => {
           const active = match(pathname);
           return (
@@ -122,7 +80,4 @@ export function BottomTabNav(): React.ReactElement {
       </ul>
     </nav>
   );
-
-  if (!mounted) return <></>;
-  return createPortal(nav, document.body);
 }

--- a/src/components/ui/bottom-tab-nav.tsx
+++ b/src/components/ui/bottom-tab-nav.tsx
@@ -49,7 +49,10 @@ export function BottomTabNav(): React.ReactElement {
   const pathname = usePathname();
 
   return (
-    <nav aria-label="주요 기능" className="fixed bottom-6 left-3 right-3 z-40">
+    <nav
+      aria-label="주요 기능"
+      className="fixed inset-x-0 bottom-0 z-[60] px-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
+    >
       <ul className="mx-auto flex w-full max-w-screen-md items-stretch overflow-hidden rounded-[22px] border border-border bg-card/95 shadow-card backdrop-blur sm:rounded-[24px]">
         {TABS.map(({ label, href, Icon, match }) => {
           const active = match(pathname);

--- a/src/components/ui/bottom-tab-nav.tsx
+++ b/src/components/ui/bottom-tab-nav.tsx
@@ -51,45 +51,51 @@ export function BottomTabNav(): React.ReactElement {
   const pathname = usePathname();
   const [mounted, setMounted] = useState(false);
   const [bottomOffset, setBottomOffset] = useState(12);
+  const [frame, setFrame] = useState({ left: 12, width: 351 });
 
   useEffect(() => {
     setMounted(true);
 
-    function syncBottomOffset(): void {
+    function syncFrame(): void {
       const visualViewport = window.visualViewport;
-      if (!visualViewport) {
-        setBottomOffset(12);
-        return;
-      }
+      const documentWidth = document.documentElement.clientWidth;
+      const maxWidth = 768;
+      const horizontalGap = documentWidth < 640 ? 12 : 0;
+      const navWidth = Math.min(maxWidth, Math.max(0, documentWidth - horizontalGap * 2));
+      const left = Math.max(horizontalGap, Math.round((documentWidth - navWidth) / 2));
+      const hiddenViewportBottom = visualViewport
+        ? Math.max(0, window.innerHeight - visualViewport.height - visualViewport.offsetTop)
+        : 0;
 
-      const hiddenViewportBottom = Math.max(
-        0,
-        window.innerHeight - visualViewport.height - visualViewport.offsetTop,
-      );
+      setFrame({ left, width: navWidth });
       setBottomOffset(Math.round(hiddenViewportBottom + 12));
     }
 
-    syncBottomOffset();
-    window.visualViewport?.addEventListener("resize", syncBottomOffset);
-    window.visualViewport?.addEventListener("scroll", syncBottomOffset);
-    window.addEventListener("resize", syncBottomOffset);
-    window.addEventListener("scroll", syncBottomOffset, { passive: true });
+    syncFrame();
+    window.visualViewport?.addEventListener("resize", syncFrame);
+    window.visualViewport?.addEventListener("scroll", syncFrame);
+    window.addEventListener("resize", syncFrame);
+    window.addEventListener("scroll", syncFrame, { passive: true });
 
     return () => {
-      window.visualViewport?.removeEventListener("resize", syncBottomOffset);
-      window.visualViewport?.removeEventListener("scroll", syncBottomOffset);
-      window.removeEventListener("resize", syncBottomOffset);
-      window.removeEventListener("scroll", syncBottomOffset);
+      window.visualViewport?.removeEventListener("resize", syncFrame);
+      window.visualViewport?.removeEventListener("scroll", syncFrame);
+      window.removeEventListener("resize", syncFrame);
+      window.removeEventListener("scroll", syncFrame);
     };
   }, []);
 
   const nav = (
     <nav
       aria-label="주요 기능"
-      className="fixed inset-x-0 z-[60] px-3"
-      style={{ bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))` }}
+      className="fixed z-[60]"
+      style={{
+        bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))`,
+        left: frame.left,
+        width: frame.width,
+      }}
     >
-      <ul className="mx-auto flex w-full max-w-screen-md items-stretch overflow-hidden rounded-[22px] border border-border bg-card/95 shadow-card backdrop-blur sm:rounded-[24px]">
+      <ul className="flex w-full items-stretch overflow-hidden rounded-[22px] border border-border bg-card/95 shadow-card backdrop-blur sm:rounded-[24px]">
         {TABS.map(({ label, href, Icon, match }) => {
           const active = match(pathname);
           return (

--- a/src/components/ui/bottom-tab-nav.tsx
+++ b/src/components/ui/bottom-tab-nav.tsx
@@ -49,8 +49,8 @@ export function BottomTabNav(): React.ReactElement {
   const pathname = usePathname();
 
   return (
-    <nav aria-label="주요 기능" className="fixed inset-x-0 bottom-0 z-40 px-3 pb-3">
-      <ul className="mx-auto flex max-w-screen-md items-stretch rounded-[24px] border border-border bg-card/95 shadow-card backdrop-blur">
+    <nav aria-label="주요 기능" className="fixed bottom-6 left-3 right-3 z-40">
+      <ul className="mx-auto flex w-full max-w-screen-md items-stretch overflow-hidden rounded-[22px] border border-border bg-card/95 shadow-card backdrop-blur sm:rounded-[24px]">
         {TABS.map(({ label, href, Icon, match }) => {
           const active = match(pathname);
           return (
@@ -59,17 +59,17 @@ export function BottomTabNav(): React.ReactElement {
                 href={href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "relative flex h-16 flex-col items-center justify-center gap-1 rounded-[20px] text-caption transition",
+                  "relative flex h-14 min-w-0 flex-col items-center justify-center gap-0.5 rounded-[18px] text-[11px] font-medium transition sm:h-16 sm:gap-1 sm:rounded-[20px] sm:text-caption",
                   active ? "bg-blue-soft text-blue-deep" : "text-ink-2 hover:text-ink-1",
                 )}
               >
                 <Icon
-                  size={20}
+                  size={18}
                   strokeWidth={active ? 2.2 : 1.8}
                   aria-hidden="true"
                   className="relative z-10"
                 />
-                <span className="relative z-10">{label}</span>
+                <span className="relative z-10 truncate">{label}</span>
               </Link>
             </li>
           );

--- a/src/components/ui/bottom-tab-nav.tsx
+++ b/src/components/ui/bottom-tab-nav.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { createPortal } from "react-dom";
+import { useEffect, useState } from "react";
 import { Calendar, House, Package, ScrollText, ShoppingBasket } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -47,11 +49,45 @@ const TABS: Tab[] = [
 
 export function BottomTabNav(): React.ReactElement {
   const pathname = usePathname();
+  const [mounted, setMounted] = useState(false);
+  const [bottomOffset, setBottomOffset] = useState(12);
 
-  return (
+  useEffect(() => {
+    setMounted(true);
+
+    function syncBottomOffset(): void {
+      const visualViewport = window.visualViewport;
+      if (!visualViewport) {
+        setBottomOffset(12);
+        return;
+      }
+
+      const hiddenViewportBottom = Math.max(
+        0,
+        window.innerHeight - visualViewport.height - visualViewport.offsetTop,
+      );
+      setBottomOffset(Math.round(hiddenViewportBottom + 12));
+    }
+
+    syncBottomOffset();
+    window.visualViewport?.addEventListener("resize", syncBottomOffset);
+    window.visualViewport?.addEventListener("scroll", syncBottomOffset);
+    window.addEventListener("resize", syncBottomOffset);
+    window.addEventListener("scroll", syncBottomOffset, { passive: true });
+
+    return () => {
+      window.visualViewport?.removeEventListener("resize", syncBottomOffset);
+      window.visualViewport?.removeEventListener("scroll", syncBottomOffset);
+      window.removeEventListener("resize", syncBottomOffset);
+      window.removeEventListener("scroll", syncBottomOffset);
+    };
+  }, []);
+
+  const nav = (
     <nav
       aria-label="주요 기능"
-      className="fixed inset-x-0 bottom-0 z-[60] px-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
+      className="fixed inset-x-0 z-[60] px-3"
+      style={{ bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))` }}
     >
       <ul className="mx-auto flex w-full max-w-screen-md items-stretch overflow-hidden rounded-[22px] border border-border bg-card/95 shadow-card backdrop-blur sm:rounded-[24px]">
         {TABS.map(({ label, href, Icon, match }) => {
@@ -80,4 +116,7 @@ export function BottomTabNav(): React.ReactElement {
       </ul>
     </nav>
   );
+
+  if (!mounted) return <></>;
+  return createPortal(nav, document.body);
 }

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -217,7 +217,7 @@ function getCellTags(
     return [
       {
         label: formatForecastRevenueRange(forecast.totalRevenue, revenueMeanAbsoluteWonError),
-        mobileLabel: formatNumber(Math.round(forecast.totalRevenue / 10000)),
+        mobileLabel: `예${formatNumber(Math.round(forecast.totalRevenue / 10000))}`,
         tone: "blue",
       },
     ];
@@ -281,7 +281,7 @@ function CellStatusTags({ tags }: { tags: readonly CellStatusTag[] }): React.Rea
         <span
           key={tag.label}
           className={cn(
-            "inline-flex max-w-full min-w-0 items-center justify-center overflow-hidden rounded-full px-1 py-0.5 text-[9px] font-bold leading-none shadow-soft sm:w-fit sm:px-2 sm:py-1 sm:text-micro",
+            "inline-flex max-w-full min-w-0 items-center justify-center overflow-hidden rounded-full px-[clamp(2px,0.9vw,4px)] py-0.5 text-[clamp(8px,2.45vw,10px)] font-bold leading-none shadow-soft sm:w-fit sm:px-2 sm:py-1 sm:text-micro",
             tag.tone === "red"
               ? "bg-red-soft text-red-deep"
               : tag.tone === "blue"

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -92,9 +92,9 @@ function MobileCalendarGuide(): React.ReactElement {
   return (
     <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-1 text-[10px] font-medium text-ink-3 sm:hidden">
       <span className="font-semibold text-ink-1">만원 단위</span>
-      <GuideItem tone="ink" sample="50" label="실제" />
-      <GuideItem tone="blue" sample="-8" label="오차" />
-      <GuideItem tone="blue" sample="예27" label="예상" />
+      <GuideItem tone="ink" sample="50" label="실제 매출" />
+      <GuideItem tone="blue" sample="-8" label="매출 오차" />
+      <GuideItem tone="blue" sample="예27" label="예상 매출" />
       <GuideItem tone="red" sample="누락" label="입력 필요" />
       <span className="inline-flex items-center gap-1">
         <span className="size-1.5 rounded-full bg-amber-deep" aria-hidden />

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -181,17 +181,17 @@ function DayCell({
           : { backgroundColor: `color-mix(in srgb, var(--ink-1) ${intensityPct}%, var(--card))` }
       }
     >
-      <div className="flex items-start justify-between gap-1">
+      <div className="flex items-start">
         <span
           className={cn(
-            "text-[18px] font-semibold leading-none tabular-nums sm:text-title-md",
+            "text-[17px] font-semibold leading-none tabular-nums sm:text-title-md",
             !isSelected && weekdayTone(weekday, isInactive),
           )}
         >
           {day}
         </span>
-        <TopBadges cell={cell} />
       </div>
+      <TopBadges cell={cell} />
 
       {!isSelected && tags.length > 0 && <CellStatusTags tags={tags} />}
     </button>
@@ -298,7 +298,7 @@ function TopBadges({ cell }: TopBadgesProps): React.ReactElement | null {
   return (
     <>
       <span
-        className="mt-1 size-1.5 rounded-full bg-amber-deep shadow-soft sm:hidden"
+        className="absolute right-1.5 top-1.5 size-1.5 rounded-full bg-amber-deep shadow-soft sm:hidden"
         aria-label="매입 있음"
       />
       <span className="hidden rounded-full bg-amber-soft px-1.5 py-0.5 text-[9px] font-semibold leading-none text-amber-deep shadow-soft sm:inline">

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -48,9 +48,10 @@ export function CalendarGrid({
   const trailingBlanks = 42 - leadingBlanks - cells.length;
 
   return (
-    <div className="glow-panel flex flex-col gap-stack-tight rounded-[28px] border border-border bg-card p-4 shadow-card">
+    <div className="glow-panel flex flex-col gap-stack-tight rounded-[28px] border border-border bg-card p-3 shadow-card sm:p-4">
+      <MobileCalendarGuide />
       <WeekdayHeader />
-      <div className="grid grid-cols-7 gap-1.5">
+      <div className="grid grid-cols-7 gap-1 sm:gap-1.5">
         {Array.from({ length: leadingBlanks }, (_, i) => (
           <BlankCell key={`lead-${i}`} />
         ))}
@@ -87,8 +88,57 @@ function WeekdayHeader(): React.ReactElement {
   );
 }
 
+function MobileCalendarGuide(): React.ReactElement {
+  return (
+    <div className="rounded-2xl border border-blue/10 bg-blue-soft/45 px-3 py-2 sm:hidden">
+      <div className="flex items-start gap-2">
+        <p className="shrink-0 text-caption font-semibold text-ink-1">읽는 법</p>
+        <span className="shrink-0 rounded-full bg-white/85 px-2 py-1 text-[10px] font-semibold text-ink-3">
+          만원 단위
+        </span>
+        <div className="flex min-w-0 flex-1 flex-wrap gap-1.5 text-[10px] font-medium text-ink-3">
+          <GuideItem tone="ink" sample="50" label="실제" />
+          <GuideItem tone="blue" sample="-8" label="오차" />
+          <GuideItem tone="blue" sample="예27" label="예상" />
+          <GuideItem tone="red" sample="누락" label="입력 필요" />
+          <span className="flex items-center gap-1.5 rounded-xl bg-white/70 px-2 py-1">
+            <span className="size-1.5 rounded-full bg-amber-deep" aria-hidden />
+            <span>매입</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface GuideItemProps {
+  tone: "ink" | "blue" | "red";
+  sample: string;
+  label: string;
+}
+
+function GuideItem({ tone, sample, label }: GuideItemProps): React.ReactElement {
+  return (
+    <span className="flex items-center gap-1.5 rounded-xl bg-white/70 px-2 py-1">
+      <span
+        className={cn(
+          "rounded-full px-1.5 py-0.5 text-[9px] font-bold leading-none",
+          tone === "red"
+            ? "bg-red-soft text-red-deep"
+            : tone === "blue"
+              ? "bg-blue-soft text-blue-deep"
+              : "bg-white text-ink-1 shadow-soft",
+        )}
+      >
+        {sample}
+      </span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
 function BlankCell(): React.ReactElement {
-  return <div className="min-h-20 rounded-2xl bg-bg sm:min-h-24" aria-hidden />;
+  return <div className="min-h-16 rounded-2xl bg-bg sm:min-h-24" aria-hidden />;
 }
 
 interface DayCellProps {
@@ -126,7 +176,7 @@ function DayCell({
       aria-label={`${cell.date} ${cellAriaSummary(cell)}`}
       onClick={() => onSelect(cell)}
       className={cn(
-        "relative flex min-h-20 flex-col justify-between rounded-2xl p-2 text-left transition-colors sm:min-h-24 sm:p-2.5",
+        "relative flex min-h-16 flex-col justify-between rounded-2xl p-1.5 text-left transition-colors sm:min-h-24 sm:p-2.5",
         "shadow-soft hover:-translate-y-0.5 hover:shadow-card",
         isSelected ? "bg-ink-1 text-bg" : "text-ink-1",
         isToday && !isSelected && "border-2 border-blue ring-2 ring-blue/15",
@@ -141,7 +191,7 @@ function DayCell({
       <div className="flex items-start justify-between gap-1">
         <span
           className={cn(
-            "text-body font-semibold tabular-nums sm:text-title-md",
+            "text-caption font-semibold tabular-nums sm:text-title-md",
             !isSelected && weekdayTone(weekday, isInactive),
           )}
         >
@@ -157,6 +207,7 @@ function DayCell({
 
 interface CellStatusTag {
   label: string;
+  mobileLabel: string;
   tone: "red" | "blue" | "ink";
 }
 
@@ -166,26 +217,38 @@ function getCellTags(
   revenueError: CalendarRevenueAccuracySummary | null,
   revenueMeanAbsoluteWonError: number | null,
 ): CellStatusTag[] {
-  if (cell.isMissing) return [{ label: "누락", tone: "red" }];
+  if (cell.isMissing) return [{ label: "누락", mobileLabel: "누락", tone: "red" }];
   if (cell.isFuture && forecast && forecast.totalRevenue > 0) {
     return [
       {
         label: formatForecastRevenueRange(forecast.totalRevenue, revenueMeanAbsoluteWonError),
+        mobileLabel: `예${formatNumber(Math.round(forecast.totalRevenue / 10000))}`,
         tone: "blue",
       },
     ];
   }
   if (cell.revenue !== null && cell.revenue > 0 && revenueError !== null) {
     return [
-      { label: `매출 ${formatNumber(Math.round(cell.revenue / 10000))}만`, tone: "ink" },
+      {
+        label: `매출 ${formatNumber(Math.round(cell.revenue / 10000))}만`,
+        mobileLabel: formatNumber(Math.round(cell.revenue / 10000)),
+        tone: "ink",
+      },
       {
         label: `오차 ${formatSignedWonError(revenueError.signedWonError)}`,
+        mobileLabel: formatSignedWonErrorMobile(revenueError.signedWonError),
         tone: (revenueError.weightedAbsolutePercentageError ?? 0) >= 0.35 ? "red" : "blue",
       },
     ];
   }
   if (cell.revenue !== null && cell.revenue > 0) {
-    return [{ label: `매출 ${formatNumber(Math.round(cell.revenue / 10000))}만`, tone: "ink" }];
+    return [
+      {
+        label: `매출 ${formatNumber(Math.round(cell.revenue / 10000))}만`,
+        mobileLabel: formatNumber(Math.round(cell.revenue / 10000)),
+        tone: "ink",
+      },
+    ];
   }
   return [];
 }
@@ -203,22 +266,30 @@ function formatSignedWonError(signedWonError: number): string {
   return `${prefix}${formatNumber(Math.round(Math.abs(actualVsForecast) / 10000))}만`;
 }
 
+function formatSignedWonErrorMobile(signedWonError: number): string {
+  const actualVsForecast = -signedWonError;
+  const prefix = actualVsForecast >= 0 ? "+" : "-";
+  return `${prefix}${formatNumber(Math.round(Math.abs(actualVsForecast) / 10000))}`;
+}
+
 function CellStatusTags({ tags }: { tags: readonly CellStatusTag[] }): React.ReactElement {
   return (
-    <span className="flex flex-col items-start gap-1">
+    <span className="flex min-w-0 flex-col items-start gap-0.5 sm:gap-1">
       {tags.map((tag) => (
         <span
           key={tag.label}
           className={cn(
-            "w-fit rounded-full px-2 py-1 text-[10px] font-semibold leading-none shadow-soft sm:text-micro",
+            "max-w-full truncate rounded-full px-0.5 py-0.5 text-[8px] font-semibold leading-none shadow-soft sm:w-fit sm:px-2 sm:py-1 sm:text-micro",
             tag.tone === "red"
               ? "bg-red-soft text-red-deep"
               : tag.tone === "blue"
                 ? "bg-blue-soft text-blue-deep"
                 : "bg-white/90 text-ink-1",
           )}
+          title={tag.label}
         >
-          {tag.label}
+          <span className="sm:hidden">{tag.mobileLabel}</span>
+          <span className="hidden sm:inline">{tag.label}</span>
         </span>
       ))}
     </span>
@@ -232,9 +303,15 @@ interface TopBadgesProps {
 function TopBadges({ cell }: TopBadgesProps): React.ReactElement | null {
   if (!cell.hasPurchase) return null;
   return (
-    <span className="rounded-full bg-amber-soft px-1.5 py-0.5 text-[9px] font-semibold leading-none text-amber-deep shadow-soft">
-      매입
-    </span>
+    <>
+      <span
+        className="mt-1 size-1.5 rounded-full bg-amber-deep shadow-soft sm:hidden"
+        aria-label="매입 있음"
+      />
+      <span className="hidden rounded-full bg-amber-soft px-1.5 py-0.5 text-[9px] font-semibold leading-none text-amber-deep shadow-soft sm:inline">
+        매입
+      </span>
+    </>
   );
 }
 

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -90,16 +90,18 @@ function WeekdayHeader(): React.ReactElement {
 
 function MobileCalendarGuide(): React.ReactElement {
   return (
-    <div className="flex h-7 items-center gap-1.5 overflow-hidden whitespace-nowrap px-1 text-[11px] font-semibold text-ink-3 sm:hidden">
-      <span className="font-semibold text-ink-1">만원 단위</span>
-      <GuideItem tone="ink" sample="50" label="실매출" />
-      <GuideItem tone="blue" sample="-8" label="오차" />
-      <GuideItem tone="blue" sample="예27" label="예상" />
-      <GuideItem tone="red" sample="누락" label="" />
-      <span className="inline-flex items-center gap-1">
-        <span className="size-1.5 rounded-full bg-amber-deep" aria-hidden />
-        <span>매입</span>
-      </span>
+    <div className="relative sm:hidden">
+      <span className="absolute right-1 top-0 text-[9px] font-semibold text-ink-4">단위 만원</span>
+      <div className="flex h-7 items-center gap-1.5 overflow-hidden whitespace-nowrap pr-10 text-[11px] font-semibold text-ink-3">
+        <GuideItem tone="ink" sample="50" label="실매출" />
+        <GuideItem tone="blue" sample="±8" label="예측오차" />
+        <GuideItem tone="blue" sample="예27" label="예상" />
+        <GuideItem tone="red" sample="누락" label="" />
+        <span className="inline-flex items-center gap-1">
+          <span className="size-1.5 rounded-full bg-amber-deep" aria-hidden />
+          <span>매입</span>
+        </span>
+      </div>
     </div>
   );
 }
@@ -230,7 +232,7 @@ function getCellTags(
       {
         label: `오차 ${formatSignedWonError(revenueError.signedWonError)}`,
         mobileLabel: formatSignedWonErrorMobile(revenueError.signedWonError),
-        tone: (revenueError.weightedAbsolutePercentageError ?? 0) >= 0.35 ? "red" : "blue",
+        tone: getSignedWonErrorTone(revenueError.signedWonError),
       },
     ];
   }
@@ -263,6 +265,13 @@ function formatSignedWonErrorMobile(signedWonError: number): string {
   const actualVsForecast = -signedWonError;
   const prefix = actualVsForecast >= 0 ? "+" : "-";
   return `${prefix}${formatNumber(Math.round(Math.abs(actualVsForecast) / 10000))}`;
+}
+
+function getSignedWonErrorTone(signedWonError: number): CellStatusTag["tone"] {
+  const actualVsForecast = -signedWonError;
+  const roundedMan = Math.round(Math.abs(actualVsForecast) / 10000);
+  if (roundedMan === 0) return "ink";
+  return actualVsForecast > 0 ? "red" : "blue";
 }
 
 function CellStatusTags({ tags }: { tags: readonly CellStatusTag[] }): React.ReactElement {

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -90,7 +90,7 @@ function WeekdayHeader(): React.ReactElement {
 
 function MobileCalendarGuide(): React.ReactElement {
   return (
-    <div className="flex h-6 items-center gap-1.5 overflow-hidden whitespace-nowrap px-1 text-[9px] font-medium text-ink-3 sm:hidden">
+    <div className="flex h-7 items-center gap-1.5 overflow-hidden whitespace-nowrap px-1 text-[11px] font-semibold text-ink-3 sm:hidden">
       <span className="font-semibold text-ink-1">만원 단위</span>
       <GuideItem tone="ink" sample="50" label="실매출" />
       <GuideItem tone="blue" sample="-8" label="오차" />
@@ -115,7 +115,7 @@ function GuideItem({ tone, sample, label }: GuideItemProps): React.ReactElement 
     <span className="inline-flex items-center gap-1">
       <span
         className={cn(
-          "rounded-full px-1 py-0.5 text-[9px] font-bold leading-none shadow-soft",
+          "rounded-full px-1.5 py-0.5 text-[10px] font-bold leading-none shadow-soft",
           tone === "red"
             ? "bg-red-soft text-red-deep"
             : tone === "blue"

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -217,7 +217,7 @@ function getCellTags(
     return [
       {
         label: formatForecastRevenueRange(forecast.totalRevenue, revenueMeanAbsoluteWonError),
-        mobileLabel: `예${formatNumber(Math.round(forecast.totalRevenue / 10000))}`,
+        mobileLabel: formatNumber(Math.round(forecast.totalRevenue / 10000)),
         tone: "blue",
       },
     ];
@@ -281,7 +281,7 @@ function CellStatusTags({ tags }: { tags: readonly CellStatusTag[] }): React.Rea
         <span
           key={tag.label}
           className={cn(
-            "max-w-full truncate rounded-full px-1 py-0.5 text-[10px] font-bold leading-none shadow-soft sm:w-fit sm:px-2 sm:py-1 sm:text-micro",
+            "inline-flex max-w-full min-w-0 items-center justify-center overflow-hidden rounded-full px-1 py-0.5 text-[9px] font-bold leading-none shadow-soft sm:w-fit sm:px-2 sm:py-1 sm:text-micro",
             tag.tone === "red"
               ? "bg-red-soft text-red-deep"
               : tag.tone === "blue"
@@ -289,8 +289,9 @@ function CellStatusTags({ tags }: { tags: readonly CellStatusTag[] }): React.Rea
                 : "bg-white/90 text-ink-1",
           )}
           title={tag.label}
+          aria-label={tag.label}
         >
-          <span className="sm:hidden">{tag.mobileLabel}</span>
+          <span className="min-w-0 truncate sm:hidden">{tag.mobileLabel}</span>
           <span className="hidden sm:inline">{tag.label}</span>
         </span>
       ))}

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -90,23 +90,16 @@ function WeekdayHeader(): React.ReactElement {
 
 function MobileCalendarGuide(): React.ReactElement {
   return (
-    <div className="rounded-2xl border border-blue/10 bg-blue-soft/45 px-3 py-2 sm:hidden">
-      <div className="flex items-start gap-2">
-        <p className="shrink-0 text-caption font-semibold text-ink-1">읽는 법</p>
-        <span className="shrink-0 rounded-full bg-white/85 px-2 py-1 text-[10px] font-semibold text-ink-3">
-          만원 단위
-        </span>
-        <div className="flex min-w-0 flex-1 flex-wrap gap-1.5 text-[10px] font-medium text-ink-3">
-          <GuideItem tone="ink" sample="50" label="실제" />
-          <GuideItem tone="blue" sample="-8" label="오차" />
-          <GuideItem tone="blue" sample="예27" label="예상" />
-          <GuideItem tone="red" sample="누락" label="입력 필요" />
-          <span className="flex items-center gap-1.5 rounded-xl bg-white/70 px-2 py-1">
-            <span className="size-1.5 rounded-full bg-amber-deep" aria-hidden />
-            <span>매입</span>
-          </span>
-        </div>
-      </div>
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-1 text-[10px] font-medium text-ink-3 sm:hidden">
+      <span className="font-semibold text-ink-1">만원 단위</span>
+      <GuideItem tone="ink" sample="50" label="실제" />
+      <GuideItem tone="blue" sample="-8" label="오차" />
+      <GuideItem tone="blue" sample="예27" label="예상" />
+      <GuideItem tone="red" sample="누락" label="입력 필요" />
+      <span className="inline-flex items-center gap-1">
+        <span className="size-1.5 rounded-full bg-amber-deep" aria-hidden />
+        <span>매입</span>
+      </span>
     </div>
   );
 }
@@ -119,10 +112,10 @@ interface GuideItemProps {
 
 function GuideItem({ tone, sample, label }: GuideItemProps): React.ReactElement {
   return (
-    <span className="flex items-center gap-1.5 rounded-xl bg-white/70 px-2 py-1">
+    <span className="inline-flex items-center gap-1">
       <span
         className={cn(
-          "rounded-full px-1.5 py-0.5 text-[9px] font-bold leading-none",
+          "rounded-full px-1.5 py-0.5 text-[9px] font-bold leading-none shadow-soft",
           tone === "red"
             ? "bg-red-soft text-red-deep"
             : tone === "blue"

--- a/src/features/calendar/components/CalendarGrid.tsx
+++ b/src/features/calendar/components/CalendarGrid.tsx
@@ -90,12 +90,12 @@ function WeekdayHeader(): React.ReactElement {
 
 function MobileCalendarGuide(): React.ReactElement {
   return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-1 text-[10px] font-medium text-ink-3 sm:hidden">
+    <div className="flex h-6 items-center gap-1.5 overflow-hidden whitespace-nowrap px-1 text-[9px] font-medium text-ink-3 sm:hidden">
       <span className="font-semibold text-ink-1">만원 단위</span>
-      <GuideItem tone="ink" sample="50" label="실제 매출" />
-      <GuideItem tone="blue" sample="-8" label="매출 오차" />
-      <GuideItem tone="blue" sample="예27" label="예상 매출" />
-      <GuideItem tone="red" sample="누락" label="입력 필요" />
+      <GuideItem tone="ink" sample="50" label="실매출" />
+      <GuideItem tone="blue" sample="-8" label="오차" />
+      <GuideItem tone="blue" sample="예27" label="예상" />
+      <GuideItem tone="red" sample="누락" label="" />
       <span className="inline-flex items-center gap-1">
         <span className="size-1.5 rounded-full bg-amber-deep" aria-hidden />
         <span>매입</span>
@@ -115,7 +115,7 @@ function GuideItem({ tone, sample, label }: GuideItemProps): React.ReactElement 
     <span className="inline-flex items-center gap-1">
       <span
         className={cn(
-          "rounded-full px-1.5 py-0.5 text-[9px] font-bold leading-none shadow-soft",
+          "rounded-full px-1 py-0.5 text-[9px] font-bold leading-none shadow-soft",
           tone === "red"
             ? "bg-red-soft text-red-deep"
             : tone === "blue"
@@ -125,7 +125,7 @@ function GuideItem({ tone, sample, label }: GuideItemProps): React.ReactElement 
       >
         {sample}
       </span>
-      <span>{label}</span>
+      {label !== "" && <span>{label}</span>}
     </span>
   );
 }
@@ -169,7 +169,7 @@ function DayCell({
       aria-label={`${cell.date} ${cellAriaSummary(cell)}`}
       onClick={() => onSelect(cell)}
       className={cn(
-        "relative flex min-h-16 flex-col justify-between rounded-2xl p-1.5 text-left transition-colors sm:min-h-24 sm:p-2.5",
+        "relative flex min-h-[4.5rem] flex-col justify-between rounded-2xl p-1.5 text-left transition-colors sm:min-h-24 sm:p-2.5",
         "shadow-soft hover:-translate-y-0.5 hover:shadow-card",
         isSelected ? "bg-ink-1 text-bg" : "text-ink-1",
         isToday && !isSelected && "border-2 border-blue ring-2 ring-blue/15",
@@ -184,7 +184,7 @@ function DayCell({
       <div className="flex items-start justify-between gap-1">
         <span
           className={cn(
-            "text-caption font-semibold tabular-nums sm:text-title-md",
+            "text-[18px] font-semibold leading-none tabular-nums sm:text-title-md",
             !isSelected && weekdayTone(weekday, isInactive),
           )}
         >
@@ -272,7 +272,7 @@ function CellStatusTags({ tags }: { tags: readonly CellStatusTag[] }): React.Rea
         <span
           key={tag.label}
           className={cn(
-            "max-w-full truncate rounded-full px-0.5 py-0.5 text-[8px] font-semibold leading-none shadow-soft sm:w-fit sm:px-2 sm:py-1 sm:text-micro",
+            "max-w-full truncate rounded-full px-1 py-0.5 text-[10px] font-bold leading-none shadow-soft sm:w-fit sm:px-2 sm:py-1 sm:text-micro",
             tag.tone === "red"
               ? "bg-red-soft text-red-deep"
               : tag.tone === "blue"

--- a/src/features/calendar/components/CalendarLegend.tsx
+++ b/src/features/calendar/components/CalendarLegend.tsx
@@ -18,14 +18,16 @@ export function CalendarLegend(): React.ReactElement {
       </div>
       <div className="flex flex-wrap items-center gap-stack-tight">
         <BadgeKey tone="ink" sample="매출 50만" label="실제 매출" />
-        <BadgeKey tone="blue" sample="오차 -8만" label="예상 대비 실제 매출 차이" />
+        <BadgeKey tone="red" sample="+8만" label="예상보다 많이 나옴" />
+        <BadgeKey tone="blue" sample="-8만" label="예상보다 적게 나옴" />
+        <BadgeKey tone="ink" sample="0만" label="예상과 거의 일치" />
         <BadgeKey tone="blue" sample="예상 27만" label="미래 예상 매출" />
         <BadgeKey tone="red" sample="누락" label="판매 입력 필요" />
         <DotKey tone="amber" label="매입 있음" />
       </div>
       <p className="text-micro text-ink-4">
-        숫자는 만원 단위입니다. 예상 매출은 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기
-        예측만 표시합니다.
+        숫자는 만원 단위입니다. 오차 색상은 크기가 아니라 방향입니다. 예상 매출은 오늘부터{" "}
+        {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기 예측만 표시합니다.
       </p>
     </section>
   );

--- a/src/features/calendar/components/CalendarLegend.tsx
+++ b/src/features/calendar/components/CalendarLegend.tsx
@@ -10,18 +10,22 @@ export function CalendarLegend(): React.ReactElement {
   return (
     <section
       aria-label="캘린더 범례"
-      className="flex flex-col gap-stack-tight rounded-lg border border-border bg-card p-tile text-caption text-ink-3"
+      className="hidden flex-col gap-stack-tight rounded-lg border border-border bg-card p-tile text-caption text-ink-3 sm:flex"
     >
       <div className="flex items-center gap-stack-tight">
-        <span className="text-micro">매출</span>
+        <span className="text-micro font-semibold text-ink-2">배경 진하기</span>
         <IntensityScale />
       </div>
       <div className="flex flex-wrap items-center gap-stack-tight">
+        <BadgeKey tone="ink" sample="매출 50만" label="실제 매출" />
+        <BadgeKey tone="blue" sample="오차 -8만" label="예상 대비 실제 매출 차이" />
+        <BadgeKey tone="blue" sample="예상 27만" label="미래 예상 매출" />
+        <BadgeKey tone="red" sample="누락" label="판매 입력 필요" />
         <DotKey tone="amber" label="매입 있음" />
-        <DotKey tone="red" label="판매 미입력" />
       </div>
       <p className="text-micro text-ink-4">
-        예상 매출은 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기 예측만 표시합니다.
+        숫자는 만원 단위입니다. 예상 매출은 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기
+        예측만 표시합니다.
       </p>
     </section>
   );
@@ -48,6 +52,31 @@ function IntensityScale(): React.ReactElement {
 interface DotKeyProps {
   tone: "amber" | "red";
   label: string;
+}
+
+interface BadgeKeyProps {
+  tone: "ink" | "blue" | "red";
+  sample: string;
+  label: string;
+}
+
+function BadgeKey({ tone, sample, label }: BadgeKeyProps): React.ReactElement {
+  return (
+    <span className="flex items-center gap-1">
+      <span
+        className={`rounded-full px-2 py-1 text-micro font-semibold leading-none ${
+          tone === "red"
+            ? "bg-red-soft text-red-deep"
+            : tone === "blue"
+              ? "bg-blue-soft text-blue-deep"
+              : "bg-white text-ink-1 shadow-soft"
+        }`}
+      >
+        {sample}
+      </span>
+      <span>{label}</span>
+    </span>
+  );
 }
 
 function DotKey({ tone, label }: DotKeyProps): React.ReactElement {

--- a/src/features/calendar/components/MonthHeader.tsx
+++ b/src/features/calendar/components/MonthHeader.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 interface MonthHeaderProps {
   year: number;
   month: number;
@@ -36,14 +38,28 @@ export function MonthHeader({
             ›
           </NavButton>
         </div>
-        <button
-          type="button"
-          onClick={onToday}
-          className="rounded-xl border border-border bg-card px-3 py-2 text-caption text-ink-2 shadow-soft transition hover:bg-card-hover"
-        >
-          오늘
-        </button>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/inventory/forecast-accuracy?tab=revenue"
+            className="hidden rounded-xl border border-border bg-card px-3 py-2 text-caption font-semibold text-ink-2 shadow-soft transition hover:bg-card-hover sm:inline-flex"
+          >
+            예측 정확도
+          </Link>
+          <button
+            type="button"
+            onClick={onToday}
+            className="rounded-xl border border-border bg-card px-3 py-2 text-caption text-ink-2 shadow-soft transition hover:bg-card-hover"
+          >
+            오늘
+          </button>
+        </div>
       </div>
+      <Link
+        href="/inventory/forecast-accuracy?tab=revenue"
+        className="mt-3 inline-flex rounded-xl border border-border bg-card px-3 py-2 text-caption font-semibold text-ink-2 shadow-soft transition hover:bg-card-hover sm:hidden"
+      >
+        예측 정확도 보기
+      </Link>
     </header>
   );
 }

--- a/src/features/calendar/components/MonthHeader.tsx
+++ b/src/features/calendar/components/MonthHeader.tsx
@@ -40,10 +40,10 @@ export function MonthHeader({
         </div>
         <div className="flex items-center gap-2">
           <Link
-            href="/inventory/forecast-accuracy?tab=revenue"
+            href="/inventory/forecast?tab=revenue"
             className="hidden rounded-xl border border-border bg-card px-3 py-2 text-caption font-semibold text-ink-2 shadow-soft transition hover:bg-card-hover sm:inline-flex"
           >
-            예측 정확도
+            매출 예측
           </Link>
           <button
             type="button"
@@ -55,10 +55,10 @@ export function MonthHeader({
         </div>
       </div>
       <Link
-        href="/inventory/forecast-accuracy?tab=revenue"
+        href="/inventory/forecast?tab=revenue"
         className="mt-3 inline-flex rounded-xl border border-border bg-card px-3 py-2 text-caption font-semibold text-ink-2 shadow-soft transition hover:bg-card-hover sm:hidden"
       >
-        예측 정확도 보기
+        매출 예측 보기
       </Link>
     </header>
   );

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -140,19 +140,15 @@ function IngredientRow({
           {deleteMutation.error.message}
         </p>
       )}
-      {isOrderRecommended && (
-        <OrderRecommendationCard item={item} depletionLabel={depletionLabel} />
-      )}
+      {isOrderRecommended && <OrderRecommendationCard item={item} />}
     </li>
   );
 }
 
 function OrderRecommendationCard({
   item,
-  depletionLabel,
 }: {
   item: IngredientForecastView;
-  depletionLabel: string;
 }): React.ReactElement | null {
   const recommendation = item.purchaseRecommendation;
   if (!recommendation?.isOrderRecommended) return null;
@@ -164,20 +160,17 @@ function OrderRecommendationCard({
   return (
     <div className="rounded-[22px] border border-red/15 bg-red-soft/70 px-3 py-3 text-red-deep shadow-soft">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-w-0 space-y-2">
+        <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <span className="rounded-full bg-red px-2.5 py-1 text-micro font-semibold text-white shadow-soft">
               {formatDepletionBadge(days)}
             </span>
-            <span className="text-caption font-semibold">{depletionLabel}</span>
+            <span className="text-caption font-semibold text-red-deep/70">권장 발주</span>
           </div>
-          <div>
-            <p className="text-caption text-red-deep/70">권장 발주</p>
-            <p className="mt-0.5 text-title-lg tabular-nums text-red-deep">
-              {formatAmount(quantity, item.unit)}
-            </p>
-          </div>
-          <p className="text-caption text-red-deep/75">{orderByLabel}까지 매입 등록 권장</p>
+          <p className="mt-1 text-title-lg tabular-nums text-red-deep">
+            {formatAmount(quantity, item.unit)}
+          </p>
+          <p className="mt-1 text-caption text-red-deep/75">{orderByLabel}까지 매입 등록 권장</p>
         </div>
         <Link
           href={buildPurchasePrefillHref(item)}

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -156,6 +156,10 @@ function OrderRecommendationCard({
   const quantity = Math.ceil(recommendation.recommendedOrderQuantity);
   const days = daysUntilDate(item.expectedDepletionDate);
   const orderByLabel = formatOrderByDate(recommendation.orderByDate);
+  const depletionDemand = Math.min(
+    Math.max(0, item.currentStock),
+    recommendation.targetDemandQuantity,
+  );
 
   return (
     <div className="rounded-[22px] border border-red/15 bg-red-soft/70 px-3 py-3 text-red-deep shadow-soft">
@@ -185,11 +189,17 @@ function OrderRecommendationCard({
         <dl className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
           <OrderStockDemandFactor
             currentStock={formatAmount(item.currentStock, item.unit)}
-            targetDemand={formatAmount(recommendation.targetDemandQuantity, item.unit)}
+            depletionDemand={formatAmount(depletionDemand, item.unit)}
+          />
+          <OrderFactor
+            label="목표 필요량"
+            value={formatAmount(recommendation.targetDemandQuantity, item.unit)}
           />
           <OrderFactor label="리드타임" value={`${item.leadTimeDays}일`} />
-          <OrderFactor label="안전여유" value={`${item.safetyBufferDays}일`} />
-          <OrderFactor label="목표운영" value={`${recommendation.targetCoverageDays}일`} />
+          <OrderFactor
+            label="안전여유 + 목표운영"
+            value={`${item.safetyBufferDays}일 + ${recommendation.targetCoverageDays}일`}
+          />
         </dl>
         <div className="mt-3 flex flex-col gap-1 leading-relaxed text-ink-3">
           <span>{formatForecastBasisCompact(item)}</span>
@@ -203,18 +213,18 @@ function OrderRecommendationCard({
 
 function OrderStockDemandFactor({
   currentStock,
-  targetDemand,
+  depletionDemand,
 }: {
   currentStock: string;
-  targetDemand: string;
+  depletionDemand: string;
 }): React.ReactElement {
   return (
     <div className="rounded-2xl bg-card px-2 py-2 shadow-soft">
-      <dt className="text-micro text-ink-3">현재고 | 예상 소모량</dt>
+      <dt className="text-micro text-ink-3">현재고 | 소진까지 사용</dt>
       <dd className="mt-0.5 flex items-center justify-center gap-1 text-caption font-semibold tabular-nums text-ink-1">
         <span>{currentStock}</span>
         <span className="text-ink-4">|</span>
-        <span>{targetDemand}</span>
+        <span>{depletionDemand}</span>
       </dd>
     </div>
   );

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -156,10 +156,7 @@ function OrderRecommendationCard({
   const quantity = Math.ceil(recommendation.recommendedOrderQuantity);
   const days = daysUntilDate(item.expectedDepletionDate);
   const orderByLabel = formatOrderByDate(recommendation.orderByDate);
-  const depletionDemand = Math.min(
-    Math.max(0, item.currentStock),
-    recommendation.targetDemandQuantity,
-  );
+  const depletionDemandLabel = formatDepletionDemandLabel(days);
 
   return (
     <div className="rounded-[22px] border border-red/15 bg-red-soft/70 px-3 py-3 text-red-deep shadow-soft">
@@ -189,7 +186,8 @@ function OrderRecommendationCard({
         <dl className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
           <OrderStockDemandFactor
             currentStock={formatAmount(item.currentStock, item.unit)}
-            depletionDemand={formatAmount(depletionDemand, item.unit)}
+            depletionDemandLabel={depletionDemandLabel}
+            depletionDemand={formatAmount(recommendation.depletionWindowDemandQuantity, item.unit)}
           />
           <OrderFactor
             label="목표 필요량"
@@ -213,14 +211,16 @@ function OrderRecommendationCard({
 
 function OrderStockDemandFactor({
   currentStock,
+  depletionDemandLabel,
   depletionDemand,
 }: {
   currentStock: string;
+  depletionDemandLabel: string;
   depletionDemand: string;
 }): React.ReactElement {
   return (
     <div className="rounded-2xl bg-card px-2 py-2 shadow-soft">
-      <dt className="text-micro text-ink-3">현재고 | 소진까지 사용</dt>
+      <dt className="text-micro text-ink-3">현재고 | {depletionDemandLabel}</dt>
       <dd className="mt-0.5 flex items-center justify-center gap-1 text-caption font-semibold tabular-nums text-ink-1">
         <span>{currentStock}</span>
         <span className="text-ink-4">|</span>
@@ -335,6 +335,12 @@ function formatDepletionBadge(days: number | null): string {
   if (days === null) return "예측 부족";
   if (days === 0) return "오늘";
   return `D-${days}`;
+}
+
+function formatDepletionDemandLabel(days: number | null): string {
+  if (days === null) return "소진까지 사용";
+  if (days === 0) return "오늘 예상 소모";
+  return `${days}일 예상 소모`;
 }
 
 function formatAmount(value: number, unit: string): string {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -182,7 +182,11 @@ function OrderRecommendationCard({
 
       <details className="mt-3 rounded-2xl bg-white/70 px-3 py-2 text-caption text-ink-2 shadow-soft">
         <summary className="cursor-pointer select-none font-semibold text-ink-1">근거 보기</summary>
-        <dl className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
+        <dl className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-5">
+          <OrderFactor
+            label="예상 소모량"
+            value={formatAmount(recommendation.targetDemandQuantity, item.unit)}
+          />
           <OrderFactor label="현재고" value={formatAmount(item.currentStock, item.unit)} />
           <OrderFactor label="리드타임" value={`${item.leadTimeDays}일`} />
           <OrderFactor label="안전여유" value={`${item.safetyBufferDays}일`} />

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -86,6 +86,7 @@ function IngredientRow({
   accuracy?: IngredientForecastAccuracyView;
 }): React.ReactElement {
   const depletionLabel = formatDepletion(item);
+  const isOrderRecommended = Boolean(item.purchaseRecommendation?.isOrderRecommended);
   const deleteMutation = useDeleteIngredient();
 
   async function handleDelete(): Promise<void> {
@@ -107,15 +108,15 @@ function IngredientRow({
         <div className="min-w-0 flex flex-col gap-1">
           <span className="text-body text-ink-1">{item.name}</span>
           <span className="text-caption text-ink-3 tabular-nums">
-            현재 {formatNumber(item.currentStock)}
-            {item.unit}
-            <span className="text-ink-4"> · </span>
-            리드타임 {item.leadTimeDays}일<span className="text-ink-4"> · </span>
-            안전여유 {item.safetyBufferDays}일
+            현재 {formatAmount(item.currentStock, item.unit)}
           </span>
-          <span className="text-caption text-ink-3">{formatLeadTimeSource(item)}</span>
-          <span className="text-caption text-ink-3">{formatForecastSource(item)}</span>
-          <span className="text-caption text-ink-3">{formatForecastBasis(item)}</span>
+          {!isOrderRecommended && (
+            <>
+              <span className="text-caption text-ink-3">{formatLeadTimeSource(item)}</span>
+              <span className="text-caption text-ink-3">{formatForecastSource(item)}</span>
+              <span className="text-caption text-ink-3">{formatForecastBasis(item)}</span>
+            </>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-stack-tight">
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
@@ -139,7 +140,7 @@ function IngredientRow({
           {deleteMutation.error.message}
         </p>
       )}
-      {item.purchaseRecommendation?.isOrderRecommended && (
+      {isOrderRecommended && (
         <OrderRecommendationCard item={item} depletionLabel={depletionLabel} />
       )}
     </li>
@@ -157,48 +158,58 @@ function OrderRecommendationCard({
   if (!recommendation?.isOrderRecommended) return null;
 
   const quantity = Math.ceil(recommendation.recommendedOrderQuantity);
+  const days = daysUntilDate(item.expectedDepletionDate);
   const orderByLabel = formatOrderByDate(recommendation.orderByDate);
 
   return (
-    <div className="rounded-[22px] border border-blue/20 bg-blue-soft px-3 py-3 text-blue-deep shadow-soft">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <p className="text-caption font-semibold">권장 발주</p>
-          <p className="mt-1 text-title-md tabular-nums">
-            {formatNumber(quantity)}
-            {item.unit}
-          </p>
-          <p className="mt-1 text-caption text-blue-deep/75">
-            {orderByLabel}까지 발주 · {depletionLabel}
-          </p>
+    <div className="rounded-[22px] border border-red/15 bg-red-soft/70 px-3 py-3 text-red-deep shadow-soft">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-red px-2.5 py-1 text-micro font-semibold text-white shadow-soft">
+              {formatDepletionBadge(days)}
+            </span>
+            <span className="text-caption font-semibold">{depletionLabel}</span>
+          </div>
+          <div>
+            <p className="text-caption text-red-deep/70">권장 발주</p>
+            <p className="mt-0.5 text-title-lg tabular-nums text-red-deep">
+              {formatAmount(quantity, item.unit)}
+            </p>
+          </div>
+          <p className="text-caption text-red-deep/75">{orderByLabel}까지 매입 등록 권장</p>
         </div>
         <Link
           href={buildPurchasePrefillHref(item)}
-          className="flex shrink-0 items-center justify-center rounded-xl bg-blue px-4 py-2.5 text-label text-white shadow-soft transition hover:-translate-y-0.5"
+          className="flex shrink-0 items-center justify-center rounded-xl bg-red px-4 py-2.5 text-label text-white shadow-soft transition hover:-translate-y-0.5 hover:bg-red-deep"
         >
-          매입 등록
+          권장량으로 매입 등록
         </Link>
       </div>
 
-      <dl className="mt-3 grid grid-cols-3 gap-2 text-center">
-        <OrderFactor label="리드타임" value={`${item.leadTimeDays}일`} />
-        <OrderFactor label="안전여유" value={`${item.safetyBufferDays}일`} />
-        <OrderFactor label="목표운영" value={`${recommendation.targetCoverageDays}일`} />
-      </dl>
-
-      <p className="mt-3 text-caption leading-relaxed text-blue-deep/75">
-        현재 재고에서 리드타임, 안전여유, 목표 운영일 동안의 예상 소요량을 뺀 부족분만 추천합니다.{" "}
-        {formatLeadTimeSource(item)}
-      </p>
+      <details className="mt-3 rounded-2xl bg-white/70 px-3 py-2 text-caption text-ink-2 shadow-soft">
+        <summary className="cursor-pointer select-none font-semibold text-ink-1">근거 보기</summary>
+        <dl className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
+          <OrderFactor label="현재고" value={formatAmount(item.currentStock, item.unit)} />
+          <OrderFactor label="리드타임" value={`${item.leadTimeDays}일`} />
+          <OrderFactor label="안전여유" value={`${item.safetyBufferDays}일`} />
+          <OrderFactor label="목표운영" value={`${recommendation.targetCoverageDays}일`} />
+        </dl>
+        <div className="mt-3 flex flex-col gap-1 leading-relaxed text-ink-3">
+          <span>{formatForecastBasisCompact(item)}</span>
+          <span>{formatForecastSource(item)}</span>
+          <span>{formatLeadTimeSource(item)}</span>
+        </div>
+      </details>
     </div>
   );
 }
 
 function OrderFactor({ label, value }: { label: string; value: string }): React.ReactElement {
   return (
-    <div className="rounded-2xl bg-white/70 px-2 py-2 shadow-soft">
-      <dt className="text-micro text-blue-deep/60">{label}</dt>
-      <dd className="mt-0.5 text-caption font-semibold tabular-nums text-blue-deep">{value}</dd>
+    <div className="rounded-2xl bg-card px-2 py-2 shadow-soft">
+      <dt className="text-micro text-ink-3">{label}</dt>
+      <dd className="mt-0.5 text-caption font-semibold tabular-nums text-ink-1">{value}</dd>
     </div>
   );
 }
@@ -265,6 +276,11 @@ function formatForecastBasis(item: IngredientForecastView): string {
   return `${label} · 데이터 ${item.basis.usableSampleCount}일 · 요일 보정 ${confidence}%`;
 }
 
+function formatForecastBasisCompact(item: IngredientForecastView): string {
+  const label = CONFIDENCE_LABEL[item.basis.confidenceLevel];
+  return `${label} · 데이터 ${item.basis.usableSampleCount}일 기준`;
+}
+
 const CONFIDENCE_LABEL: Record<IngredientForecastView["basis"]["confidenceLevel"], string> = {
   high: "예측 신뢰도 높음",
   medium: "예측 신뢰도 보통",
@@ -288,6 +304,29 @@ function formatDepletion(item: IngredientForecastView): string {
   if (days === null) return "예측 데이터 부족";
   if (days === 0) return "오늘 소진";
   return `${days}일 후 소진`;
+}
+
+function formatDepletionBadge(days: number | null): string {
+  if (days === null) return "예측 부족";
+  if (days === 0) return "오늘";
+  return `D-${days}`;
+}
+
+function formatAmount(value: number, unit: string): string {
+  const normalizedUnit = unit.toLowerCase();
+  if (normalizedUnit === "g" && Math.abs(value) >= 1000) {
+    return `${formatDecimal(value / 1000)}kg`;
+  }
+  if (normalizedUnit === "ml" && Math.abs(value) >= 1000) {
+    return `${formatDecimal(value / 1000)}L`;
+  }
+  return `${formatNumber(Math.round(value))}${unit}`;
+}
+
+function formatDecimal(value: number): string {
+  return value.toLocaleString("ko-KR", {
+    maximumFractionDigits: 1,
+  });
 }
 
 function formatOrderByDate(date: Date | null): string {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -182,12 +182,11 @@ function OrderRecommendationCard({
 
       <details className="mt-3 rounded-2xl bg-white/70 px-3 py-2 text-caption text-ink-2 shadow-soft">
         <summary className="cursor-pointer select-none font-semibold text-ink-1">근거 보기</summary>
-        <dl className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-5">
-          <OrderFactor
-            label="예상 소모량"
-            value={formatAmount(recommendation.targetDemandQuantity, item.unit)}
+        <dl className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
+          <OrderStockDemandFactor
+            currentStock={formatAmount(item.currentStock, item.unit)}
+            targetDemand={formatAmount(recommendation.targetDemandQuantity, item.unit)}
           />
-          <OrderFactor label="현재고" value={formatAmount(item.currentStock, item.unit)} />
           <OrderFactor label="리드타임" value={`${item.leadTimeDays}일`} />
           <OrderFactor label="안전여유" value={`${item.safetyBufferDays}일`} />
           <OrderFactor label="목표운영" value={`${recommendation.targetCoverageDays}일`} />
@@ -198,6 +197,25 @@ function OrderRecommendationCard({
           <span>{formatLeadTimeSource(item)}</span>
         </div>
       </details>
+    </div>
+  );
+}
+
+function OrderStockDemandFactor({
+  currentStock,
+  targetDemand,
+}: {
+  currentStock: string;
+  targetDemand: string;
+}): React.ReactElement {
+  return (
+    <div className="rounded-2xl bg-card px-2 py-2 shadow-soft">
+      <dt className="text-micro text-ink-3">현재고 | 예상 소모량</dt>
+      <dd className="mt-0.5 flex items-center justify-center gap-1 text-caption font-semibold tabular-nums text-ink-1">
+        <span>{currentStock}</span>
+        <span className="text-ink-4">|</span>
+        <span>{targetDemand}</span>
+      </dd>
     </div>
   );
 }

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -161,6 +161,7 @@ export interface PurchaseRecommendationInput {
 
 export interface PurchaseRecommendationResult {
   recommendedOrderQuantity: number;
+  targetDemandQuantity: number;
   orderByDate: Date | null;
   targetCoverageDays: number;
   isOrderRecommended: boolean;
@@ -491,6 +492,7 @@ export function recommendPurchaseQuantity({
 
   return {
     recommendedOrderQuantity,
+    targetDemandQuantity: targetDemand,
     orderByDate,
     targetCoverageDays,
     isOrderRecommended: recommendedOrderQuantity > 0,

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -162,6 +162,7 @@ export interface PurchaseRecommendationInput {
 export interface PurchaseRecommendationResult {
   recommendedOrderQuantity: number;
   targetDemandQuantity: number;
+  depletionWindowDemandQuantity: number;
   orderByDate: Date | null;
   targetCoverageDays: number;
   isOrderRecommended: boolean;
@@ -489,14 +490,41 @@ export function recommendPurchaseQuantity({
     dailyDemand: demandByDay,
     today: normalizedToday,
   });
+  const daysToDepletion = computeDaysToDepletion({
+    currentStock,
+    dailyDemand: demandByDay,
+  });
+  const depletionWindowDemand =
+    daysToDepletion === null
+      ? 0
+      : demandByDay
+          .slice(0, daysToDepletion)
+          .reduce((sum, day) => sum + Math.max(0, day.amount), 0);
 
   return {
     recommendedOrderQuantity,
     targetDemandQuantity: targetDemand,
+    depletionWindowDemandQuantity: depletionWindowDemand,
     orderByDate,
     targetCoverageDays,
     isOrderRecommended: recommendedOrderQuantity > 0,
   };
+}
+
+function computeDaysToDepletion({
+  currentStock,
+  dailyDemand,
+}: {
+  currentStock: number;
+  dailyDemand: readonly IngredientDemandForecastDay[];
+}): number | null {
+  if (currentStock <= 0) return 0;
+  let remaining = currentStock;
+  for (let index = 0; index < dailyDemand.length; index += 1) {
+    remaining -= Math.max(0, dailyDemand[index]?.amount ?? 0);
+    if (remaining <= 0) return index + 1;
+  }
+  return null;
 }
 
 function computeOrderByDate({

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -407,6 +407,7 @@ describe("recommendPurchaseQuantity", () => {
 
     expect(result.recommendedOrderQuantity).toBe(100);
     expect(result.targetDemandQuantity).toBe(200);
+    expect(result.depletionWindowDemandQuantity).toBe(100);
     expect(result.targetCoverageDays).toBe(7);
     expect(result.isOrderRecommended).toBe(true);
     expect(result.orderByDate).toEqual(new Date(today.getTime() + 2 * ONE_DAY));
@@ -426,6 +427,7 @@ describe("recommendPurchaseQuantity", () => {
 
     expect(result.recommendedOrderQuantity).toBe(0);
     expect(result.targetDemandQuantity).toBe(180);
+    expect(result.depletionWindowDemandQuantity).toBe(0);
     expect(result.isOrderRecommended).toBe(false);
     expect(result.orderByDate).toBeNull();
   });

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -406,6 +406,7 @@ describe("recommendPurchaseQuantity", () => {
     });
 
     expect(result.recommendedOrderQuantity).toBe(100);
+    expect(result.targetDemandQuantity).toBe(200);
     expect(result.targetCoverageDays).toBe(7);
     expect(result.isOrderRecommended).toBe(true);
     expect(result.orderByDate).toEqual(new Date(today.getTime() + 2 * ONE_DAY));
@@ -424,6 +425,7 @@ describe("recommendPurchaseQuantity", () => {
     });
 
     expect(result.recommendedOrderQuantity).toBe(0);
+    expect(result.targetDemandQuantity).toBe(180);
     expect(result.isOrderRecommended).toBe(false);
     expect(result.orderByDate).toBeNull();
   });


### PR DESCRIPTION
## Summary
- add a compact mobile-only calendar guide for badge meanings
- shorten mobile calendar badges to fit narrow 7-column cells
- keep desktop calendar labels unchanged

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- headless mobile screenshot check: /tmp/ezstock-calendar-mobile-ux-final-2.png