### PR TITLE
Lift today alerts above KPI

### DIFF
--- a/src/app/(main)/today/page.tsx
+++ b/src/app/(main)/today/page.tsx
@@ -110,10 +110,6 @@ export default function TodayPage(): React.ReactElement {
         </div>
       </header>
 
-      <YesterdayKpiCard yesterday={data.yesterday} weeklyChart={data.weeklyChart} />
-
-      <OrderSummaryCard items={orderItems} isLoading={forecast.isLoading} />
-
       <AlertsCard
         depletionItems={forecast.data ?? []}
         expiryAlerts={data.expiryAlerts}
@@ -125,6 +121,10 @@ export default function TodayPage(): React.ReactElement {
         <QuickAction href="/sale" label="판매 입력" tone="primary" />
         <QuickAction href="/purchase" label="매입 등록" tone="secondary" />
       </nav>
+
+      <YesterdayKpiCard yesterday={data.yesterday} weeklyChart={data.weeklyChart} />
+
+      <OrderSummaryCard items={orderItems} isLoading={forecast.isLoading} />
 
       <MarginTop3Card top3={data.top3Menus} lowMargin={data.lowMarginMenu} />
     </section>


### PR DESCRIPTION
## Summary
- Move Today alerts directly below the header so urgent depletion notices are visible earlier
- Keep sale/purchase quick actions immediately after the alerts

## Checks
- npm run typecheck
- npm run lint
- npm run format:check