### PR TITLE
Compact forecast tabs on mobile

### DIFF
--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -125,7 +125,7 @@ function AccuracyTabNav({
   return (
     <nav
       aria-label="예측 정확도 종류"
-      className="grid gap-stack-tight rounded-[24px] border border-border bg-card p-2 shadow-soft md:grid-cols-3"
+      className="grid grid-cols-3 gap-1 rounded-[20px] border border-border bg-card p-1.5 shadow-soft"
     >
       <AccuracyTabLink
         tab="revenue"
@@ -173,14 +173,19 @@ function AccuracyTabLink({
       href={`/inventory/forecast-accuracy?${params.toString()}`}
       aria-current={selected ? "page" : undefined}
       className={cn(
-        "rounded-[20px] px-4 py-3 transition",
+        "min-w-0 rounded-2xl px-2 py-2.5 text-center transition md:px-4 md:py-3",
         selected
           ? "bg-blue text-white shadow-card"
           : "bg-white text-ink-2 shadow-soft hover:bg-blue-soft hover:text-blue-deep",
       )}
     >
-      <span className="block text-body font-semibold">{title}</span>
-      <span className={cn("mt-1 block text-caption", selected ? "text-white/80" : "text-ink-3")}>
+      <span className="block truncate text-caption font-semibold md:text-body">{title}</span>
+      <span
+        className={cn(
+          "mt-1 hidden text-caption md:block",
+          selected ? "text-white/80" : "text-ink-3",
+        )}
+      >
         {description}
       </span>
     </Link>

--- a/src/app/(main)/inventory/forecast/page.tsx
+++ b/src/app/(main)/inventory/forecast/page.tsx
@@ -126,7 +126,7 @@ function ForecastTabNav({
   return (
     <nav
       aria-label="예측 종류"
-      className="grid gap-stack-tight rounded-[24px] border border-border bg-card p-2 shadow-soft md:grid-cols-3"
+      className="grid grid-cols-3 gap-1 rounded-[20px] border border-border bg-card p-1.5 shadow-soft"
     >
       <ForecastTabLink
         tab="revenue"
@@ -174,14 +174,19 @@ function ForecastTabLink({
       href={`/inventory/forecast?${params.toString()}`}
       aria-current={selected ? "page" : undefined}
       className={cn(
-        "rounded-[20px] px-4 py-3 transition",
+        "min-w-0 rounded-2xl px-2 py-2.5 text-center transition md:px-4 md:py-3",
         selected
           ? "bg-blue text-white shadow-card"
           : "bg-white text-ink-2 shadow-soft hover:bg-blue-soft hover:text-blue-deep",
       )}
     >
-      <span className="block text-body font-semibold">{title}</span>
-      <span className={cn("mt-1 block text-caption", selected ? "text-white/80" : "text-ink-3")}>
+      <span className="block truncate text-caption font-semibold md:text-body">{title}</span>
+      <span
+        className={cn(
+          "mt-1 hidden text-caption md:block",
+          selected ? "text-white/80" : "text-ink-3",
+        )}
+      >
         {description}
       </span>
     </Link>


### PR DESCRIPTION
## Summary
- Make forecast and accuracy tabs fit in one horizontal row on mobile
- Hide secondary descriptions on mobile while keeping desktop detail

## Checks
- npm run typecheck
- npm run lint
- npm run format:check