### PR TITLE
Add calendar forecast action menu

### DIFF
--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -96,12 +96,6 @@ export default function CalendarPage(): React.ReactElement {
     }
   }
 
-  function jumpToday(): void {
-    const now = new Date();
-    setYear(now.getFullYear());
-    setMonth(now.getMonth() + 1);
-  }
-
   if (year === null || month === null || query.isLoading) {
     return (
       <p className="glow-panel rounded-[28px] border border-white/70 bg-white/92 px-5 py-4 text-body-regular text-ink-3 shadow-soft">
@@ -124,7 +118,6 @@ export default function CalendarPage(): React.ReactElement {
         month={month}
         onPrev={() => navigate(-1)}
         onNext={() => navigate(1)}
-        onToday={jumpToday}
       />
       <MonthCumulativeCard
         cumulative={query.data.cumulative}

--- a/src/app/(main)/menu/page.tsx
+++ b/src/app/(main)/menu/page.tsx
@@ -25,7 +25,7 @@ export default function MenuPage(): React.ReactElement {
             </Link>
             <details className="group relative">
               <summary className="flex cursor-pointer list-none items-center justify-center gap-1 rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft [&::-webkit-details-marker]:hidden">
-                <span>작업</span>
+                <span>예측</span>
                 <ChevronDown
                   size={16}
                   strokeWidth={2.2}

--- a/src/features/calendar/components/MonthHeader.tsx
+++ b/src/features/calendar/components/MonthHeader.tsx
@@ -12,7 +12,7 @@ interface MonthHeaderProps {
 
 /**
  * 월간 캘린더 헤더 (patterns.md "캘린더" 위계 #1).
- * "2026년 4월" + 이전/다음 달 네비 + 캘린더 작업.
+ * "2026년 4월" + 이전/다음 달 네비 + 캘린더 예측.
  */
 export function MonthHeader({ year, month, onPrev, onNext }: MonthHeaderProps): React.ReactElement {
   return (
@@ -61,7 +61,7 @@ function CalendarActions(): React.ReactElement {
   return (
     <details className="group relative">
       <summary className="flex cursor-pointer list-none items-center justify-center gap-1 rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft [&::-webkit-details-marker]:hidden">
-        <span>작업</span>
+        <span>예측</span>
         <ChevronDown
           size={16}
           strokeWidth={2.2}

--- a/src/features/calendar/components/MonthHeader.tsx
+++ b/src/features/calendar/components/MonthHeader.tsx
@@ -1,26 +1,20 @@
 "use client";
 
 import Link from "next/link";
+import { ChevronDown } from "lucide-react";
 
 interface MonthHeaderProps {
   year: number;
   month: number;
   onPrev: () => void;
   onNext: () => void;
-  onToday: () => void;
 }
 
 /**
  * 월간 캘린더 헤더 (patterns.md "캘린더" 위계 #1).
- * "2026년 4월" + 이전/다음 달 네비 + 오늘로 돌아가기.
+ * "2026년 4월" + 이전/다음 달 네비 + 캘린더 작업.
  */
-export function MonthHeader({
-  year,
-  month,
-  onPrev,
-  onNext,
-  onToday,
-}: MonthHeaderProps): React.ReactElement {
+export function MonthHeader({ year, month, onPrev, onNext }: MonthHeaderProps): React.ReactElement {
   return (
     <header className="glow-panel rounded-[28px] border border-border bg-card px-5 py-5 shadow-card">
       <div className="flex items-center justify-between">
@@ -38,28 +32,8 @@ export function MonthHeader({
             ›
           </NavButton>
         </div>
-        <div className="flex items-center gap-2">
-          <Link
-            href="/inventory/forecast?tab=revenue"
-            className="hidden rounded-xl border border-border bg-card px-3 py-2 text-caption font-semibold text-ink-2 shadow-soft transition hover:bg-card-hover sm:inline-flex"
-          >
-            매출 예측
-          </Link>
-          <button
-            type="button"
-            onClick={onToday}
-            className="rounded-xl border border-border bg-card px-3 py-2 text-caption text-ink-2 shadow-soft transition hover:bg-card-hover"
-          >
-            오늘
-          </button>
-        </div>
+        <CalendarActions />
       </div>
-      <Link
-        href="/inventory/forecast?tab=revenue"
-        className="mt-3 inline-flex rounded-xl border border-border bg-card px-3 py-2 text-caption font-semibold text-ink-2 shadow-soft transition hover:bg-card-hover sm:hidden"
-      >
-        매출 예측 보기
-      </Link>
     </header>
   );
 }
@@ -82,3 +56,35 @@ function NavButton({ ariaLabel, onClick, children }: NavButtonProps): React.Reac
     </button>
   );
 }
+
+function CalendarActions(): React.ReactElement {
+  return (
+    <details className="group relative">
+      <summary className="flex cursor-pointer list-none items-center justify-center gap-1 rounded-2xl border border-border-strong bg-white px-4 py-3 text-body-regular font-semibold text-ink-1 shadow-soft transition hover:-translate-y-0.5 hover:border-blue/30 hover:bg-blue-soft [&::-webkit-details-marker]:hidden">
+        <span>작업</span>
+        <ChevronDown
+          size={16}
+          strokeWidth={2.2}
+          aria-hidden="true"
+          className="transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-44 overflow-hidden rounded-2xl border border-border bg-card p-1 shadow-card">
+        {CALENDAR_ACTIONS.map((action) => (
+          <Link
+            key={action.href}
+            href={action.href}
+            className="block rounded-xl px-3 py-2.5 text-caption font-semibold text-ink-1 transition hover:bg-blue-soft hover:text-blue-deep"
+          >
+            {action.label}
+          </Link>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+const CALENDAR_ACTIONS = [
+  { href: "/inventory/forecast?tab=revenue", label: "매출 예측" },
+  { href: "/inventory/forecast-accuracy?tab=revenue", label: "예측 정확도" },
+] as const;

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -290,10 +290,10 @@ function formatAccuracyLabel(
   const errorLabel = `오차 ±${formatDayDelta(depletionDayError)}일`;
   const direction = getAccuracyDirection(accuracy);
   if (direction === "under") {
-    return `소비↑ · ${errorLabel} · 빠르면 약 ${formatDayDelta(Math.max(0, days - depletionDayError))}일`;
+    return `더 빨리 줄었음 · ${errorLabel} · 빠르면 약 ${formatDayDelta(Math.max(0, days - depletionDayError))}일`;
   }
   if (direction === "over") {
-    return `소비↓ · ${errorLabel} · 느리면 약 ${formatDayDelta(days + depletionDayError)}일`;
+    return `더 천천히 줄었음 · ${errorLabel} · 느리면 약 ${formatDayDelta(days + depletionDayError)}일`;
   }
   return errorLabel;
 }

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -286,8 +286,7 @@ function formatAccuracyLabel(
     if (dayError === null) return variant === "detail" ? "정확도 수집 중" : null;
     return `오차 ±${formatDayDelta(dayError)}일`;
   }
-  const depletionDayError =
-    accuracy.meanAbsoluteDayEquivalentError ?? days * accuracy.weightedAbsolutePercentageError;
+  const depletionDayError = days * accuracy.weightedAbsolutePercentageError;
   const errorLabel = `오차 ±${formatDayDelta(depletionDayError)}일`;
   const direction = getAccuracyDirection(accuracy);
   if (direction === "under") {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -288,20 +288,33 @@ function formatAccuracyLabel(
   }
   const depletionDayError =
     accuracy.meanAbsoluteDayEquivalentError ?? days * accuracy.weightedAbsolutePercentageError;
-  const earliestDays = Math.max(0, Math.floor(days - depletionDayError));
-  const latestDays = Math.ceil(days + depletionDayError);
   const errorLabel = `오차 ±${formatDayDelta(depletionDayError)}일`;
-  if (accuracy.bias === "under") return `${errorLabel} · 빠르면 ${earliestDays}일`;
-  if (accuracy.bias === "over") return `${errorLabel} · 느리면 ${latestDays}일`;
-  return `${errorLabel} · 예상 ${earliestDays}~${latestDays}일`;
+  const direction = getAccuracyDirection(accuracy);
+  if (direction === "under") {
+    return `${errorLabel} · 빠르면 약 ${formatDayDelta(Math.max(0, days - depletionDayError))}일`;
+  }
+  if (direction === "over") {
+    return `${errorLabel} · 느리면 약 ${formatDayDelta(days + depletionDayError)}일`;
+  }
+  return errorLabel;
 }
 
 function accuracyTone(accuracy: IngredientForecastAccuracyView): string {
-  if (accuracy.bias === "under") return "bg-red-soft text-red-deep";
-  if (accuracy.bias === "over") return "bg-blue-soft text-blue-deep";
+  const direction = getAccuracyDirection(accuracy);
+  if (direction === "under") return "bg-red-soft text-red-deep";
+  if (direction === "over") return "bg-blue-soft text-blue-deep";
   if (accuracy.reliability === "watch") return "bg-amber-soft text-amber-deep";
   if (accuracy.reliability === "low") return "bg-red-soft text-red-deep";
   return "bg-bg text-ink-3";
+}
+
+function getAccuracyDirection(
+  accuracy: IngredientForecastAccuracyView,
+): "under" | "over" | "balanced" {
+  if (accuracy.bias === "under" || accuracy.bias === "over") return accuracy.bias;
+  if (accuracy.underPredictedDayCount > accuracy.overPredictedDayCount) return "under";
+  if (accuracy.overPredictedDayCount > accuracy.underPredictedDayCount) return "over";
+  return "balanced";
 }
 
 function formatLeadTimeSource(item: IngredientForecastView): string {

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -290,10 +290,10 @@ function formatAccuracyLabel(
   const errorLabel = `오차 ±${formatDayDelta(depletionDayError)}일`;
   const direction = getAccuracyDirection(accuracy);
   if (direction === "under") {
-    return `${errorLabel} · 빠르면 약 ${formatDayDelta(Math.max(0, days - depletionDayError))}일`;
+    return `소비↑ · ${errorLabel} · 빠르면 약 ${formatDayDelta(Math.max(0, days - depletionDayError))}일`;
   }
   if (direction === "over") {
-    return `${errorLabel} · 느리면 약 ${formatDayDelta(days + depletionDayError)}일`;
+    return `소비↓ · ${errorLabel} · 느리면 약 ${formatDayDelta(days + depletionDayError)}일`;
   }
   return errorLabel;
 }

--- a/src/features/inventory/components/IngredientStatusList.tsx
+++ b/src/features/inventory/components/IngredientStatusList.tsx
@@ -290,10 +290,10 @@ function formatAccuracyLabel(
   const errorLabel = `오차 ±${formatDayDelta(depletionDayError)}일`;
   const direction = getAccuracyDirection(accuracy);
   if (direction === "under") {
-    return `더 빨리 줄었음 · ${errorLabel} · 빠르면 약 ${formatDayDelta(Math.max(0, days - depletionDayError))}일`;
+    return `사용량 증가 · ${errorLabel} · 빠르면 약 ${formatDayDelta(Math.max(0, days - depletionDayError))}일`;
   }
   if (direction === "over") {
-    return `더 천천히 줄었음 · ${errorLabel} · 느리면 약 ${formatDayDelta(days + depletionDayError)}일`;
+    return `사용량 감소 · ${errorLabel} · 느리면 약 ${formatDayDelta(days + depletionDayError)}일`;
   }
   return errorLabel;
 }


### PR DESCRIPTION
## Summary
- replace the calendar header forecast link with a compact action dropdown
- add revenue forecast accuracy entry from the calendar header
- remove the Today button from the calendar header

## Checks
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run tests/unit/forecast.test.ts tests/unit/application.test.ts tests/unit/calendar-menu-forecast.test.ts