### PR TITLE
Show ingredient forecast uncertainty on inventory cards

### DIFF
--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -127,8 +127,8 @@ function IngredientRow({
           <div className="flex flex-col items-end gap-1 text-caption tabular-nums">
             <span className={cn(toneClass(item.status))}>{depletionLabel}</span>
             {item.trend !== "normal" && <TrendBadge trend={item.trend} />}
-            {variant === "detail" && accuracy && shouldShowAccuracyBadge(item) && (
-              <AccuracyBadge item={item} accuracy={accuracy} />
+            {accuracy && shouldShowAccuracyBadge(item) && (
+              <AccuracyBadge item={item} accuracy={accuracy} variant={variant} />
             )}
           </div>
           <button
@@ -253,25 +253,19 @@ function OrderFactor({ label, value }: { label: string; value: string }): React.
 function AccuracyBadge({
   item,
   accuracy,
+  variant,
 }: {
   item: IngredientForecastView;
   accuracy: IngredientForecastAccuracyView;
-}): React.ReactElement {
-  const label = formatAccuracyLabel(item, accuracy);
+  variant: "action" | "detail";
+}): React.ReactElement | null {
+  const label = formatAccuracyLabel(item, accuracy, variant);
+  if (!label) return null;
 
   return (
     <Link
       href="/inventory/forecast-accuracy?tab=ingredient"
-      className={cn(
-        "rounded-full px-2 py-0.5 text-micro shadow-soft",
-        accuracy.reliability === "good"
-          ? "bg-blue-soft text-blue-deep"
-          : accuracy.reliability === "watch"
-            ? "bg-amber-soft text-amber-deep"
-            : accuracy.reliability === "low"
-              ? "bg-red-soft text-red-deep"
-              : "bg-bg text-ink-3",
-      )}
+      className={cn("rounded-full px-2 py-0.5 text-micro shadow-soft", accuracyTone(accuracy))}
     >
       {label}
     </Link>
@@ -281,22 +275,33 @@ function AccuracyBadge({
 function formatAccuracyLabel(
   item: IngredientForecastView,
   accuracy: IngredientForecastAccuracyView,
-): string {
+  variant: "action" | "detail",
+): string | null {
   if (accuracy.weightedAbsolutePercentageError === null || accuracy.evaluatedDayCount < 3) {
-    return "정확도 수집 중";
+    return variant === "detail" ? "정확도 수집 중" : null;
   }
   const days = daysUntilDate(item.expectedDepletionDate);
   if (days === null) {
     const dayError = accuracy.meanAbsoluteDayEquivalentError;
-    return dayError === null ? "정확도 수집 중" : `오차 ±${Number(dayError.toFixed(1))}일`;
+    if (dayError === null) return variant === "detail" ? "정확도 수집 중" : null;
+    return `오차 ±${formatDayDelta(dayError)}일`;
   }
-  const depletionDayError = days * accuracy.weightedAbsolutePercentageError;
+  const depletionDayError =
+    accuracy.meanAbsoluteDayEquivalentError ?? days * accuracy.weightedAbsolutePercentageError;
   const earliestDays = Math.max(0, Math.floor(days - depletionDayError));
   const latestDays = Math.ceil(days + depletionDayError);
-  const errorLabel = `오차 ±${Number(depletionDayError.toFixed(1))}일`;
+  const errorLabel = `오차 ±${formatDayDelta(depletionDayError)}일`;
   if (accuracy.bias === "under") return `${errorLabel} · 빠르면 ${earliestDays}일`;
-  if (accuracy.bias === "over") return `${errorLabel} · 늦으면 ${latestDays}일`;
+  if (accuracy.bias === "over") return `${errorLabel} · 느리면 ${latestDays}일`;
   return `${errorLabel} · 예상 ${earliestDays}~${latestDays}일`;
+}
+
+function accuracyTone(accuracy: IngredientForecastAccuracyView): string {
+  if (accuracy.bias === "under") return "bg-red-soft text-red-deep";
+  if (accuracy.bias === "over") return "bg-blue-soft text-blue-deep";
+  if (accuracy.reliability === "watch") return "bg-amber-soft text-amber-deep";
+  if (accuracy.reliability === "low") return "bg-red-soft text-red-deep";
+  return "bg-bg text-ink-3";
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {
@@ -355,7 +360,13 @@ function formatDepletion(item: IngredientForecastView): string {
 
 function shouldShowAccuracyBadge(item: IngredientForecastView): boolean {
   const days = daysUntilDate(item.expectedDepletionDate);
-  return days !== null && days <= 14;
+  return days !== null && days <= 30;
+}
+
+function formatDayDelta(value: number): string {
+  return Number(value.toFixed(1)).toLocaleString("ko-KR", {
+    maximumFractionDigits: 1,
+  });
 }
 
 function formatDepletionBadge(days: number | null): string {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -199,14 +199,14 @@ function OrderRecommendationCard({
             depletionDemand={formatAmount(recommendation.depletionWindowDemandQuantity, item.unit)}
           />
           <OrderFactor
-            label="목표 필요량"
+            label={`목표 필요량 (${recommendation.targetCoverageDays}일)`}
             value={formatAmount(recommendation.targetDemandQuantity, item.unit)}
           />
-          <OrderFactor label="리드타임" value={`${item.leadTimeDays}일`} />
           <OrderFactor
-            label="안전여유 + 목표운영"
-            value={`${item.safetyBufferDays}일 + ${recommendation.targetCoverageDays}일`}
+            label="리드타임 | 안전여유"
+            value={`${item.leadTimeDays}일 | ${item.safetyBufferDays}일`}
           />
+          <OrderFactor label="목표운영" value={`${recommendation.targetCoverageDays}일`} />
         </dl>
         {variant === "detail" && (
           <div className="mt-3 flex flex-col gap-1 leading-relaxed text-ink-3">

--- a/src/lib/domain/forecast.ts
+++ b/src/lib/domain/forecast.ts
@@ -444,10 +444,7 @@ export function classifyStatus(
 ): DepletionStatus {
   if (!depletionDate) return "safe";
 
-  const daysUntilDepletion = Math.max(
-    0,
-    Math.floor((depletionDate.getTime() - today.getTime()) / ONE_DAY_MS),
-  );
+  const daysUntilDepletion = Math.max(0, daysBetweenForecastDays(today, depletionDate));
   const buffer = daysUntilDepletion - leadTimeDays - safetyBufferDays;
 
   if (buffer <= 1) return "critical";
@@ -459,8 +456,8 @@ export function classifyStatus(
 /**
  * 발주 추천량.
  *
- * 현재 재고가 `리드타임 + 안전여유 + 목표 커버리지` 기간의 예상 소요량을
- * 커버하도록 부족분만 추천한다. 기본 목표 커버리지는 7일이다.
+ * 발주 시점은 `리드타임 + 안전여유`로 판단하고, 권장 수량은 목표 운영일수만큼의
+ * 예상 소요량으로 추천한다. 기본 목표 커버리지는 7일이다.
  */
 export function recommendPurchaseQuantity({
   currentStock,
@@ -471,18 +468,14 @@ export function recommendPurchaseQuantity({
   coverageDays = 7,
 }: PurchaseRecommendationInput): PurchaseRecommendationResult {
   const targetCoverageDays = Math.max(1, Math.ceil(coverageDays));
-  const reorderWindowDays = Math.max(0, Math.ceil(leadTimeDays)) + Math.max(0, safetyBufferDays);
-  const targetWindowDays = reorderWindowDays + targetCoverageDays;
   const normalizedToday = startOfForecastDay(today);
   const demandByDay = dailyDemand
     .filter((day) => startOfForecastDay(day.date).getTime() > normalizedToday.getTime())
     .sort((a, b) => startOfForecastDay(a.date).getTime() - startOfForecastDay(b.date).getTime());
 
   const targetDemand = demandByDay
-    .slice(0, targetWindowDays)
+    .slice(0, targetCoverageDays)
     .reduce((sum, day) => sum + Math.max(0, day.amount), 0);
-  const recommendedOrderQuantity = Math.max(0, targetDemand - Math.max(0, currentStock));
-
   const orderByDate = computeOrderByDate({
     currentStock,
     leadTimeDays,
@@ -494,6 +487,7 @@ export function recommendPurchaseQuantity({
     currentStock,
     dailyDemand: demandByDay,
   });
+  const recommendedOrderQuantity = orderByDate === null ? 0 : targetDemand;
   const depletionWindowDemand =
     daysToDepletion === null
       ? 0
@@ -852,4 +846,10 @@ function addIngredientDemand(
 
 function startOfForecastDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function daysBetweenForecastDays(from: Date, to: Date): number {
+  return Math.floor(
+    (startOfForecastDay(to).getTime() - startOfForecastDay(from).getTime()) / ONE_DAY_MS,
+  );
 }

--- a/tests/unit/application.test.ts
+++ b/tests/unit/application.test.ts
@@ -424,7 +424,7 @@ describe("application layer", () => {
       expect(result?.forecastSource).toBe("menu_demand");
       expect(result?.purchaseRecommendation?.isOrderRecommended).toBe(true);
       expect(result?.purchaseRecommendation?.recommendedOrderQuantity).toBeGreaterThan(10);
-      expect(result?.purchaseRecommendation?.targetDemandQuantity).toBeGreaterThan(80);
+      expect(result?.purchaseRecommendation?.targetDemandQuantity).toBeGreaterThan(60);
     });
 
     it("loadDepletionForecast falls back to safety buffer 1 when rpc field is missing", async () => {

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -390,10 +390,17 @@ describe("classifyStatus (FR-013)", () => {
     expect(classifyStatus(date, 1, 1, today)).toBe("caution");
     expect(classifyStatus(date, 1, 3, today)).toBe("order_needed");
   });
+
+  it("상태 분류는 시각이 아니라 캘린더 일수 기준으로 계산한다", () => {
+    const afternoon = new Date("2026-04-30T15:30:00");
+    const depletionDate = new Date("2026-05-06T00:00:00");
+
+    expect(classifyStatus(depletionDate, 2, 2, afternoon)).toBe("order_needed");
+  });
 });
 
 describe("recommendPurchaseQuantity", () => {
-  it("리드타임 + 안전여유 + 7일 운영분까지 부족한 수량을 추천한다", () => {
+  it("발주 시점이면 목표 운영일수만큼의 수량을 추천한다", () => {
     const result = recommendPurchaseQuantity({
       currentStock: 100,
       leadTimeDays: 2,
@@ -405,8 +412,8 @@ describe("recommendPurchaseQuantity", () => {
       })),
     });
 
-    expect(result.recommendedOrderQuantity).toBe(100);
-    expect(result.targetDemandQuantity).toBe(200);
+    expect(result.recommendedOrderQuantity).toBe(140);
+    expect(result.targetDemandQuantity).toBe(140);
     expect(result.depletionWindowDemandQuantity).toBe(100);
     expect(result.targetCoverageDays).toBe(7);
     expect(result.isOrderRecommended).toBe(true);
@@ -426,7 +433,7 @@ describe("recommendPurchaseQuantity", () => {
     });
 
     expect(result.recommendedOrderQuantity).toBe(0);
-    expect(result.targetDemandQuantity).toBe(180);
+    expect(result.targetDemandQuantity).toBe(140);
     expect(result.depletionWindowDemandQuantity).toBe(0);
     expect(result.isOrderRecommended).toBe(false);
     expect(result.orderByDate).toBeNull();


### PR DESCRIPTION
## Summary
- show short ingredient forecast uncertainty labels directly on inventory cards
- express signed forecast bias as faster depletion or slower depletion
- hide uncertainty labels on action cards until enough backtest data exists
- keep detailed diagnostics in the forecast accuracy page

## Checks
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/forecast.test.ts tests/unit/application.test.ts
- npm run build