### PR TITLE
Make ingredient day error depletion-based

### DIFF
--- a/src/features/inventory/components/IngredientForecastAccuracyList.tsx
+++ b/src/features/inventory/components/IngredientForecastAccuracyList.tsx
@@ -97,7 +97,7 @@ function IngredientForecastAccuracyCard({
           label="평균 소비오차"
           value={formatNullableAmount(item.meanAbsoluteAmountError, item.unit)}
         />
-        <Metric label="일수오차" value={formatDayError(item.meanAbsoluteDayEquivalentError)} />
+        <Metric label="소진일 영향" value={formatDayError(item.meanAbsoluteDayEquivalentError)} />
       </dl>
 
       <TuningHint item={item} />

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -284,7 +284,10 @@ function formatAccuracyLabel(
   const depletionDayError = days * accuracy.weightedAbsolutePercentageError;
   const earliestDays = Math.max(0, Math.floor(days - depletionDayError));
   const latestDays = Math.ceil(days + depletionDayError);
-  return `오차 ±${Number(depletionDayError.toFixed(1))}일 · 예상 ${earliestDays}~${latestDays}일`;
+  const errorLabel = `오차 ±${Number(depletionDayError.toFixed(1))}일`;
+  if (accuracy.bias === "under") return `${errorLabel} · 빠르면 ${earliestDays}일`;
+  if (accuracy.bias === "over") return `${errorLabel} · 늦으면 ${latestDays}일`;
+  return `${errorLabel} · 예상 ${earliestDays}~${latestDays}일`;
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -122,7 +122,9 @@ function IngredientRow({
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
             <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
             {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
-            {accuracy && <AccuracyBadge item={item} accuracy={accuracy} />}
+            {accuracy && shouldShowAccuracyBadge(item) && (
+              <AccuracyBadge item={item} accuracy={accuracy} />
+            )}
           </div>
           <button
             type="button"
@@ -277,12 +279,12 @@ function formatAccuracyLabel(
   const days = daysUntilDate(item.expectedDepletionDate);
   if (days === null) {
     const dayError = accuracy.meanAbsoluteDayEquivalentError;
-    return dayError === null ? "정확도 수집 중" : `보통 ±${Number(dayError.toFixed(1))}일`;
+    return dayError === null ? "정확도 수집 중" : `오차 ±${Number(dayError.toFixed(1))}일`;
   }
   const depletionDayError = days * accuracy.weightedAbsolutePercentageError;
   const earliestDays = Math.max(0, Math.floor(days - depletionDayError));
   const latestDays = Math.ceil(days + depletionDayError);
-  return `보통 ±${Number(depletionDayError.toFixed(1))}일 · 예상 ${earliestDays}~${latestDays}일`;
+  return `오차 ±${Number(depletionDayError.toFixed(1))}일 · 예상 ${earliestDays}~${latestDays}일`;
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {
@@ -334,7 +336,14 @@ function formatDepletion(item: IngredientForecastView): string {
   const days = daysUntilDate(item.expectedDepletionDate);
   if (days === null) return "예측 데이터 부족";
   if (days === 0) return "오늘 소진";
+  if (days > 30) return `여유 있음 · 약 ${days}일 후 소진`;
+  if (days > 14) return `약 ${days}일 후 소진`;
   return `${days}일 후 소진`;
+}
+
+function shouldShowAccuracyBadge(item: IngredientForecastView): boolean {
+  const days = daysUntilDate(item.expectedDepletionDate);
+  return days !== null && days <= 14;
 }
 
 function formatDepletionBadge(days: number | null): string {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -271,12 +271,18 @@ function formatAccuracyLabel(
   item: IngredientForecastView,
   accuracy: IngredientForecastAccuracyView,
 ): string {
-  const dayError = accuracy.meanAbsoluteDayEquivalentError;
-  if (dayError === null || accuracy.evaluatedDayCount < 3) return "정확도 수집 중";
+  if (accuracy.weightedAbsolutePercentageError === null || accuracy.evaluatedDayCount < 3) {
+    return "정확도 수집 중";
+  }
   const days = daysUntilDate(item.expectedDepletionDate);
-  if (days === null) return `보통 ±${Number(dayError.toFixed(1))}일`;
-  const earliestDays = Math.max(0, days - Math.ceil(dayError));
-  return `보통 ±${Number(dayError.toFixed(1))}일 · 빠르면 ${earliestDays}일`;
+  if (days === null) {
+    const dayError = accuracy.meanAbsoluteDayEquivalentError;
+    return dayError === null ? "정확도 수집 중" : `보통 ±${Number(dayError.toFixed(1))}일`;
+  }
+  const depletionDayError = days * accuracy.weightedAbsolutePercentageError;
+  const earliestDays = Math.max(0, Math.floor(days - depletionDayError));
+  const latestDays = Math.ceil(days + depletionDayError);
+  return `보통 ±${Number(depletionDayError.toFixed(1))}일 · 예상 ${earliestDays}~${latestDays}일`;
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {

--- a/src/lib/application/inventory.ts
+++ b/src/lib/application/inventory.ts
@@ -540,22 +540,26 @@ export async function loadIngredientForecastAccuracyViews(
         evaluated.length > 0
           ? sumBy(evaluated, (result) => result.absoluteAmountError) / evaluated.length
           : null;
+      const meanActualDailyAmount =
+        evaluated.length > 0
+          ? sumBy(evaluated, (result) => result.actualAmount) / evaluated.length
+          : null;
       const weightedAbsolutePercentageError = computeWape(
         sumBy(dailyResults, (result) => result.absoluteAmountError),
         actualTotalAmount,
       );
-      const dayErrorSamples = evaluated.filter((result) => result.dayEquivalentError !== null);
       const meanAbsoluteDayEquivalentError =
-        dayErrorSamples.length > 0
-          ? sumBy(dayErrorSamples, (result) => result.dayEquivalentError ?? 0) /
-            dayErrorSamples.length
+        meanAbsoluteAmountError !== null &&
+        meanActualDailyAmount !== null &&
+        meanActualDailyAmount > 0
+          ? meanAbsoluteAmountError / meanActualDailyAmount
           : null;
       const riskAdjustedDayError =
-        dayErrorSamples.length > 0
-          ? sumBy(dayErrorSamples, (result) => {
+        meanActualDailyAmount !== null && meanActualDailyAmount > 0 && evaluated.length > 0
+          ? sumBy(evaluated, (result) => {
               const weight = result.signedAmountError < 0 ? 2 : 1;
-              return (result.dayEquivalentError ?? 0) * weight;
-            }) / dayErrorSamples.length
+              return (result.absoluteAmountError / meanActualDailyAmount) * weight;
+            }) / evaluated.length
           : null;
       const underPredictedDayCount = evaluated.filter(
         (result) => result.signedAmountError < 0,


### PR DESCRIPTION
## Summary
- Recalculate ingredient day-equivalent error from average amount error over average daily consumption
- Show forecast badges as depletion-day impact using remaining days × WAPE
- Rename the accuracy metric from day error to depletion-day impact

## Checks
- npm run typecheck
- npm run lint
- npm run format:check