### PR TITLE
Refine forecast card information hierarchy

### DIFF
--- a/src/app/(main)/calendar/[date]/page.tsx
+++ b/src/app/(main)/calendar/[date]/page.tsx
@@ -198,7 +198,7 @@ function FutureForecastDetail({
     <div className="flex flex-col gap-section">
       <article className="flex flex-col gap-stack rounded-xl border border-border bg-card p-tile">
         <div className="flex flex-col gap-stack-tight">
-          <p className="text-micro text-ink-3">현재 예측 모델 기준</p>
+          <p className="text-micro text-ink-3">예상 범위</p>
           <div className="grid grid-cols-2 gap-stack">
             <Metric
               label="예상 매출"
@@ -212,10 +212,14 @@ function FutureForecastDetail({
             </p>
           )}
           <Notice tone="neutral">
-            캘린더는 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기 예측만 보여줘요. 장기
-            구간은 메뉴 수요 예측 화면에서 참고용으로 확인하세요.
+            캘린더는 오늘부터 {CALENDAR_SHORT_FORECAST_DAYS}일 이내 단기 예측만 간단히 보여줘요.
           </Notice>
-          <ForecastConfidenceNote forecast={forecast} />
+          <Link
+            href={`/inventory/forecast?tab=revenue`}
+            className="inline-flex w-fit rounded-full bg-blue-soft px-3 py-2 text-caption font-semibold text-blue-deep shadow-soft"
+          >
+            예측 자세히 보기
+          </Link>
         </div>
       </article>
 
@@ -234,10 +238,6 @@ function FutureForecastDetail({
                     예상 {formatNumber(Number(item.predictedQuantity.toFixed(1)))}개 ×{" "}
                     {formatWon(item.price)}원
                   </p>
-                  <p className="text-micro text-ink-4">
-                    {CONFIDENCE_LABEL[item.confidenceLevel]} · 데이터 {item.usableSampleCount}일 ·
-                    요일 보정 {Math.round(item.weekdayConfidence * 100)}%
-                  </p>
                 </div>
                 <p className="text-body tabular-nums text-ink-1">
                   {formatWon(item.predictedRevenue)}원
@@ -247,22 +247,6 @@ function FutureForecastDetail({
           ))}
         </ul>
       </article>
-    </div>
-  );
-}
-
-function ForecastConfidenceNote({
-  forecast,
-}: {
-  forecast: CalendarMenuForecastSummary;
-}): React.ReactElement {
-  return (
-    <div className="rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
-      <p className="font-semibold text-ink-2">{CONFIDENCE_LABEL[forecast.confidenceLevel]}</p>
-      <p className="mt-1">
-        메뉴별 최소 데이터 {forecast.minSampleCount}일 · 평균 요일 보정{" "}
-        {Math.round(forecast.averageWeekdayConfidence * 100)}% 기준입니다.
-      </p>
     </div>
   );
 }
@@ -680,13 +664,6 @@ function classifyDateBacktestReliability(
   if (weightedAbsolutePercentageError >= 0.35) return "watch";
   return "good";
 }
-
-const CONFIDENCE_LABEL: Record<CalendarMenuForecastSummary["confidenceLevel"], string> = {
-  high: "예측 신뢰도 높음",
-  medium: "예측 신뢰도 보통",
-  low: "예측 신뢰도 낮음",
-  collecting: "예측 데이터 수집 중",
-};
 
 const RELIABILITY_LABEL: Record<MenuForecastAccuracyView["reliability"], string> = {
   good: "신뢰도 좋음",

--- a/src/app/(main)/inventory/forecast-accuracy/page.tsx
+++ b/src/app/(main)/inventory/forecast-accuracy/page.tsx
@@ -52,7 +52,8 @@ function ForecastAccuracyContent(): React.ReactElement {
           최근 {backtestDays}일 기준으로 {getTabNoun(activeTab)} 예측과 실제값을 비교합니다.
         </p>
         <p className="mt-1 text-caption text-ink-3">
-          각 날짜의 예측은 그 전날까지의 판매 이력만 사용해 다시 계산합니다.
+          각 날짜의 전날까지 데이터만 사용해 다시 예측하므로, 모델이 실제로 얼마나 빗나갔는지
+          검증하는 화면입니다.
         </p>
       </section>
 

--- a/src/app/(main)/inventory/forecast/page.tsx
+++ b/src/app/(main)/inventory/forecast/page.tsx
@@ -10,6 +10,7 @@ import { useDepletionForecast } from "@/features/inventory/hooks/useDepletionFor
 import { useIngredientForecastAccuracy } from "@/features/inventory/hooks/useIngredientForecastAccuracy";
 import { useMenuDemandForecast } from "@/features/inventory/hooks/useMenuDemandForecast";
 import { useMenuForecastAccuracy } from "@/features/inventory/hooks/useMenuForecastAccuracy";
+import { useRevenueForecastAccuracy } from "@/features/inventory/hooks/useRevenueForecastAccuracy";
 import { PageHeader } from "@/components/ui/page-header";
 import { ErrorAlert, LoadingText } from "@/components/ui/query-state";
 import { cn } from "@/lib/utils";
@@ -34,6 +35,7 @@ function ForecastContent(): React.ReactElement {
   const horizonDays = parseOption(searchParams.get("horizon"), HORIZON_OPTIONS, 7);
   const menuQuery = useMenuDemandForecast(horizonDays);
   const menuAccuracyQuery = useMenuForecastAccuracy(14);
+  const revenueAccuracyQuery = useRevenueForecastAccuracy(14, activeTab === "revenue");
   const ingredientQuery = useDepletionForecast();
   const ingredientAccuracyQuery = useIngredientForecastAccuracy(14);
   const revenueDays = useMemo(
@@ -58,7 +60,7 @@ function ForecastContent(): React.ReactElement {
       <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
         <p className="text-body text-ink-1">{getIntro(activeTab, horizonDays)}</p>
         <p className="mt-1 text-caption text-ink-3">
-          메뉴 수요 예측을 기준으로 매출과 재료 소진을 함께 계산합니다.
+          중심값은 보정된 메뉴 예측 기준이고, 자세한 오차 검증은 정확도 화면에서 확인합니다.
         </p>
       </section>
 
@@ -81,7 +83,15 @@ function ForecastContent(): React.ReactElement {
         >
           {menuQuery.isLoading && <LoadingText />}
           {menuQuery.error && <ErrorAlert message={menuQuery.error.message} />}
-          {menuQuery.data && <RevenueForecastList days={revenueDays} />}
+          {revenueAccuracyQuery.error && (
+            <ErrorAlert message={revenueAccuracyQuery.error.message} />
+          )}
+          {menuQuery.data && (
+            <RevenueForecastList
+              days={revenueDays}
+              meanAbsoluteWonError={revenueAccuracyQuery.data?.meanAbsoluteWonError ?? null}
+            />
+          )}
         </ForecastSection>
       ) : activeTab === "menu" ? (
         <ForecastSection
@@ -94,6 +104,7 @@ function ForecastContent(): React.ReactElement {
             <MenuDemandForecastList
               items={menuQuery.data}
               accuracyItems={menuAccuracyQuery.data ?? []}
+              variant="detail"
             />
           )}
         </ForecastSection>
@@ -108,6 +119,7 @@ function ForecastContent(): React.ReactElement {
             <IngredientStatusList
               items={ingredientQuery.data}
               accuracyItems={ingredientAccuracyQuery.data ?? []}
+              variant="detail"
             />
           )}
         </ForecastSection>
@@ -219,8 +231,10 @@ interface RevenueForecastDay {
 
 function RevenueForecastList({
   days,
+  meanAbsoluteWonError,
 }: {
   days: readonly RevenueForecastDay[];
+  meanAbsoluteWonError: number | null;
 }): React.ReactElement {
   if (days.length === 0) {
     return (
@@ -232,15 +246,24 @@ function RevenueForecastList({
 
   const totalRevenue = days.reduce((sum, day) => sum + day.predictedRevenue, 0);
   const totalQuantity = days.reduce((sum, day) => sum + day.predictedQuantity, 0);
+  const periodMeanAbsoluteWonError =
+    meanAbsoluteWonError === null ? null : meanAbsoluteWonError * Math.sqrt(days.length);
 
   return (
     <div className="flex flex-col gap-stack">
       <section className="rounded-[24px] border border-border bg-card px-5 py-5 shadow-soft">
-        <p className="text-caption text-ink-3">기간 합계</p>
-        <p className="mt-1 text-title-lg text-ink-1">{formatWon(totalRevenue)}원</p>
+        <p className="text-caption text-ink-3">예상 매출 합계</p>
+        <p className="mt-1 text-title-lg text-ink-1">
+          {formatRevenueRange(totalRevenue, periodMeanAbsoluteWonError)}
+        </p>
         <p className="mt-1 text-caption text-ink-3">
           예상 판매 {formatNumber(Number(totalQuantity.toFixed(1)))}개
         </p>
+        {meanAbsoluteWonError !== null && (
+          <p className="mt-2 text-caption text-ink-3">
+            최근 14일 기준 평균 {formatWon(meanAbsoluteWonError)}원 정도 차이가 났어요.
+          </p>
+        )}
       </section>
       <ol className="flex flex-col gap-stack-tight">
         {days.map((day) => (
@@ -254,9 +277,14 @@ function RevenueForecastList({
                 예상 판매 {formatNumber(Number(day.predictedQuantity.toFixed(1)))}개
               </p>
             </div>
-            <p className="shrink-0 text-body font-semibold text-blue-deep">
-              {formatWon(day.predictedRevenue)}원
-            </p>
+            <div className="shrink-0 text-right">
+              <p className="text-body font-semibold text-blue-deep">
+                {formatWon(day.predictedRevenue)}원
+              </p>
+              {meanAbsoluteWonError !== null && (
+                <p className="text-micro text-ink-3">±{formatWon(meanAbsoluteWonError)}원</p>
+              )}
+            </div>
           </li>
         ))}
       </ol>
@@ -297,11 +325,20 @@ function parseTab(raw: string | null): ForecastTab {
 }
 
 function getIntro(tab: ForecastTab, horizonDays: number): string {
-  if (tab === "revenue") return `앞으로 ${horizonDays}일간 예상 매출을 보여줍니다.`;
-  if (tab === "menu") return `앞으로 ${horizonDays}일간 메뉴별 예상 판매량을 보여줍니다.`;
-  return "재료별 소진 위험과 권장 발주량을 보여줍니다.";
+  if (tab === "revenue")
+    return `앞으로 ${horizonDays}일간 예상 매출과 흔들릴 수 있는 범위를 보여줍니다.`;
+  if (tab === "menu")
+    return `앞으로 ${horizonDays}일간 메뉴별 예상 판매량과 옵션 선택 근거를 보여줍니다.`;
+  return "재료별 소진 위험, 권장 발주량, 계산 근거를 함께 보여줍니다.";
 }
 
 function formatDateLabel(date: Date): string {
   return `${date.getMonth() + 1}/${date.getDate()} ${WEEKDAY_KO[date.getDay()]}`;
+}
+
+function formatRevenueRange(value: number, meanAbsoluteWonError: number | null): string {
+  if (meanAbsoluteWonError === null) return `${formatWon(value)}원`;
+  const low = Math.max(0, value - meanAbsoluteWonError);
+  const high = value + meanAbsoluteWonError;
+  return `${formatWon(low)}~${formatWon(high)}원`;
 }

--- a/src/app/(main)/today/page.tsx
+++ b/src/app/(main)/today/page.tsx
@@ -88,9 +88,9 @@ export default function TodayPage(): React.ReactElement {
 
         <div className="mt-stack flex flex-col gap-4 rounded-2xl border border-blue/10 bg-blue-soft px-stack py-stack shadow-soft sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-caption text-blue-deep">예측 대시보드</p>
+            <p className="text-caption text-blue-deep">오늘 미리보기</p>
             <p className="mt-1 text-body text-ink-1">
-              매출, 메뉴 수요, 재료 소진 예측과 정확도를 확인하세요.
+              앞으로의 매출, 메뉴 수요, 재료 소진을 한 번에 확인하세요.
             </p>
           </div>
           <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
@@ -104,7 +104,7 @@ export default function TodayPage(): React.ReactElement {
               href="/inventory/forecast-accuracy?tab=revenue"
               className="inline-flex w-fit items-center rounded-full border border-blue/15 bg-white/70 px-4 py-2.5 text-caption font-semibold text-ink-2 shadow-soft transition hover:-translate-y-0.5 hover:bg-white"
             >
-              예측 정확도
+              정확도 보기
             </Link>
           </div>
         </div>

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -11,6 +11,7 @@ import type { IngredientForecastAccuracyView } from "../hooks/useIngredientForec
 interface IngredientStatusListProps {
   items: readonly IngredientForecastView[];
   accuracyItems?: readonly IngredientForecastAccuracyView[];
+  variant?: "action" | "detail";
 }
 
 const STATUS_GROUP_ORDER: readonly DepletionStatus[] = [
@@ -30,6 +31,7 @@ const STATUS_LABEL: Record<DepletionStatus, string> = {
 export function IngredientStatusList({
   items,
   accuracyItems = [],
+  variant = "action",
 }: IngredientStatusListProps): React.ReactElement {
   if (items.length === 0) {
     return (
@@ -68,6 +70,7 @@ export function IngredientStatusList({
                   key={item.ingredientId}
                   item={item}
                   accuracy={accuracyByIngredient.get(item.ingredientId)}
+                  variant={variant}
                 />
               ))}
             </ul>
@@ -81,9 +84,11 @@ export function IngredientStatusList({
 function IngredientRow({
   item,
   accuracy,
+  variant,
 }: {
   item: IngredientForecastView;
   accuracy?: IngredientForecastAccuracyView;
+  variant: "action" | "detail";
 }): React.ReactElement {
   const depletionLabel = formatDepletion(item);
   const isOrderRecommended = Boolean(item.purchaseRecommendation?.isOrderRecommended);
@@ -110,7 +115,7 @@ function IngredientRow({
           <span className="text-caption text-ink-3 tabular-nums">
             현재 {formatAmount(item.currentStock, item.unit)}
           </span>
-          {!isOrderRecommended && (
+          {!isOrderRecommended && variant === "detail" && (
             <>
               <span className="text-caption text-ink-3">{formatLeadTimeSource(item)}</span>
               <span className="text-caption text-ink-3">{formatForecastSource(item)}</span>
@@ -122,7 +127,7 @@ function IngredientRow({
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
             <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
             {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
-            {accuracy && shouldShowAccuracyBadge(item) && (
+            {variant === "detail" && accuracy && shouldShowAccuracyBadge(item) && (
               <AccuracyBadge item={item} accuracy={accuracy} />
             )}
           </div>
@@ -142,15 +147,17 @@ function IngredientRow({
           {deleteMutation.error.message}
         </p>
       )}
-      {isOrderRecommended && <OrderRecommendationCard item={item} />}
+      {isOrderRecommended && <OrderRecommendationCard item={item} variant={variant} />}
     </li>
   );
 }
 
 function OrderRecommendationCard({
   item,
+  variant,
 }: {
   item: IngredientForecastView;
+  variant: "action" | "detail";
 }): React.ReactElement | null {
   const recommendation = item.purchaseRecommendation;
   if (!recommendation?.isOrderRecommended) return null;
@@ -201,11 +208,13 @@ function OrderRecommendationCard({
             value={`${item.safetyBufferDays}일 + ${recommendation.targetCoverageDays}일`}
           />
         </dl>
-        <div className="mt-3 flex flex-col gap-1 leading-relaxed text-ink-3">
-          <span>{formatForecastBasisCompact(item)}</span>
-          <span>{formatForecastSource(item)}</span>
-          <span>{formatLeadTimeSource(item)}</span>
-        </div>
+        {variant === "detail" && (
+          <div className="mt-3 flex flex-col gap-1 leading-relaxed text-ink-3">
+            <span>{formatForecastBasisCompact(item)}</span>
+            <span>{formatForecastSource(item)}</span>
+            <span>{formatLeadTimeSource(item)}</span>
+          </div>
+        )}
       </details>
     </div>
   );

--- a/src/features/inventory/components/MenuDemandForecastList.tsx
+++ b/src/features/inventory/components/MenuDemandForecastList.tsx
@@ -9,6 +9,7 @@ import type { MenuForecastAccuracyView } from "../hooks/useMenuForecastAccuracy"
 interface MenuDemandForecastListProps {
   items: readonly MenuDemandForecastView[];
   accuracyItems?: readonly MenuForecastAccuracyView[];
+  variant?: "summary" | "detail";
 }
 
 const TREND_LABEL: Record<MenuDemandForecastView["trend"], string> = {
@@ -27,6 +28,7 @@ const CONFIDENCE_LABEL: Record<MenuDemandForecastView["basis"]["confidenceLevel"
 export function MenuDemandForecastList({
   items,
   accuracyItems = [],
+  variant = "detail",
 }: MenuDemandForecastListProps): React.ReactElement {
   if (items.length === 0) {
     return (
@@ -45,6 +47,7 @@ export function MenuDemandForecastList({
           key={item.menuId}
           item={item}
           accuracy={accuracyByMenu.get(item.menuId)}
+          variant={variant}
         />
       ))}
     </div>
@@ -54,9 +57,11 @@ export function MenuDemandForecastList({
 function MenuDemandForecastCard({
   item,
   accuracy,
+  variant,
 }: {
   item: MenuDemandForecastView;
   accuracy?: MenuForecastAccuracyView;
+  variant: "summary" | "detail";
 }): React.ReactElement {
   const maxDailyQuantity = Math.max(
     1,
@@ -80,9 +85,11 @@ function MenuDemandForecastCard({
         </div>
       </div>
 
-      <p className="mt-stack-tight rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
-        {formatForecastBasis(item)}
-      </p>
+      {variant === "detail" && (
+        <p className="mt-stack-tight rounded-2xl border border-border bg-bg px-3 py-2 text-caption text-ink-3">
+          {formatForecastBasis(item)}
+        </p>
+      )}
 
       <ol className="mt-stack grid grid-cols-7 gap-1.5">
         {item.dailyPredictions.map((day) => (
@@ -103,7 +110,7 @@ function MenuDemandForecastCard({
         ))}
       </ol>
 
-      {item.optionGroups.length > 0 && (
+      {variant === "detail" && item.optionGroups.length > 0 && (
         <div className="mt-stack flex flex-col gap-stack-tight border-t border-border pt-stack-tight">
           <p className="text-caption font-semibold text-ink-2">옵션 선택률</p>
           {item.optionGroups.map((group) => (


### PR DESCRIPTION
## Summary
- make general forecast entry points focus on action-friendly copy
- move detailed forecast basis into dedicated forecast page variants
- simplify calendar forecast details and link to the full forecast page
- show revenue forecast ranges from recent residual error on the forecast page

## Checks
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run
- npm run build